### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-06-28
+
+### Fixed
+- Desktop app now opens directly into the app instead of the marketing landing page.
+- Landing, docs, and blog links inside the desktop app open in the system browser rather than navigating the app window.
+
 ## [0.3.0] - 2026-06-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.3.0"
+version = "0.3.1"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
Version bump 0.3.0 → 0.3.1 (`package.json`, `src-tauri/Cargo.toml`, `tauri.conf.json`, `Cargo.lock`) + CHANGELOG entry.

The actual desktop fix (boot into the app, not the landing page) already merged in #33 — this is just the version bump that got separated from it. Merging this, then tagging `v0.3.1`, cuts the release.