### PR TITLE
feat: local TTS via OpenAI-compatible servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - **Voice Input**: Speech-to-text via Groq (Whisper) or Web Speech API with real-time audio visualization
 - **LLM Integration**: Support for 7 LLM providers including OpenAI, Anthropic, Google, xAI, DeepSeek, Ollama, and LM Studio
 - **Local Model Discovery**: Ollama and LM Studio discover installed local models directly from your device
-- **Text-to-Speech**: Support for ElevenLabs and OpenAI TTS
+- **Text-to-Speech**: Support for ElevenLabs and OpenAI TTS, plus local voices via any OpenAI-compatible server (Kokoro-FastAPI, openedai-speech)
 - **Lip-sync**: Audio-driven mouth animation synced to TTS playback
 - **Animations**: VRMA-based idle and talking animations with automatic blinking
 - **Character Customization**: Customize your companion's name, personality, and system prompt
@@ -83,11 +83,12 @@ The desktop app uses the same codebase as the web version — your save files ar
 | **Cloud** | OpenAI, Anthropic, Google Gemini, DeepSeek, xAI (Grok) |
 | **Local** | Ollama, LM Studio |
 
-### TTS Providers (2)
+### TTS Providers (3)
 
 | Category | Providers |
 |----------|-----------|
 | **Cloud** | ElevenLabs, OpenAI TTS |
+| **Local** | Local TTS (Kokoro-FastAPI, openedai-speech, any OpenAI-compatible server) |
 
 ### STT Providers (2)
 

