### PR TITLE
Fix time-based decay re-applying on every page load

### DIFF
--- a/src/lib/engine/state-updates.test.ts
+++ b/src/lib/engine/state-updates.test.ts
@@ -1,8 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { applyTimeDecay, mergeUpdates, checkAndApplyStageTransition } from './state-updates.ts';
+import {
+	applyTimeDecay,
+	mergeUpdates,
+	checkAndApplyStageTransition,
+	resolveTimeDecayOnLoad
+} from './state-updates.ts';
 import type { CharacterState, StateUpdates } from '$lib/types/character';
+
+const HOUR = 1000 * 60 * 60;
 
 function makeState(overrides: Partial<CharacterState> = {}): CharacterState {
 	return {
@@ -81,6 +88,75 @@ test('mood shifts to melancholy after 3 days away', () => {
 	const updates = applyTimeDecay(makeState(), 96);
 	assert.equal(updates.moodChange?.emotion, 'melancholy');
 	assert.ok((updates.moodChange?.intensityDelta ?? 0) <= 30);
+});
+
+// --- resolveTimeDecayOnLoad (once-per-absence guard) ---
+
+test('a 3-day absence decays affection once and marks lastDecayAt', () => {
+	const now = 1_000_000_000_000;
+	const state = makeState({
+		affection: 500,
+		trust: 90,
+		lastInteraction: new Date(now - 72 * HOUR),
+		lastDecayAt: null
+	});
+	const result = resolveTimeDecayOnLoad(state, now);
+	assert.equal(result.changed, true);
+	assert.equal(result.next.affection, 495); // -5 for a 3-day absence
+	assert.ok(result.next.lastDecayAt instanceof Date);
+});
+
+test('regression: reloading after decay does NOT re-deduct affection', () => {
+	const now = 1_000_000_000_000;
+	const lastInteraction = new Date(now - 72 * HOUR);
+	const first = resolveTimeDecayOnLoad(
+		makeState({ affection: 500, trust: 90, lastInteraction, lastDecayAt: null }),
+		now
+	);
+	// Second load: same absence, but lastDecayAt is now set from the first pass
+	const second = resolveTimeDecayOnLoad(
+		makeState({ affection: 495, trust: 90, lastInteraction, lastDecayAt: first.next.lastDecayAt }),
+		now + HOUR
+	);
+	assert.equal(second.next.affection, undefined, 'affection must not decay a second time');
+	assert.equal(second.changed, false);
+});
+
+test('interacting re-arms decay for the next absence', () => {
+	const now = 1_000_000_000_000;
+	// Decayed during a past absence, then chatted (lastInteraction advanced past lastDecayAt)
+	const state = makeState({
+		affection: 500,
+		trust: 90,
+		lastDecayAt: new Date(now - 100 * HOUR),
+		lastInteraction: new Date(now - 72 * HOUR)
+	});
+	const result = resolveTimeDecayOnLoad(state, now);
+	assert.equal(result.next.affection, 495, 'a new absence decays again');
+});
+
+test('energy still recovers on every load even when decay is locked out', () => {
+	const now = 1_000_000_000_000;
+	const lastInteraction = new Date(now - 72 * HOUR);
+	const state = makeState({
+		energy: 40,
+		affection: 500,
+		lastInteraction,
+		lastDecayAt: lastInteraction // already decayed this absence
+	});
+	const result = resolveTimeDecayOnLoad(state, now);
+	assert.equal(result.next.energy, 100); // energy is self-limiting, always recovers
+	assert.equal(result.next.affection, undefined); // decay stays locked out
+	assert.equal(result.changed, true);
+});
+
+test('no decay under the 30-minute floor', () => {
+	const now = 1_000_000_000_000;
+	const result = resolveTimeDecayOnLoad(
+		makeState({ lastInteraction: new Date(now - 10 * 60 * 1000) }),
+		now
+	);
+	assert.equal(result.changed, false);
 });
 
 // --- mergeUpdates ---

--- a/src/lib/engine/state-updates.ts
+++ b/src/lib/engine/state-updates.ts
@@ -1,4 +1,4 @@
-import type { CharacterState, StateUpdates, Emotion, RelationshipStage } from '$lib/types/character';
+import type { CharacterState, StateUpdates, Emotion, MoodState, RelationshipStage } from '$lib/types/character';
 import { calculateStage } from './stages.ts';
 
 // Clamp a value between min and max
@@ -69,6 +69,71 @@ export function applyTimeDecay(state: CharacterState, hoursSinceLastInteraction:
 	}
 
 	return updates;
+}
+
+// The subset of fields a load-time decay pass may change, plus whether anything
+// changed at all (so the caller only persists when needed).
+export interface TimeDecayApplication {
+	next: Partial<Pick<CharacterState, 'energy' | 'affection' | 'trust' | 'mood' | 'lastDecayAt'>>;
+	changed: boolean;
+}
+
+// Resolve how a page load should apply time decay. Energy recovery is
+// self-limiting (caps at 100) so it runs on every load, but affection/trust/mood
+// decay is applied at most once per absence: a refresh or a second window would
+// otherwise re-deduct the same time away. `lastDecayAt` records that this
+// absence's decay is accounted for; it re-arms when the user next interacts
+// (which advances lastInteraction past lastDecayAt). `now` is passed in so this
+// stays pure and testable.
+export function resolveTimeDecayOnLoad(state: CharacterState, now: number): TimeDecayApplication {
+	const result: TimeDecayApplication = { next: {}, changed: false };
+	if (!state.lastInteraction) return result;
+
+	const lastInteractionMs = new Date(state.lastInteraction).getTime();
+	const hoursSince = (now - lastInteractionMs) / (1000 * 60 * 60);
+	if (hoursSince <= 0.5) return result;
+
+	const timeUpdates = applyTimeDecay(state, hoursSince);
+	const alreadyDecayed =
+		state.lastDecayAt != null && new Date(state.lastDecayAt).getTime() >= lastInteractionMs;
+
+	const next: TimeDecayApplication['next'] = {};
+	let decayApplied = false;
+
+	if (timeUpdates.energyDelta !== undefined) {
+		next.energy = clamp(state.energy + timeUpdates.energyDelta, 0, 100);
+	}
+
+	if (!alreadyDecayed) {
+		if (timeUpdates.affectionDelta !== undefined) {
+			next.affection = clamp(state.affection + timeUpdates.affectionDelta, 0, 1000);
+			decayApplied = true;
+		}
+		if (timeUpdates.trustDelta !== undefined) {
+			next.trust = clamp(state.trust + timeUpdates.trustDelta, 0, 100);
+			decayApplied = true;
+		}
+		if (timeUpdates.moodChange) {
+			const mood: MoodState = {
+				...state.mood,
+				primary: timeUpdates.moodChange.emotion,
+				intensity: clamp(state.mood.intensity + (timeUpdates.moodChange.intensityDelta ?? 0), 0, 100),
+				causes: timeUpdates.moodChange.cause
+					? [...state.mood.causes.slice(-4), timeUpdates.moodChange.cause]
+					: state.mood.causes
+			};
+			next.mood = mood;
+			decayApplied = true;
+		}
+	}
+
+	if (decayApplied) {
+		next.lastDecayAt = new Date(now);
+	}
+
+	result.next = next;
+	result.changed = timeUpdates.energyDelta !== undefined || decayApplied;
+	return result;
 }
 
 // Calculate interaction impact based on message analysis

--- a/src/lib/services/storage/character.ts
+++ b/src/lib/services/storage/character.ts
@@ -49,6 +49,7 @@ function serializeCharacterState(state: CharacterState): Omit<DBCharacterState, 
 	return {
 		...state,
 		lastInteraction: state.lastInteraction ? new Date(state.lastInteraction) : null,
+		lastDecayAt: state.lastDecayAt ? new Date(state.lastDecayAt) : null,
 		firstMet: new Date(state.firstMet),
 		createdAt: new Date(state.createdAt),
 		updatedAt: new Date()
@@ -60,6 +61,7 @@ function deserializeCharacterState(state: DBCharacterState): CharacterState {
 	return {
 		...state,
 		lastInteraction: state.lastInteraction ? new Date(state.lastInteraction) : null,
+		lastDecayAt: state.lastDecayAt ? new Date(state.lastDecayAt) : null,
 		firstMet: new Date(state.firstMet),
 		createdAt: new Date(state.createdAt),
 		updatedAt: new Date(state.updatedAt)

--- a/src/lib/stores/character.svelte.ts
+++ b/src/lib/stores/character.svelte.ts
@@ -15,7 +15,7 @@ import {
 	deleteCharacterState
 } from '$lib/services/storage/character';
 import { statChangesStore } from './statChanges.svelte';
-import { applyTimeDecay } from '$lib/engine/state-updates';
+import { resolveTimeDecayOnLoad } from '$lib/engine/state-updates';
 import { calculateStage } from '$lib/engine/stages';
 
 // Single character state
@@ -61,54 +61,15 @@ function createCharacterStore() {
 			const loaded = await getCharacterState();
 			state = loaded;
 
-			// Apply time-based recovery/decay based on time since last interaction
-			if (state.lastInteraction) {
-				const hoursSince =
-					(Date.now() - new Date(state.lastInteraction).getTime()) / (1000 * 60 * 60);
-				if (hoursSince > 0.5) {
-					// Only apply if at least 30 minutes have passed
-					const timeUpdates = applyTimeDecay(state, hoursSince);
-					if (Object.keys(timeUpdates).length > 0) {
-						// Apply updates directly without emitting visual indicators (silent recovery)
-						if (timeUpdates.energyDelta !== undefined) {
-							state = {
-								...state,
-								energy: Math.max(0, Math.min(100, state.energy + timeUpdates.energyDelta))
-							};
-						}
-						if (timeUpdates.affectionDelta !== undefined) {
-							state = {
-								...state,
-								affection: Math.max(0, Math.min(1000, state.affection + timeUpdates.affectionDelta))
-							};
-						}
-						if (timeUpdates.trustDelta !== undefined) {
-							state = {
-								...state,
-								trust: Math.max(0, Math.min(100, state.trust + timeUpdates.trustDelta))
-							};
-						}
-						if (timeUpdates.moodChange) {
-							state = {
-								...state,
-								mood: {
-									...state.mood,
-									primary: timeUpdates.moodChange.emotion,
-									intensity: Math.max(
-										0,
-										Math.min(100, state.mood.intensity + (timeUpdates.moodChange.intensityDelta ?? 0))
-									),
-									causes: timeUpdates.moodChange.cause
-										? [...state.mood.causes.slice(-4), timeUpdates.moodChange.cause]
-										: state.mood.causes
-								}
-							};
-						}
-						// Save the recovered state (use $state.snapshot to strip Proxy)
-						const plainState = $state.snapshot(state);
-						await saveCharacterState({ ...plainState, updatedAt: new Date() });
-					}
-				}
+			// Apply time-based recovery/decay based on time since last interaction.
+			// Energy recovers every load; affection/trust/mood decay applies once per
+			// absence so a refresh or second window can't re-deduct it (see helper).
+			const decay = resolveTimeDecayOnLoad(state, Date.now());
+			if (decay.changed) {
+				state = { ...state, ...decay.next };
+				// Save the recovered state (use $state.snapshot to strip Proxy)
+				const plainState = $state.snapshot(state);
+				await saveCharacterState({ ...plainState, updatedAt: new Date() });
 			}
 
 			isReady = true;

--- a/src/lib/types/character.ts
+++ b/src/lib/types/character.ts
@@ -99,6 +99,9 @@ export interface CharacterState {
 
 	// Temporal
 	lastInteraction: Date | null;
+	// Timestamp through which time-based decay has been applied, so a refresh or a
+	// second window doesn't re-apply the same absence's decay. Re-armed on interaction.
+	lastDecayAt?: Date | null;
 	firstMet: Date;
 	daysKnown: number;
 	totalInteractions: number;
@@ -178,6 +181,7 @@ export function createDefaultCharacterState(): Omit<CharacterState, 'id'> {
 		relationshipStage: 'stranger',
 		personality: createDefaultPersonality(),
 		lastInteraction: null,
+		lastDecayAt: null,
 		firstMet: now,
 		daysKnown: 0,
 		totalInteractions: 0,


### PR DESCRIPTION
## The bug

On load, `loadState` computes decay from the time since `lastInteraction`, applies it, and saves — but never advances any marker. So `lastInteraction` stays put, and the next load re-applies the same absence's decay. Refreshing the page (or opening the overlay window, which runs its own store instance) repeatedly drains affection, trust, and pushes mood toward melancholy for a single time away.

Example: return after 3 days → −5 affection applied and saved. Refresh 5 times → −5 each time. Energy recovery didn't have this problem because it's self-limiting (caps at 100).

## The fix

Introduce a `lastDecayAt` marker. Affection/trust/mood decay applies at most once per absence: it's skipped when `lastDecayAt >= lastInteraction` (i.e. this absence was already accounted for), and `lastDecayAt` is stamped when decay runs. Interacting advances `lastInteraction` past `lastDecayAt`, which re-arms decay for the next absence. Energy recovery still runs on every load since it can't overshoot.

The decision logic is extracted into a pure `resolveTimeDecayOnLoad(state, now)` helper in the engine (with `now` injected), so the store's `loadState` just merges the result and the behavior is unit-testable.

## Tests

Added coverage in `state-updates.test.ts`, including the regression: two consecutive loads over the same 3-day absence deduct affection only once; a subsequent real absence decays again; energy keeps recovering even when decay is locked out.

## Verification
- `pnpm test` — 86/86 pass
- `pnpm check` — 0 errors
- Manual: reloaded the app; character state loads with the new decay path and no console errors.
