### PR TITLE
Fix relationship progression deadlocking at romantic_interest

### DIFF
--- a/src/lib/engine/event-completion.test.ts
+++ b/src/lib/engine/event-completion.test.ts
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { completionMarkers } from './event-completion.ts';
+import { calculateStage } from './stages.ts';
+import { romanticEvents } from '../data/events/romantic.ts';
+import type { EventDefinition } from '$lib/types/events';
+import type { CharacterState } from '$lib/types/character';
+
+const confession = romanticEvents.find((e) => e.id === 'confession_event') as EventDefinition;
+
+test('an event with no choices records only its own id', () => {
+	const event = { id: 'plain_event', type: 'conditional' } as EventDefinition;
+	assert.deepEqual(completionMarkers(event), ['plain_event']);
+	assert.deepEqual(completionMarkers(event, 0), ['plain_event']);
+});
+
+test('accepting the confession records the outcome marker that gates dating', () => {
+	// Choice 0 is "I feel the same way." -> nextSceneId: confession_accepted
+	const markers = completionMarkers(confession, 0);
+	assert.ok(markers.includes('confession_event'));
+	assert.ok(
+		markers.includes('confession_accepted'),
+		'accepting the confession must record confession_accepted so the dating stage can unlock'
+	);
+});
+
+test('declining the confession does NOT record the dating-gate marker', () => {
+	// Choice 1 is "I need time to think about this." -> nextSceneId: confession_delayed
+	const markers = completionMarkers(confession, 1);
+	assert.ok(markers.includes('confession_event'));
+	assert.ok(!markers.includes('confession_accepted'));
+});
+
+test('a choice without a nextSceneId records only the event id', () => {
+	// first_i_love_you has choices but no nextSceneId on them
+	const iLoveYou = romanticEvents.find((e) => e.id === 'first_i_love_you') as EventDefinition;
+	assert.deepEqual(completionMarkers(iLoveYou, 0), ['first_i_love_you']);
+});
+
+test('regression: accepting the confession actually unlocks the dating stage', () => {
+	// Stats high enough for the dating gate, plus the two romantic_interest events
+	const state = {
+		affection: 1000,
+		trust: 100,
+		intimacy: 100,
+		comfort: 100,
+		respect: 100,
+		daysKnown: 100,
+		totalInteractions: 500,
+		appMode: 'dating_sim',
+		relationshipStage: 'romantic_interest'
+	} as CharacterState;
+
+	const events = ['first_deep_conversation', 'shared_vulnerability'];
+	// Before accepting the confession, dating is unreachable (this was the deadlock)
+	assert.equal(calculateStage(state, events), 'romantic_interest');
+
+	// Completing the confession with the accept choice records confession_accepted
+	const afterConfession = [...events, ...completionMarkers(confession, 0)];
+	assert.equal(calculateStage(state, afterConfession), 'dating');
+});

--- a/src/lib/engine/event-completion.ts
+++ b/src/lib/engine/event-completion.ts
@@ -1,0 +1,15 @@
+import type { EventDefinition } from '$lib/types/events';
+
+// The completed-event markers a finished event contributes. Always the event's
+// own id, plus the chosen choice's outcome marker (nextSceneId) when present.
+// Those outcome markers (e.g. 'confession_accepted') are what gate later
+// relationship stages, so the accept path unlocks progression while the decline
+// path does not. Kept dependency-free so it can be unit tested.
+export function completionMarkers(event: EventDefinition, choiceIndex?: number): string[] {
+	const markers = [event.id];
+	const choice = choiceIndex !== undefined ? event.scene?.choices?.[choiceIndex] : undefined;
+	if (choice?.nextSceneId) {
+		markers.push(choice.nextSceneId);
+	}
+	return markers;
+}

--- a/src/lib/stores/character.svelte.ts
+++ b/src/lib/stores/character.svelte.ts
@@ -267,12 +267,21 @@ function createCharacterStore() {
 		save();
 	}
 
