### PR TITLE
release: v0.3.1 — desktop opens into the app, not the landing page

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,12 +1,22 @@
 <script lang="ts">
 	import '../app.css';
 	import { browser } from '$app/environment';
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
 	import { modulesStore } from '$lib/stores/modules.svelte';
 	import { moduleRegistry } from '$lib/services/modules';
 	import { isTauri } from '$lib/services/platform/platform';
 	import { SITE_URL } from '$lib/config/site';
 
 	let { children } = $props();
+
+	// Marketing/content routes that should never live inside the desktop app.
+	const isWebOnly = (path: string) =>
+		path === '/' || path.startsWith('/docs') || path.startsWith('/blog');
+
+	// The desktop window launches at "/" (the landing route). Send it straight
+	// into the app so the marketing site never renders inside the window.
+	const redirecting = $derived(browser && isTauri() && page.url.pathname === '/');
 
 	if (browser) {
 		for (const mod of moduleRegistry) {
@@ -22,13 +32,14 @@
 			}
 		});
 
-		// In the desktop app, open docs/blog links in the system browser
+		// In the desktop app, marketing/docs/blog links open in the system
+		// browser instead of navigating the webview.
 		document.addEventListener('click', (e) => {
 			if (!isTauri()) return;
 			const anchor = (e.target as Element).closest('a');
 			if (!anchor) return;
 			const href = anchor.getAttribute('href');
-			if (href && (href.startsWith('/docs') || href.startsWith('/blog'))) {
+			if (href && isWebOnly(href)) {
 				e.preventDefault();
 				e.stopPropagation();
 				import('@tauri-apps/plugin-opener').then(({ openUrl }) => {
@@ -37,6 +48,11 @@
 			}
 		}, true);
 	}
+
+	// Bounce the desktop app off the landing route into the app itself.
+	$effect(() => {
+		if (redirecting) goto('/app', { replaceState: true });
+	});
 </script>
 
 <svelte:head>
@@ -44,4 +60,6 @@
 	<meta name="description" content="Open-source AI companion with 3D VRM avatars, voice chat, semantic memory, and multi-provider LLM support. Self-hosted and privacy-first." />
 </svelte:head>
 
-{@render children()}
+{#if !redirecting}
+	{@render children()}
+{/if}


### PR DESCRIPTION
## Problem
Opening the desktop app dropped the user on the **marketing landing page** instead of the app, and the docs were viewable inside the app webview.

## Fix
In the root layout, guarded entirely behind `isTauri()`:
- **Launch:** the window opens at `/` (the landing route) — now it redirects straight to `/app`, and the landing is gated from rendering so it never flashes.
- **Navigation:** clicking a link to the landing / docs / blog routes opens the **system browser** instead of navigating the webview (extends the existing docs/blog interception to also cover the landing route).

## Notes
- **Web is unchanged** — all behavior is `isTauri()`-guarded, and prerendering still emits the landing/docs/blog HTML (verified: build exits 0, pages render with real content).
- `svelte-check` clean, production build passes.
- This is a desktop-app change, so it needs a new desktop release (v0.3.1) to reach installed users; the web app picks it up on the next deploy.