### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.5.0"
+version = "0.6.0"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
Bumps the app version from 0.5.0 to 0.6.0 across all manifests (`package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`) ahead of tagging `v0.6.0`.

Release highlights since 0.5.0: modernized design language with a unified motion system across the app, memory graph and onboarding fixes, README and brand refresh.