### PR TITLE
fix: don't prefix /api in the subdomain reroute (real fix for web /api 404s)

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -9,11 +9,11 @@ export const reroute: Reroute = ({ url }) => {
 	const host = url.hostname;
 
 	if (host.startsWith('docs.')) {
-		if (!url.pathname.startsWith('/docs')) {
+		if (!url.pathname.startsWith('/docs') && !url.pathname.startsWith('/api')) {
 			return url.pathname === '/' ? '/docs' : `/docs${url.pathname}`;
 		}
 	} else if (host.startsWith('app.')) {
-		if (!url.pathname.startsWith('/app')) {
+		if (!url.pathname.startsWith('/app') && !url.pathname.startsWith('/api')) {
 			return url.pathname === '/' ? '/app' : `/app${url.pathname}`;
 		}
 	}

--- a/vercel.json
+++ b/vercel.json
@@ -6,19 +6,14 @@
 			"destination": "/docs"
 		},
 		{
-			"source": "/((?!api/).+)",
+			"source": "/:path+",
 			"has": [{ "type": "host", "value": "docs.utsuwa.ai" }],
-			"destination": "/docs/$1"
+			"destination": "/docs/:path+"
 		},
 		{
 			"source": "/",
 			"has": [{ "type": "host", "value": "app.utsuwa.ai" }],
 			"destination": "/app"
-		},
-		{
-			"source": "/((?!api/).+)",
-			"has": [{ "type": "host", "value": "app.utsuwa.ai" }],
-			"destination": "/app/$1"
 		}
 	],
 	"redirects": [


### PR DESCRIPTION
## Real root cause (supersedes #39)

Web users could not use any cloud provider on `app.utsuwa.ai` — `/api/providers/models` (model listing) and `/api/chat` both 404'd. Local providers and the desktop app were fine because they call providers directly and never hit `/api`.

#39 blamed the `vercel.json` host rewrite, but that was the wrong layer (and its negative-lookahead exclusion doesn't even compile on live Vercel). The actual cause is the **SvelteKit `reroute` hook** in `src/hooks.ts`, which runs on every request and prefixes app-subdomain paths with `/app`. It also prefixed `/api`, so `app.utsuwa.ai/api/providers/models` → `/app/api/providers/models` → no route → SvelteKit 404 page (`x-sveltekit-page: true`). Removing the `vercel.json` catch-all didn't help because the hook does the same thing one layer down.

## Fix
- `src/hooks.ts`: don't prefix shared `/api` routes for the `app.`/`docs.` subdomains.
- `vercel.json`: drop the redundant app catch-all (the reroute hook handles subdomain prefixing) and revert #39's lookahead; keep only `/` → `/app`.

## Verified on production
Deployed and confirmed on `app.utsuwa.ai`:
- `POST /api/providers/models` → 400 (endpoint reached), real key → JSON response
- `POST /api/chat` → 400 (reached)
- `/`, `/settings`, `/settings/persona`, `/blog` → 200 (pages still route via the hook)
