### PR TITLE
Cross-platform desktop builds (macOS, Windows, Linux)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+# Needed so tauri-action can create the GitHub Release and upload installers.
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Universal binary covers both Apple Silicon and Intel Macs.
+          - platform: macos-latest
+            args: '--target universal-apple-darwin'
+          # 22.04 builds against an older glibc/webkit, so the AppImage runs on more distros.
+          - platform: ubuntu-22.04
+            args: ''
+          - platform: windows-latest
+            args: ''
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
+
+      - name: Install Linux build dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            libayatana-appindicator3-dev \
+            patchelf
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build and release
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Only publish a release on a tag push. Manual runs just verify the build.
+          tagName: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+          releaseName: ${{ github.ref_type == 'tag' && 'Utsuwa __VERSION__' || '' }}
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.args }}
+          releaseBody: |
+            Desktop builds for macOS, Windows, and Linux.
+
+            **Downloads**
+            - macOS: `.dmg` (universal — Apple Silicon + Intel)
+            - Windows: `.exe` installer
+            - Linux: `.AppImage`, `.deb`, or `.rpm`
+
+            > These builds are **unsigned** while the desktop app is in beta, so your OS will warn you the first time you open it.
+            > - **macOS:** right-click the app → **Open** → **Open** (or run `xattr -dr com.apple.quarantine /Applications/Utsuwa.app`).
+            > - **Windows:** on the SmartScreen prompt, click **More info** → **Run anyway**.
+            >
+            > See the [Desktop Guide](https://docs.utsuwa.ai/docs/guides/desktop-guide) for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,26 @@ src/
 src-tauri/              # Tauri desktop app (Rust)
 ```
 
+## Releases
+
+Desktop builds are produced automatically by CI — there's no need to build installers on your own machine for a release.
+
+Maintainers cut a release by pushing a version tag:
+
+```bash
+# Bump the version in package.json, src-tauri/Cargo.toml, and src-tauri/tauri.conf.json first
+git tag v0.3.0
+git push origin v0.3.0
+```
+
+The [`Release` workflow](.github/workflows/release.yml) then builds the app on macOS, Windows, and Linux runners in parallel and attaches the installers to a **draft** GitHub Release:
+
+- **macOS** — `.dmg` (universal: Apple Silicon + Intel)
+- **Windows** — `.exe` installer
+- **Linux** — `.AppImage`, `.deb`, and `.rpm`
+
+A maintainer reviews the draft, edits the release notes, and publishes it. You can also trigger the workflow manually from the Actions tab to verify a build without cutting a release.
+
 ## Questions?
 
 If you have questions about contributing, feel free to open an issue for discussion.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 - **Memory Graph**: Interactive visualization showing how memories connect semantically
 - **Data Export/Import**: Download your data as a save file, restore anytime
 - **Theming**: Light and dark mode support with system preference detection
-- **Desktop App** *(beta, macOS only)*: Native desktop app with transparent overlay mode — your companion floats on your desktop
+- **Desktop App** *(beta)*: Native desktop app for macOS, Windows, and Linux with transparent overlay mode — your companion floats on your desktop
 
 ### Local-First Storage
 
@@ -105,7 +105,22 @@ Voice input is accessed via the microphone button in the chat bar. Groq STT uses
 
 ### Try it Online
 
-Use Utsuwa directly at **[utsuwa.ai](https://utsuwa.ai)** — no installation required. Or download the macOS desktop app from [GitHub Releases](https://github.com/The-Lab-by-Ordinary-Company/utsuwa/releases).
+Use Utsuwa directly at **[utsuwa.ai](https://utsuwa.ai)** — no installation required.
+
+### Download the Desktop App
+
+Native desktop builds (with transparent overlay mode) are available for all three platforms on the [GitHub Releases](https://github.com/The-Lab-by-Ordinary-Company/utsuwa/releases) page:
+
+| Platform | Download |
+|----------|----------|
+| **macOS** | `.dmg` (universal — Apple Silicon + Intel) |
+| **Windows** | `.exe` installer |
+| **Linux** | `.AppImage`, `.deb`, or `.rpm` |
+
+> [!NOTE]
+> The desktop app is in beta and currently **unsigned**, so your OS will warn you the first time you open it.
+> - **macOS:** right-click the app → **Open** → **Open** (or run `xattr -dr com.apple.quarantine /Applications/Utsuwa.app`).
+> - **Windows:** on the SmartScreen prompt, click **More info** → **Run anyway**.
 
 ### Self-Hosting
 
@@ -238,7 +253,8 @@ pnpm tauri build  # Build desktop app installer
 - [x] Local-first IndexedDB storage with export/import
 - [x] Theme system with light/dark modes
 - [x] Voice input via Groq STT (Whisper) and Web Speech API
-- [x] Desktop application with transparent overlay mode (macOS only, Windows/Linux planned)
+- [x] Desktop application with transparent overlay mode (macOS, Windows, and Linux)
+- [x] Cross-platform desktop builds via CI (macOS, Windows, Linux)
 
 ### In Progress / Planned
 
@@ -246,7 +262,7 @@ pnpm tauri build  # Build desktop app installer
 - [ ] **OpenAI-Compatible Models** - Add a configurable option for OpenAI-compatible model endpoints beyond the currently listed providers
 - [ ] **Multi-provider STT** - Support for additional speech-to-text providers beyond Groq and Web Speech API
 - [ ] **Live2D Support** - Alternative to VRM for 2D animated avatars
-- [ ] **Windows and Linux Desktop Apps** - Expand desktop builds beyond the current macOS beta
+- [ ] **In-App Auto-Updates** - Let installed desktop apps update themselves when a new release ships
 
 ## Contributing
 

--- a/src/content/docs/guides/desktop-guide.md
+++ b/src/content/docs/guides/desktop-guide.md
@@ -7,15 +7,28 @@ description: How to install and use the Utsuwa desktop application with overlay 
 
 Utsuwa Desktop is an application that brings your AI companion to your desktop with a transparent overlay mode. Your companion can float over other applications, always visible while you work.
 
-Currently available for **macOS** only. Windows and Linux support is planned.
+Available for **macOS**, **Windows**, and **Linux**.
 
 ## Installation
 
 ### Download
 
-Head to the [GitHub Releases](https://github.com/The-Lab-by-Ordinary-Company/utsuwa/releases) page and download the `.dmg` disk image for macOS.
+Head to the [GitHub Releases](https://github.com/The-Lab-by-Ordinary-Company/utsuwa/releases) page and grab the build for your platform:
 
-Open the `.dmg`, drag Utsuwa to your Applications folder, and you're good to go.
+| Platform | File | Install |
+|----------|------|---------|
+| **macOS** | `.dmg` (universal) | Open the disk image and drag Utsuwa to your Applications folder |
+| **Windows** | `.exe` | Run the installer |
+| **Linux** | `.AppImage` | `chmod +x` the file and run it |
+| **Linux** | `.deb` / `.rpm` | Install with your package manager |
+
+#### Opening an unsigned build
+
+The desktop app is in beta and currently **unsigned**, so your OS will warn you the first time you open it. This is expected.
+
+- **macOS:** right-click the app → **Open** → **Open**. Or run `xattr -dr com.apple.quarantine /Applications/Utsuwa.app` once.
+- **Windows:** on the SmartScreen prompt, click **More info** → **Run anyway**.
+- **Linux:** AppImages just need the executable bit (`chmod +x Utsuwa.AppImage`).
 
 ### Building from Source
 
@@ -95,10 +108,11 @@ Some features are still being worked on:
 | Feature | Status |
 |---------|--------|
 | macOS support | ✅ Available |
-| Windows support | ⏳ Planned |
-| Linux support | ⏳ Planned |
+| Windows support | ✅ Available |
+| Linux support | ✅ Available |
 | Click-through transparency | ❌ Disabled (blocks UI) |
 | Global hotkeys | ✅ Available |
+| In-app auto-updates | ⏳ Planned |
 | Position persistence | ⏳ Planned |
 | System tray | ⏳ Planned |
 

--- a/src/content/docs/overview/introduction.md
+++ b/src/content/docs/overview/introduction.md
@@ -11,7 +11,7 @@ description: What is Utsuwa and how to get started.
 - Load a VRM model, connect any LLM provider, and bring your AI companion to life
 - Voice, memory, and a relationship system built in
 - Local-first — your data stays on your device
-- Desktop app with transparent overlay mode (macOS only, Windows/Linux planned)
+- Desktop app with transparent overlay mode for macOS, Windows, and Linux
 
 ## What is Utsuwa?
 

--- a/src/lib/components/docs/DocsGetStartedCards.svelte
+++ b/src/lib/components/docs/DocsGetStartedCards.svelte
@@ -31,7 +31,7 @@
 		</div>
 		<h3 class="card-title">Desktop</h3>
 		<p class="card-desc">
-			Desktop app with transparent overlay mode. Currently macOS only — Windows and Linux planned.
+			Desktop app with transparent overlay mode for macOS, Windows, and Linux.
 		</p>
 		<div class="card-actions">
 			<a href={GITHUB_RELEASES} target="_blank" rel="noopener noreferrer" class="card-btn primary">


### PR DESCRIPTION
## What this does

Ships **official desktop builds for macOS, Windows, and Linux**. Tauri is already cross-platform, so no source porting is needed — we just never produced Windows/Linux installers because releases were built locally on macOS. This adds a CI release pipeline that produces all three.

## Changes

**`ci:` cross-platform release pipeline** (`.github/workflows/release.yml`)
- Triggers on `v*` tag push (plus manual `workflow_dispatch`).
- Builds in parallel on `macos-latest`, `windows-latest`, and `ubuntu-22.04` via `tauri-apps/tauri-action`.
- macOS is built as a **universal** binary (Apple Silicon + Intel). Ubuntu is pinned to 22.04 so the AppImage runs on more distros.
- Attaches installers to a **draft** GitHub Release for review before publishing:
  - macOS — `.dmg`
  - Windows — `.exe`
  - Linux — `.AppImage`, `.deb`, `.rpm`
- Manual runs build without publishing, so the pipeline can be verified without cutting a release.

**`docs:` announce cross-platform availability**
- README, docs site (`desktop-guide`, `introduction`, `DocsGetStartedCards`), and `CONTRIBUTING.md` updated to reflect macOS/Windows/Linux.
- Added per-platform download table and "opening an unsigned beta build" instructions (macOS Gatekeeper, Windows SmartScreen).
- Documented the tag-based release flow for maintainers.

## Notes

- Builds are **unsigned** for now (matches the current macOS state). Users get a one-time OS warning; install steps are documented.
- No app runtime code is touched — this is CI + docs only.
- In-app auto-updates are a planned follow-up.

## How to verify

1. Run the workflow manually from the **Actions** tab (builds all three platforms, no release created), or
2. Push a version tag (e.g. `v0.3.0`) to produce a full draft release.
