### PR TITLE
fix(desktop): only expose the app, boot reliably on macOS

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,6 +14,7 @@
       {
         "label": "main",
         "title": "Utsuwa",
+        "url": "/app",
         "width": 1200,
         "height": 800,
         "minWidth": 800,

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,6 +1,10 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
 declare global {
+	// Build-time flag injected by Vite (see vite.config.ts). True only in the
+	// Tauri desktop build.
+	const __IS_DESKTOP__: boolean;
+
 	namespace App {
 		// interface Error {}
 		// interface Locals {}

--- a/src/lib/services/platform/platform.ts
+++ b/src/lib/services/platform/platform.ts
@@ -16,6 +16,16 @@ export function isWeb(): boolean {
 }
 
 /**
+ * True only in the Tauri desktop build, decided at build time (see
+ * vite.config.ts). Prefer this over isTauri() for routing/marketing-gating
+ * decisions: isTauri() reads the Tauri globals, which inject after first paint
+ * on macOS WKWebView and race the initial render. This never races.
+ */
+export function isDesktopBuild(): boolean {
+	return typeof __IS_DESKTOP__ !== 'undefined' && __IS_DESKTOP__;
+}
+
+/**
  * Get the current platform name
  */
 export function getPlatform(): 'tauri' | 'web' | 'server' {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,7 +5,7 @@
 	import { goto } from '$app/navigation';
 	import { modulesStore } from '$lib/stores/modules.svelte';
 	import { moduleRegistry } from '$lib/services/modules';
-	import { isTauri } from '$lib/services/platform/platform';
+	import { isDesktopBuild } from '$lib/services/platform/platform';
 	import { SITE_URL } from '$lib/config/site';
 
 	let { children } = $props();
@@ -14,9 +14,10 @@
 	const isWebOnly = (path: string) =>
 		path === '/' || path.startsWith('/docs') || path.startsWith('/blog');
 
-	// The desktop window launches at "/" (the landing route). Send it straight
-	// into the app so the marketing site never renders inside the window.
-	const redirecting = $derived(browser && isTauri() && page.url.pathname === '/');
+	// The desktop build must only ever show the app. The window now boots at
+	// "/app" (tauri.conf.json), but this also bounces any web-only route to the
+	// app as a safety net, using the build-time flag so it can't race.
+	const redirecting = $derived(browser && isDesktopBuild() && isWebOnly(page.url.pathname));
 
 	if (browser) {
 		for (const mod of moduleRegistry) {
@@ -35,7 +36,7 @@
 		// In the desktop app, marketing/docs/blog links open in the system
 		// browser instead of navigating the webview.
 		document.addEventListener('click', (e) => {
-			if (!isTauri()) return;
+			if (!isDesktopBuild()) return;
 			const anchor = (e.target as Element).closest('a');
 			if (!anchor) return;
 			const href = anchor.getAttribute('href');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,11 @@ const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 export default defineConfig({
 	plugins: [sveltekit(), tailwindcss()],
 	define: {
-		'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkg.version)
+		'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkg.version),
+		// True only when the frontend is built by the Tauri CLI (which sets
+		// TAURI_ENV_PLATFORM). Baked in at build time so routing decisions never
+		// depend on the Tauri globals being injected at runtime.
+		__IS_DESKTOP__: JSON.stringify(!!process.env.TAURI_ENV_PLATFORM)
 	},
 	ssr: {
 		noExternal: ['bits-ui']


### PR DESCRIPTION
The desktop app was defaulting to the marketing landing page on macOS (worked on Windows). 0.3.1 claimed to fix this but the fix raced on macOS WebKit.

## Root cause
The window loaded `/` and relied on a client-side `isTauri()` redirect. On macOS (WKWebView) the Tauri globals inject after the layout first evaluates, so `isTauri()` returned false and the non-reactive guard never re-ran. Windows (WebView2) injects earlier, so it worked there.

## Fix
- Pin the main window `url` to `/app` in `tauri.conf.json` (like the overlay window already pins `/overlay`), so it boots into the app on every platform with no race.
- Add a build-time `__IS_DESKTOP__` flag (from `TAURI_ENV_PLATFORM`) and `isDesktopBuild()`, used for the web-only-route guard and the link interceptor so routing is deterministic. `isTauri()` is unchanged for real Tauri-API calls.
- The redirect now covers `/`, `/docs`, and `/blog`; those links open in the system browser.

## Result
Only the app is ever reachable in the desktop window, on all platforms.

## Verified
Confirmed on a local macOS `tauri build`: boots straight to the app, no landing page.