### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-06-29
+
+### Added
+- **Local text-to-speech**: connect any OpenAI-compatible TTS server (Kokoro-FastAPI, openedai-speech) for a self-hosted companion voice with no API key. New "Local TTS" provider with voice, model, and base URL settings, plus a setup guide.
+
+### Fixed
+- Desktop app now reliably boots into the app on **macOS** (and all platforms). The previous launch raced on macOS WebKit; the window now opens directly into the app, with routing gated by a build-time flag so the landing page and docs are never reachable inside the desktop window.
+- Info modal "Docs" link now points to the docs subdomain (docs.utsuwa.ai) and opens in the system browser on desktop.
+- Info modal logo is now a clean mark (blue in light mode, white in dark) without the badge container.
+- Desktop update notification now appears from the top of the window.
+- OpenAI TTS now respects the selected model instead of always using `tts-1`.
+
 ## [0.3.1] - 2026-06-28
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.3.1",
+	"version": "0.4.0",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.3.1"
+version = "0.4.0"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
Version bump to **0.4.0** across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`, plus the CHANGELOG entry.

Covers the three feature/fix PRs in this release:
- #35 — Local TTS (OpenAI-compatible servers)
- #36 — Desktop: only expose the app, reliable macOS boot
- #37 — Info modal docs link + logo, update toast position

## Merge order
Merge this **last**, after #35, #36, and #37 are in `main`. Then push the `v0.4.0` tag to trigger the release workflow (it builds macOS/Windows/Linux installers and creates a **draft** GitHub Release).

## Before tagging
- The macOS desktop fix has been verified on a local `tauri build` (boots straight to the app).
- Confirm the `TAURI_SIGNING_PRIVATE_KEY` / password secrets are still set (used for 0.3.x, so they should be). Do **not** regenerate the updater keypair, or installed apps will reject the update.
- After CI creates the draft, check all three installers + `latest.json` + signatures are attached, then publish to push the auto-update live.