### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.4.0"
+version = "0.5.0"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
Bump version `0.4.0` → `0.5.0` across `package.json`, `tauri.conf.json`, `Cargo.toml`, and the `utsuwa` entry in `Cargo.lock`.

This is the release version for the work now on `main`:
- Multimodal image support ("show her photos") + memory/personality pipeline hardening (#41)
- macOS drag-drop + overlay camera-crash fixes (#42)