-	// Mark event as completed
+	// Mark event as completed. Also accepts synthetic choice-outcome markers
+	// (a choice's nextSceneId, e.g. 'confession_accepted') that gate later stages.
 	function markEventCompleted(eventId: string): void {
 		if (!state.completedEvents.includes(eventId)) {
+			const completedEvents = [...state.completedEvents, eventId];
+			// A gating event can unlock the next relationship stage right away.
+			// Companion mode has no dating-sim ladder, so leave its stage locked.
+			const relationshipStage =
+				state.appMode === 'companion'
+					? state.relationshipStage
+					: calculateStage(state, completedEvents);
 			state = {
 				...state,
-				completedEvents: [...state.completedEvents, eventId],
+				completedEvents,
+				relationshipStage,
 				updatedAt: new Date()
 			};
 			save();

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -47,6 +47,7 @@
 	} from '$lib/engine/memory';
 	import { initEmbeddingModel } from '$lib/services/embeddings';
 	import { checkAllEvents, eventsApi } from '$lib/engine/events';
+	import { completionMarkers } from '$lib/engine/event-completion';
 	import { allEvents } from '$lib/data/events';
 
 	let canvasRef: HTMLCanvasElement | null = null;
@@ -473,7 +474,11 @@
 			choiceIndex,
 			choiceIndex !== undefined ? `Choice ${choiceIndex + 1}` : undefined
 		).then(() => {
-			characterStore.markEventCompleted(event.id);
+			// Records the event id plus the chosen outcome marker (e.g.
+			// confession_accepted), which is what gates later relationship stages.
+			for (const marker of completionMarkers(event, choiceIndex)) {
+				characterStore.markEventCompleted(marker);
+			}
 		}).catch((e) => {
 			console.error('Failed to record event completion:', e);
 		});

--- a/src/routes/overlay/+page.svelte
+++ b/src/routes/overlay/+page.svelte
@@ -24,6 +24,7 @@
 	import { streamChatDirect } from '$lib/services/chat/client-chat';
 	import { allEvents } from '$lib/data/events';
 	import { checkAllEvents, eventsApi } from '$lib/engine/events';
+	import { completionMarkers } from '$lib/engine/event-completion';
 	import type { TTSProvider } from '$lib/types';
 	import type { EventDefinition } from '$lib/types/events';
 	import type { StateUpdates } from '$lib/types/character';
@@ -364,7 +365,11 @@
 		eventsApi.recordCompletedEvent(
 			event, choiceIndex,
 			choiceIndex !== undefined ? `Choice ${choiceIndex + 1}` : undefined
-		).then(() => characterStore.markEventCompleted(event.id))
+		).then(() => {
+			for (const marker of completionMarkers(event, choiceIndex)) {
+				characterStore.markEventCompleted(marker);
+			}
+		})
 		.catch((e) => console.error('Failed to record event:', e));
 		activeEvent = null;
 	}


### PR DESCRIPTION
## The bug

Relationship progression silently caps at `romantic_interest`. The `dating` stage gate requires a completed event with the id `confession_accepted`:

```
dating: { ..., requiredEvents: ['confession_accepted'] }
```

But `confession_accepted` only ever existed as the `nextSceneId` on the confession event's accept choice. Nothing in the codebase processes `nextSceneId`, and event completion only records the event's own id (`confession_event`). So `confession_accepted` could never land in `completedEvents`, which made `dating` — and transitively `committed` and `soulmate` — impossible to reach for every player.

## The fix

When an event with a chosen outcome completes, record the choice's outcome marker (its `nextSceneId`) alongside the event id. Accepting the confession now records `confession_accepted` and unlocks `dating`; declining records `confession_delayed` instead, so it correctly does not.

- New `completionMarkers(event, choiceIndex)` helper (pure, dependency-free) returns `[event.id, ...outcomeMarker]`. Both the app and overlay completion handlers use it.
- `markEventCompleted` now recomputes the relationship stage when a marker is added, so a gating choice promotes the stage immediately instead of waiting for the next message (Companion Mode stays locked, as before).

## Tests

Added `event-completion.test.ts`, including a regression test that uses the real confession event data and the real `calculateStage`: it asserts the stage is stuck at `romantic_interest` before the confession and becomes `dating` after accepting it, and that declining does not unlock it.

## Verification
- `pnpm test` — 81/81 pass
- `pnpm check` — 0 errors
- Manual: drove a choice-based event through the completion flow in-app; the choice records and the stage recompute run without errors.