--- a/src/content/docs/guides/local-tts-setup.md
+++ b/src/content/docs/guides/local-tts-setup.md
@@ -1,0 +1,75 @@
+---
+title: Local TTS Setup
+description: Give your companion a voice that runs entirely on your machine using Kokoro-FastAPI or openedai-speech.
+---
+
+# Local TTS Setup
+
+If you already run local LLMs with Ollama or LM Studio, you can give your companion a local voice too. The audio is generated on your machine, so nothing leaves the device and there are no API keys or per-character costs.
+
+Utsuwa talks to any TTS server that exposes the OpenAI `/v1/audio/speech` endpoint. The two we recommend are **Kokoro-FastAPI** and **openedai-speech**. Lip-sync works automatically because Utsuwa animates the mouth from the audio itself, no extra data needed.
+
+## Kokoro-FastAPI (recommended)
+
+[Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI) wraps the Kokoro voice model and serves the OpenAI speech API directly. It is fast on CPU and sounds great for its size.
+
+### Installation
+
+The quickest path is Docker:
+
+```bash
+docker run -p 8880:8880 ghcr.io/remsky/kokoro-fastapi-cpu:latest
+```
+
+If you have an NVIDIA GPU, use the `kokoro-fastapi-gpu` image instead. See the project README for non-Docker installs.
+
+This serves the API at `http://localhost:8880/v1`.
+
+### Connecting to Utsuwa
+
+1. Open **Settings** (gear icon)
+2. Navigate to the **Character** tab
+3. Enable the **Speech (TTS)** toggle, then select **Local TTS** from the provider dropdown
+4. Leave the base URL as `http://localhost:8880/v1/` unless you changed the port
+5. Pick a **voice** (start typing in the voice field to see suggestions like `af_bella`)
+6. Leave **Model** blank to use the default, or set it to `kokoro`
+7. Send a message and your companion speaks
+
+### Voices
+
+Kokoro voice names encode region and gender, for example `af_bella` (American female) or `bm_george` (British male). Utsuwa seeds a few common ones in the voice field, and you can type any voice your server supports.
+
+## openedai-speech
+
+[openedai-speech](https://github.com/matatonic/openedai-speech) is another OpenAI-compatible server that can run Piper and other engines. Set up its server, then point Utsuwa's Local TTS base URL at it (default `http://localhost:8000/v1/`). Use the voice names that server exposes.
+
+## Custom Base URL
+
+Running the server on a different machine or port? Enter the full URL in the Local TTS base URL field. Utsuwa normalizes it to end in `/v1/`, so `http://localhost:8880`, `http://localhost:8880/v1`, and `http://localhost:8880/v1/` all work. Examples:
+
+- Remote machine: `http://192.168.1.50:8880/v1/`
+- Custom port: `http://localhost:9000/v1/`
+
+## Troubleshooting
+
+### No sound and no error
+
+Make sure the **Speech (TTS)** module is enabled and a voice is set. If the voice field is empty, type a valid voice for your server (e.g. `af_bella` for Kokoro).
+
+### "Could not reach a local TTS server"
+
+The server isn't running or isn't reachable at the base URL. Confirm it's up:
+
+```bash
+curl http://localhost:8880/v1/audio/voices
+```
+
+If that returns data but Utsuwa still can't reach it from a browser, it's almost certainly a CORS block. The server has to allow the page's origin. Kokoro-FastAPI allows all origins by default; if you front it with a proxy or use a server that locks CORS down, allow the Utsuwa origin (for the hosted site, `https://www.utsuwa.ai`). This is the same class of issue as the Ollama origins setup, and like that one, **it does not apply to the desktop app**.
+
+### "Local TTS server returned 400/404"
+
+The model or voice isn't valid for that server. Leave the model blank (Utsuwa sends `tts-1`, which most servers accept), and double-check the voice name against your server's voice list.
+
+### Choppy or delayed speech
+
+Local TTS generates the full clip before playback. On slower hardware, try a CPU-optimized build or a GPU image, and keep responses shorter.

--- a/src/content/docs/guides/local-tts-setup.md
+++ b/src/content/docs/guides/local-tts-setup.md
@@ -47,8 +47,20 @@ Kokoro voice names encode region and gender, for example `af_bella` (American fe
 
 Running the server on a different machine or port? Enter the full URL in the Local TTS base URL field. Utsuwa normalizes it to end in `/v1/`, so `http://localhost:8880`, `http://localhost:8880/v1`, and `http://localhost:8880/v1/` all work. Examples:
 
-- Remote machine: `http://192.168.1.50:8880/v1/`
 - Custom port: `http://localhost:9000/v1/`
+- Remote machine: `http://192.168.1.50:8880/v1/` (desktop app only, see below)
+
+## Desktop app vs hosted website
+
+Local TTS works best in the **desktop app**, where it needs no extra setup. The desktop app talks to your local server directly, with no browser origin, mixed-content, or local-network restrictions. If you want the smoothest experience, use the desktop app.
+
+On the **hosted website** (`https://www.utsuwa.ai`) it can still work, but because a public HTTPS page is reaching a server on your own machine, the browser adds a few rules:
+
+- **Same machine only.** The server has to be on `localhost` / `127.0.0.1`. A TTS server on another machine over plain `http://` is blocked by the browser as mixed content. (`localhost` is exempt from that block, which is the only reason the local case works at all.) The remote-machine base URL above therefore works in the desktop app but not on the hosted site.
+- **The server must allow the site's origin.** Your TTS server needs to send CORS headers permitting `https://www.utsuwa.ai`. Kokoro-FastAPI and openedai-speech allow all origins by default, so this usually just works; a hardened or proxied server may need the origin added explicitly.
+- **Your browser may ask permission.** Recent versions of Chrome treat a public site reaching `localhost` as a local-network request and may prompt you to allow it (or require the server to opt in). Allow it if asked.
+
+None of this applies to the desktop app. It is the same set of rules local LLMs (Ollama, LM Studio) follow on the hosted site.
 
 ## Troubleshooting
 
@@ -64,7 +76,7 @@ The server isn't running or isn't reachable at the base URL. Confirm it's up:
 curl http://localhost:8880/v1/audio/voices
 ```
 
-If that returns data but Utsuwa still can't reach it from a browser, it's almost certainly a CORS block. The server has to allow the page's origin. Kokoro-FastAPI allows all origins by default; if you front it with a proxy or use a server that locks CORS down, allow the Utsuwa origin (for the hosted site, `https://www.utsuwa.ai`). This is the same class of issue as the Ollama origins setup, and like that one, **it does not apply to the desktop app**.
+If that returns data but Utsuwa still can't reach it from a browser, it's almost certainly an origin or local-network block. On the hosted site the server has to allow the `https://www.utsuwa.ai` origin (Kokoro-FastAPI allows all origins by default; a proxied or hardened server may need it added), and your browser may prompt to allow access to local-network devices. See [Desktop app vs hosted website](#desktop-app-vs-hosted-website) for the full list. None of this applies to the **desktop app**, which is the smoothest way to run local TTS.
 
 ### "Local TTS server returned 400/404"
 

--- a/src/content/docs/guides/troubleshooting.md
+++ b/src/content/docs/guides/troubleshooting.md
@@ -128,6 +128,17 @@ If the avatar's mouth isn't moving:
 1. **Check voice settings** - ElevenLabs and OpenAI TTS have different available voices
 2. **Custom voice ID** - If using ElevenLabs custom voice, verify the voice ID is correct
 
+### Local TTS not speaking
+
+If you selected **Local TTS** but hear nothing:
+
+1. **Server running** - Confirm your TTS server is up, e.g. `curl http://localhost:8880/v1/audio/voices`
+2. **Voice is set** - The voice field must hold a name your server knows (e.g. `af_bella` for Kokoro)
+3. **Base URL** - It should point at the server's `/v1`; Utsuwa normalizes the trailing slash for you
+4. **CORS (web only)** - In a browser, the server must allow the page's origin. Kokoro-FastAPI allows all origins by default; this never applies to the desktop app
+
+See [Local TTS Setup](/docs/guides/local-tts-setup) for the full walkthrough.
+
 ## Voice Input Issues
 
 ### Mic button not responding (desktop)

--- a/src/content/docs/guides/troubleshooting.md
+++ b/src/content/docs/guides/troubleshooting.md
@@ -135,9 +135,10 @@ If you selected **Local TTS** but hear nothing:
 1. **Server running** - Confirm your TTS server is up, e.g. `curl http://localhost:8880/v1/audio/voices`
 2. **Voice is set** - The voice field must hold a name your server knows (e.g. `af_bella` for Kokoro)
 3. **Base URL** - It should point at the server's `/v1`; Utsuwa normalizes the trailing slash for you
-4. **CORS (web only)** - In a browser, the server must allow the page's origin. Kokoro-FastAPI allows all origins by default; this never applies to the desktop app
+4. **Desktop app** - Just needs the server running on `localhost`; no origin or CORS setup is required
+5. **Hosted site** (`https://www.utsuwa.ai`) - The server must be on `localhost` (one on another machine is blocked as mixed content), must allow the `utsuwa.ai` origin (Kokoro-FastAPI does by default), and your browser may prompt to allow local-network access. Allow it if asked
 
-See [Local TTS Setup](/docs/guides/local-tts-setup) for the full walkthrough.
+See [Local TTS Setup](/docs/guides/local-tts-setup#desktop-app-vs-hosted-website) for the hosted vs desktop details.
 
 ## Voice Input Issues
 
@@ -162,6 +163,37 @@ Your browser or OS is blocking microphone access:
 
 1. **Browser permissions** - Click the lock icon in the address bar and allow microphone access
 2. **System permissions** - On macOS, go to System Settings > Privacy & Security > Microphone and enable access for your browser or Utsuwa
+
+## Desktop App
+
+### App won't open
+
+The desktop app is in beta and currently **unsigned**, so your OS warns you the first time you open it. This is expected, not a broken download.
+
+1. **macOS** - Right-click the app → **Open** → **Open**, or run `xattr -dr com.apple.quarantine /Applications/Utsuwa.app` once
+2. **Windows** - On the SmartScreen prompt, click **More info** → **Run anyway**
+3. **Linux** - Give the AppImage the executable bit: `chmod +x Utsuwa.AppImage`
+
+See the [Desktop Guide](/docs/guides/desktop-guide) for the full install walkthrough.
+
+### Local LLM or TTS won't connect (desktop)
+
+On the desktop app, local providers need **only** that the server is running. The browser origin, CORS, and local-network rules that apply on the hosted website do **not** apply here, so there's no `OLLAMA_ORIGINS` or CORS setup to do.
+
+1. **Ollama** - Start it with `ollama serve` and pull a model (`ollama pull <model>`)
+2. **LM Studio** - Load a model and click Start Server
+3. **Local TTS** - Start your TTS server (e.g. Kokoro-FastAPI on `http://localhost:8880`)
+4. **Base URL** - Confirm the port in **Settings > Character** matches the port your server is using
+
+### No sound (desktop)
+
+1. **System audio** - Check your OS volume and that Utsuwa isn't muted in the system mixer
+2. **TTS configured** - Confirm a TTS provider is set up and a voice is selected (see Text-to-Speech Issues above)
+3. **Microphone/voice input** - The desktop webview has no Web Speech API, so the mic needs a Groq key; see [Mic button not responding (desktop)](#mic-button-not-responding-desktop)
+
+### Updates not installing
+
+Auto-updates work for the macOS `.dmg`, Windows `.exe`, and Linux `.AppImage`. If you installed via `.deb` or `.rpm`, update through your package manager instead. Restarting the app re-checks for an update.
 
 ## Memory & Performance
 

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -302,6 +302,7 @@
 					provider: ttsProvider,
 					apiKey: ttsConfig.apiKey,
 					voiceId: speechSettings.activeVoiceId as string || ttsConfig.voiceId,
+					model: speechSettings.activeModel as string || ttsConfig.modelId,
 					baseUrl: ttsConfig.baseUrl || ttsMeta?.defaultBaseUrl,
 					speed: speechSettings.speed as number ?? 1
 				});

--- a/src/lib/components/ui/ProviderDropdown.svelte
+++ b/src/lib/components/ui/ProviderDropdown.svelte
@@ -36,7 +36,7 @@
 	// Group providers by category for TTS
 	const ttsCategories = [
 		{ id: 'cloud', label: 'Cloud TTS', providers: ['elevenlabs', 'openai-tts', 'azure-speech', 'deepgram', 'alibaba-cosyvoice', 'volcengine', 'comet-tts'] },
-		{ id: 'local', label: 'Local / Free', providers: ['web-speech', 'index-tts', 'browser-local', 'app-local'] },
+		{ id: 'local', label: 'Local / Free', providers: ['local-tts', 'web-speech', 'index-tts', 'browser-local', 'app-local'] },
 		{ id: 'generic', label: 'Generic', providers: ['openai-compatible-tts', 'player2-tts'] }
 	];
 

--- a/src/lib/config/docs-nav.ts
+++ b/src/lib/config/docs-nav.ts
@@ -22,6 +22,7 @@ export const docsNav: DocsNavSection[] = [
 			{ title: 'Web Guide', slug: 'guides/web-guide' },
 			{ title: 'Desktop Guide', slug: 'guides/desktop-guide' },
 			{ title: 'Local LLM Setup', slug: 'guides/local-llm-setup' },
+			{ title: 'Local TTS Setup', slug: 'guides/local-tts-setup' },
 			{ title: 'Troubleshooting', slug: 'guides/troubleshooting' }
 		]
 	},

--- a/src/lib/services/providers/local-endpoints.test.ts
+++ b/src/lib/services/providers/local-endpoints.test.ts
@@ -5,7 +5,10 @@ import {
 	getChatBaseUrl,
 	getModelsBaseUrl,
 	isLocalLLMProvider,
-	getLocalProviderConnectionHint
+	getLocalProviderConnectionHint,
+	isLocalTTSProvider,
+	getTTSBaseUrl,
+	getLocalTTSConnectionHint
 } from './local-endpoints.ts';
 
 test('identifies local LLM providers', () => {
@@ -46,4 +49,29 @@ test('provides local provider troubleshooting hints', () => {
 		/docs\.ollama\.com\/faq#how-can-i-allow-additional-web-origins-to-access-ollama/
 	);
 	assert.match(getLocalProviderConnectionHint('lmstudio', 'http://localhost:1234/v1'), /Start Server/);
+});
+
+test('identifies local TTS providers', () => {
+	assert.equal(isLocalTTSProvider('local-tts'), true);
+	assert.equal(isLocalTTSProvider('openai-tts'), false);
+	assert.equal(isLocalTTSProvider('elevenlabs'), false);
+});
+
+test('normalizes local TTS base URL to a trailing-slash /v1 path', () => {
+	// OpenAI-compatible clients append "audio/speech", so the base must end in /v1/
+	assert.equal(getTTSBaseUrl('local-tts', 'http://localhost:8880'), 'http://localhost:8880/v1/');
+	assert.equal(getTTSBaseUrl('local-tts', 'http://localhost:8880/'), 'http://localhost:8880/v1/');
+	assert.equal(getTTSBaseUrl('local-tts', 'http://localhost:8880/v1'), 'http://localhost:8880/v1/');
+	assert.equal(getTTSBaseUrl('local-tts', 'http://localhost:8880/v1/'), 'http://localhost:8880/v1/');
+	assert.equal(getTTSBaseUrl('local-tts'), 'http://localhost:8880/v1/');
+});
+
+test('provides local TTS troubleshooting hint with CORS guidance', () => {
+	const hint = getLocalTTSConnectionHint('http://localhost:8880');
+	assert.match(hint, /audio\/speech/);
+	assert.match(hint, /CORS/);
+	assert.match(
+		getLocalTTSConnectionHint('http://localhost:8880', 'https://utsuwa.app'),
+		/https:\/\/utsuwa\.app/
+	);
 });

--- a/src/lib/services/providers/local-endpoints.ts
+++ b/src/lib/services/providers/local-endpoints.ts
@@ -1,8 +1,10 @@
 const LOCAL_LLM_PROVIDERS = new Set(['ollama', 'lmstudio']);
+const LOCAL_TTS_PROVIDERS = new Set(['local-tts']);
 
 const DEFAULT_BASE_URLS: Record<string, string> = {
 	ollama: 'http://localhost:11434',
-	lmstudio: 'http://localhost:1234/v1'
+	lmstudio: 'http://localhost:1234/v1',
+	'local-tts': 'http://localhost:8880/v1'
 };
 
 const OLLAMA_ORIGINS_DOC_URL =
@@ -23,6 +25,31 @@ function ensureOpenAIPath(url: string): string {
 
 export function isLocalLLMProvider(providerId: string): boolean {
 	return LOCAL_LLM_PROVIDERS.has(providerId);
+}
+
+export function isLocalTTSProvider(providerId: string): boolean {
+	return LOCAL_TTS_PROVIDERS.has(providerId);
+}
+
+// OpenAI-compatible TTS clients append "audio/speech" to the base URL, so the
+// base must end with "/v1/". Local servers (Kokoro-FastAPI, openedai-speech)
+// mount there, and users routinely paste the bare host or drop the slash.
+export function getTTSBaseUrl(providerId: string, baseUrl?: string): string {
+	const cleanUrl = trimTrailingSlashes(baseUrl || DEFAULT_BASE_URLS[providerId] || '');
+
+	if (isLocalTTSProvider(providerId)) {
+		return `${ensureOpenAIPath(cleanUrl)}/`;
+	}
+
+	return `${cleanUrl}/`;
+}
+
+export function getLocalTTSConnectionHint(baseUrl?: string, siteOrigin?: string): string {
+	const ttsBaseUrl = getTTSBaseUrl('local-tts', baseUrl);
+	const originHint = siteOrigin
+		? ` If the server blocks this site (${siteOrigin}), enable CORS for that origin.`
+		: ' If the server blocks this site, enable CORS for the app origin.';
+	return `Could not reach a local TTS server at ${ttsBaseUrl}. Make sure it is running and exposes the OpenAI /v1/audio/speech endpoint (e.g. Kokoro-FastAPI or openedai-speech).${originHint}`;
 }
 
 export function getModelsBaseUrl(providerId: string, baseUrl?: string): string {

--- a/src/lib/services/providers/registry.test.ts
+++ b/src/lib/services/providers/registry.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { LLM_PROVIDERS } from './registry.ts';
+import { LLM_PROVIDERS, TTS_PROVIDERS, getTTSProvider } from './registry.ts';
 
 test('local LLM providers rely on discovered installed models', () => {
 	const localProviders = LLM_PROVIDERS.filter((provider) => provider.isLocal);
@@ -9,5 +9,20 @@ test('local LLM providers rely on discovered installed models', () => {
 	assert.ok(localProviders.length > 0);
 	for (const provider of localProviders) {
 		assert.deepEqual(provider.models ?? [], [], `${provider.name} should not expose static model choices`);
+	}
+});
+
+test('local TTS provider is keyless, local, and ships fallback voices', () => {
+	const localTTS = getTTSProvider('local-tts');
+
+	assert.ok(localTTS, 'local-tts should be registered');
+	assert.equal(localTTS?.isLocal, true);
+	assert.equal(localTTS?.requiresApiKey, false);
+	assert.ok((localTTS?.voices?.length ?? 0) > 0, 'local-tts should seed voices for offline use');
+});
+
+test('every TTS provider declares whether it needs an API key', () => {
+	for (const provider of TTS_PROVIDERS) {
+		assert.equal(typeof provider.requiresApiKey, 'boolean', `${provider.name} must declare requiresApiKey`);
 	}
 });

--- a/src/lib/services/providers/registry.ts
+++ b/src/lib/services/providers/registry.ts
@@ -92,7 +92,7 @@ export const LLM_PROVIDERS: ProviderMetadata[] = [
 ];
 
 // ============================================
-// TTS PROVIDERS (2 total)
+// TTS PROVIDERS (3 total)
 // ============================================
 
 export const TTS_PROVIDERS: ProviderMetadata[] = [
@@ -142,6 +142,32 @@ export const TTS_PROVIDERS: ProviderMetadata[] = [
 			{ id: 'verse', name: 'Verse' },
 			{ id: 'marin', name: 'Marin' },
 			{ id: 'cedar', name: 'Cedar' }
+		]
+	},
+	// Local TTS - OpenAI-compatible server running on the user's machine
+	// (Kokoro-FastAPI, openedai-speech, etc). Voices/model are server-specific,
+	// so these are sensible Kokoro defaults plus a free-text override in the UI.
+	{
+		id: 'local-tts',
+		name: 'Local TTS',
+		description: 'Run a voice model locally (Kokoro, openedai-speech)',
+		category: 'tts',
+		icon: '🏠',
+		requiresApiKey: false,
+		isLocal: true,
+		defaultBaseUrl: 'http://localhost:8880/v1/',
+		models: [
+			{ id: 'kokoro', name: 'Kokoro' },
+			{ id: 'tts-1', name: 'tts-1 (compatibility alias)' }
+		],
+		voices: [
+			{ id: 'af_bella', name: 'Bella (US, female)' },
+			{ id: 'af_sky', name: 'Sky (US, female)' },
+			{ id: 'af_sarah', name: 'Sarah (US, female)' },
+			{ id: 'am_adam', name: 'Adam (US, male)' },
+			{ id: 'am_michael', name: 'Michael (US, male)' },
+			{ id: 'bf_emma', name: 'Emma (UK, female)' },
+			{ id: 'bm_george', name: 'George (UK, male)' }
 		]
 	},
 ];

--- a/src/lib/services/tts/index.ts
+++ b/src/lib/services/tts/index.ts
@@ -5,6 +5,7 @@ export interface TTSOptions {
 	provider: TTSProvider;
 	apiKey?: string;
 	voiceId?: string;
+	model?: string;
 	baseUrl?: string;
 	speed?: number;
 	pitch?: number;
@@ -36,13 +37,15 @@ export function getSharedAudioContext(): AudioContext {
 // Provider base URLs
 export const TTS_BASE_URLS: Partial<Record<TTSProvider, string>> = {
 	elevenlabs: 'https://api.elevenlabs.io/v1/',
-	'openai-tts': 'https://api.openai.com/v1/'
+	'openai-tts': 'https://api.openai.com/v1/',
+	'local-tts': 'http://localhost:8880/v1/'
 };
 
 // Default voices per provider
 export const DEFAULT_VOICES: Partial<Record<TTSProvider, string>> = {
 	elevenlabs: 'EXAVITQu4vr4xnSDxMaL', // Bella
-	'openai-tts': 'alloy'
+	'openai-tts': 'alloy',
+	'local-tts': 'af_bella'
 };
 
 // Import individual providers
@@ -61,6 +64,7 @@ export function getTTSProvider(options: TTSOptions): ITTSProvider {
 		currentOptions.provider === options.provider &&
 		currentOptions.apiKey === options.apiKey &&
 		currentOptions.voiceId === options.voiceId &&
+		currentOptions.model === options.model &&
 		currentOptions.baseUrl === options.baseUrl
 	) {
 		return currentProvider;
@@ -73,6 +77,12 @@ export function getTTSProvider(options: TTSOptions): ITTSProvider {
 			break;
 
 		case 'openai-tts':
+			currentProvider = new OpenAITTS(options);
+			break;
+
+		// Local TTS is OpenAI-compatible, so it reuses the OpenAI client with a
+		// localhost base URL. The provider id drives URL/key/error handling.
+		case 'local-tts':
 			currentProvider = new OpenAITTS(options);
 			break;
 

--- a/src/lib/services/tts/openai-tts.ts
+++ b/src/lib/services/tts/openai-tts.ts
@@ -1,22 +1,38 @@
 import { getSharedAudioContext, type ITTSProvider, type TTSOptions, type TTSSpeakResult } from './index';
+import {
+	getTTSBaseUrl,
+	getLocalTTSConnectionHint,
+	isLocalTTSProvider
+} from '$lib/services/providers/local-endpoints';
 
 function ensureTrailingSlash(url: string): string {
 	return url.endsWith('/') ? url : url + '/';
 }
 
+function getCurrentSiteOrigin(): string | undefined {
+	return typeof window !== 'undefined' ? window.location.origin : undefined;
+}
+
+// Shared by OpenAI's hosted TTS and any OpenAI-compatible local server
+// (Kokoro-FastAPI, openedai-speech). The provider id decides URL normalization,
+// whether an API key is required, and the failure message.
 export class OpenAITTS implements ITTSProvider {
 	private apiKey: string;
 	private voiceId: string;
 	private model: string;
 	private speed: number;
 	private baseUrl: string;
+	private isLocal: boolean;
 
 	constructor(options: TTSOptions) {
 		this.apiKey = options.apiKey || '';
 		this.voiceId = options.voiceId || 'alloy';
-		this.model = 'tts-1';
+		this.model = options.model || 'tts-1';
 		this.speed = options.speed ?? 1;
-		this.baseUrl = ensureTrailingSlash(options.baseUrl || 'https://api.openai.com/v1/');
+		this.isLocal = isLocalTTSProvider(options.provider);
+		this.baseUrl = this.isLocal
+			? getTTSBaseUrl(options.provider, options.baseUrl)
+			: ensureTrailingSlash(options.baseUrl || 'https://api.openai.com/v1/');
 	}
 
 	getAudioContext(): AudioContext {
@@ -24,22 +40,40 @@ export class OpenAITTS implements ITTSProvider {
 	}
 
 	async speak(text: string): Promise<TTSSpeakResult> {
-		const response = await fetch(`${this.baseUrl}audio/speech`, {
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${this.apiKey}`,
-				'Content-Type': 'application/json'
-			},
-			body: JSON.stringify({
-				model: this.model,
-				input: text,
-				voice: this.voiceId,
-				speed: this.speed,
-				response_format: 'mp3'
-			})
-		});
+		const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+		// Local servers don't need a key; only send auth when we actually have one.
+		if (this.apiKey) {
+			headers.Authorization = `Bearer ${this.apiKey}`;
+		}
+
+		let response: Response;
+		try {
+			response = await fetch(`${this.baseUrl}audio/speech`, {
+				method: 'POST',
+				headers,
+				body: JSON.stringify({
+					model: this.model,
+					input: text,
+					voice: this.voiceId,
+					speed: this.speed,
+					response_format: 'mp3'
+				})
+			});
+		} catch (err) {
+			// A thrown fetch is usually a refused connection or a CORS block, which
+			// is the exact failure mode that broke local LLMs before they were fixed.
+			if (this.isLocal) {
+				throw new Error(getLocalTTSConnectionHint(this.baseUrl, getCurrentSiteOrigin()));
+			}
+			throw err;
+		}
 
 		if (!response.ok) {
+			if (this.isLocal) {
+				throw new Error(
+					`Local TTS server returned ${response.status} at ${this.baseUrl}. Check the model and voice are valid for this server.`
+				);
+			}
 			throw new Error(`OpenAI TTS API error: ${response.status}`);
 		}
 

--- a/src/lib/stores/tts.svelte.ts
+++ b/src/lib/stores/tts.svelte.ts
@@ -1,4 +1,5 @@
 import { getTTSProvider, type TTSOptions } from '$lib/services/tts';
+import { isLocalTTSProvider } from '$lib/services/providers/local-endpoints';
 
 function createTTSStore() {
 	let isSpeaking = $state(false);
@@ -7,8 +8,8 @@ function createTTSStore() {
 	let queue = $state<string[]>([]);
 
 	async function speak(text: string, options: TTSOptions) {
-		// All TTS providers require API keys
-		if (!options.apiKey) {
+		// Cloud providers need a key; local servers (e.g. Kokoro) don't.
+		if (!options.apiKey && !isLocalTTSProvider(options.provider)) {
 			console.warn('TTS not configured - missing API key');
 			return;
 		}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -29,7 +29,7 @@ export interface LLMConfig {
 }
 
 // TTS Provider IDs
-export type TTSProvider = 'elevenlabs' | 'openai-tts';
+export type TTSProvider = 'elevenlabs' | 'openai-tts' | 'local-tts';
 
 export interface TTSConfig {
 	provider: TTSProvider;

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -331,6 +331,7 @@
 					provider: ttsProvider,
 					apiKey: ttsConfig.apiKey,
 					voiceId: speechSettings.activeVoiceId as string || ttsConfig.voiceId,
+					model: speechSettings.activeModel as string || ttsConfig.modelId,
 					baseUrl: ttsConfig.baseUrl || ttsMeta?.defaultBaseUrl,
 					speed: speechSettings.speed as number ?? 1
 				});

--- a/src/routes/app/settings/persona/+page.svelte
+++ b/src/routes/app/settings/persona/+page.svelte
@@ -325,6 +325,10 @@
 		if (provider?.models?.length) {
 			modulesStore.setModuleSetting('speech', 'activeModel', provider.models[0].id);
 		}
+		// Local providers ship a default voice so requests work before the user picks one
+		if (provider?.isLocal && provider.voices?.length) {
+			modulesStore.setModuleSetting('speech', 'activeVoiceId', provider.voices[0].id);
+		}
 		// Mark local providers as added immediately (they don't need API keys)
 		if (provider?.isLocal || !provider?.requiresApiKey) {
 			settingsStore.markProviderAdded(providerId);
@@ -333,6 +337,10 @@
 
 	function handleTTSModelChange(modelId: string) {
 		modulesStore.setModuleSetting('speech', 'activeModel', modelId);
+	}
+
+	function handleTTSVoiceChange(voiceId: string) {
+		modulesStore.setModuleSetting('speech', 'activeVoiceId', voiceId);
 	}
 
 	function handleTTSApiKeyBlur() {
@@ -650,18 +658,31 @@
 											<input
 												type="text"
 												class="api-key-input"
-												placeholder="Model/voice name"
-												value={speechSettings.activeModel as string ?? ''}
-												onchange={(e) => handleTTSModelChange(e.currentTarget.value)}
+												list="local-tts-voices"
+												placeholder="Voice (e.g. af_bella)"
+												value={speechSettings.activeVoiceId as string ?? ''}
+												onchange={(e) => handleTTSVoiceChange(e.currentTarget.value)}
 											/>
+											<datalist id="local-tts-voices">
+												{#each provider.voices ?? [] as voice}
+													<option value={voice.id}>{voice.name}</option>
+												{/each}
+											</datalist>
 										</div>
-									{/if}
-									{#if provider?.isLocal}
 										<div class="api-key-row">
 											<input
 												type="text"
 												class="api-key-input"
-												placeholder={provider.defaultBaseUrl || 'http://localhost:5000/'}
+												placeholder="Model (optional, e.g. kokoro)"
+												value={speechSettings.activeModel as string ?? ''}
+												onchange={(e) => handleTTSModelChange(e.currentTarget.value)}
+											/>
+										</div>
+										<div class="api-key-row">
+											<input
+												type="text"
+												class="api-key-input"
+												placeholder={provider.defaultBaseUrl || 'http://localhost:8880/v1/'}
 												value={settingsStore.getProviderConfig(provider.id).baseUrl ?? ''}
 												onchange={(e) => settingsStore.setProviderConfig(provider.id, { baseUrl: e.currentTarget.value })}
 											/>

--- a/src/routes/overlay/+page.svelte
+++ b/src/routes/overlay/+page.svelte
@@ -329,6 +329,7 @@
 					provider: ttsProvider,
 					apiKey: ttsConfig.apiKey,
 					voiceId: speechSettings.activeVoiceId as string || ttsConfig.voiceId,
+					model: speechSettings.activeModel as string || ttsConfig.modelId,
 					baseUrl: ttsConfig.baseUrl || ttsMeta?.defaultBaseUrl,
 					speed: speechSettings.speed as number ?? 1
 				});


### PR DESCRIPTION
Adds a **Local TTS** provider so users running local LLMs (Ollama, LM Studio) can also use a self-hosted voice, with no API key.

## What it does
- New `local-tts` provider (OpenAI-compatible) that reuses the OpenAI TTS client pointed at a localhost server. Works with Kokoro-FastAPI, openedai-speech, or any server exposing `/v1/audio/speech`.
- Lip-sync is amplitude-based, so any audio backend works unchanged.
- Settings expose a voice picker (seeded Kokoro voices + free-text), optional model, and base URL.

## Notes
- Applies the lessons from the Ollama fix (#17): direct client transport, no API key, normalized base URL, and an actionable connection hint on CORS/connection failure.
- Also fixes a latent bug where `openai-tts` ignored its selected model.

## Testing
- Unit tests for URL normalization, the connection hint, and registry flags.
- Verified end to end against a live local server: real audio returned, CORS preflight passes, app plays it with lip-sync.

## Docs
- New "Local TTS Setup" guide, troubleshooting entries, README updates.