### PR TITLE
fix: stop app/docs host rewrites from swallowing /api routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,9 +6,9 @@
 			"destination": "/docs"
 		},
 		{
-			"source": "/:path+",
+			"source": "/((?!api/).+)",
 			"has": [{ "type": "host", "value": "docs.utsuwa.ai" }],
-			"destination": "/docs/:path+"
+			"destination": "/docs/$1"
 		},
 		{
 			"source": "/",
@@ -16,9 +16,9 @@
 			"destination": "/app"
 		},
 		{
-			"source": "/:path+",
+			"source": "/((?!api/).+)",
 			"has": [{ "type": "host", "value": "app.utsuwa.ai" }],
-			"destination": "/app/:path+"
+			"destination": "/app/$1"
 		}
 	],
 	"redirects": [


### PR DESCRIPTION
## Problem
On `app.utsuwa.ai`, every `/api/*` request returns 404, which breaks all cloud providers (OpenAI/Anthropic/Google/xAI) for web users — both model fetching (`/api/providers/models`) and chat (`/api/chat`). Local providers and the desktop app are unaffected because they call the provider directly and never hit `/api`.

## Cause
The host rewrite for `app.utsuwa.ai`:

```json
{ "source": "/:path+", "has": [{ "host": "app.utsuwa.ai" }], "destination": "/app/:path+" }
```

matches `/api/...` too, so `app.utsuwa.ai/api/providers/models` gets rewritten to `/app/api/providers/models` (no such route) → 404.

Confirmed by comparison on the same deployment:
- `www.utsuwa.ai/api/providers/models` → **400** (route reached, empty body rejected)
- `app.utsuwa.ai/api/providers/models` → **404** (path rewritten away)

`docs.utsuwa.ai` carries the identical latent pattern.

## Fix
Exclude `/api` from both the app and docs catch-all rewrites via a negative lookahead, so those paths resolve to the real serverless functions.

## Verify after deploy
```bash
curl -s -o /dev/null -w "%{http_code}\n" -X POST \
  -H "Content-Type: application/json" -d '{}' \
  https://app.utsuwa.ai/api/providers/models
```
Expect **400** (route reached), not 404.

Note: standard Vercel preview URLs won't exercise this — the rewrites are gated on the `app.utsuwa.ai` / `docs.utsuwa.ai` hosts, so validation needs the production domain (or a preview aliased to those hosts).
