### PR TITLE
Persist conversation turns and sessions so memory survives reloads

### DIFF
--- a/src/lib/engine/memory.ts
+++ b/src/lib/engine/memory.ts
@@ -22,7 +22,7 @@ let workingMemory: WorkingMemory = {
 export function addTurnToWorkingMemory(turn: Omit<ConversationTurn, 'id'>): void {
 	workingMemory.turns.push({
 		...turn,
-		createdAt: new Date()
+		createdAt: turn.createdAt ?? new Date()
 	} as ConversationTurn);
 
 	// Trim to max size
@@ -31,6 +31,50 @@ export function addTurnToWorkingMemory(turn: Omit<ConversationTurn, 'id'>): void
 	}
 
 	workingMemory.messageCount++;
+}
+
+// How many turns have been persisted under the current session.
+let currentSessionTurnCount = 0;
+
+// Open a session for this run on first use, so persisted turns can be grouped
+// and "last time you talked" style context has something to read.
+async function ensureSession(): Promise<number | undefined> {
+	if (workingMemory.currentSessionId !== undefined) return workingMemory.currentSessionId;
+	try {
+		const session = await memoryApi.createSession();
+		workingMemory.currentSessionId = session.id;
+		workingMemory.sessionStartedAt = session.startedAt;
+		currentSessionTurnCount = 0;
+		return session.id;
+	} catch (e) {
+		console.debug('[Memory] Failed to create session:', e);
+		return undefined;
+	}
+}
+
+// Record a conversation turn: mirror it into working memory AND persist it to
+// IndexedDB so history survives reloads and exports aren't empty. Persistence
+// failures are non-fatal — the in-RAM copy still drives the current session.
+export async function recordTurn(
+	turn: Omit<ConversationTurn, 'id' | 'createdAt' | 'sessionId'>
+): Promise<void> {
+	const sessionId = await ensureSession();
+	const full: Omit<ConversationTurn, 'id'> = { ...turn, sessionId, createdAt: new Date() };
+
+	addTurnToWorkingMemory(full);
+
+	try {
+		await memoryStorage.saveConversationTurn(full);
+		if (sessionId !== undefined) {
+			currentSessionTurnCount++;
+			await memoryStorage.updateSession(sessionId, {
+				messageCount: currentSessionTurnCount,
+				endedAt: full.createdAt
+			});
+		}
+	} catch (e) {
+		console.debug('[Memory] Failed to persist conversation turn:', e);
+	}
 }
 
 // Get recent turns from working memory

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -37,7 +37,7 @@
 	import { mergeUpdates, checkAndApplyStageTransition } from '$lib/engine/state-updates';
 	import {
 		retrieveRelevantContext,
-		addTurnToWorkingMemory,
+		recordTurn,
 		hydrateWorkingMemory,
 		memoryApi,
 		determineFactCategory,
@@ -212,9 +212,9 @@
 			}
 		}
 
-		// Save to working memory
-		addTurnToWorkingMemory({ role: 'user', content: userMessage, createdAt: new Date() });
-		addTurnToWorkingMemory({ role: 'assistant', content: dialogue, createdAt: new Date() });
+		// Persist the exchange (and mirror into working memory) so it survives reloads
+		await recordTurn({ role: 'user', content: userMessage });
+		await recordTurn({ role: 'assistant', content: dialogue });
 
 		// Extract facts
 		const potentialFacts = extractPotentialFacts(dialogue, userMessage);

--- a/src/routes/overlay/+page.svelte
+++ b/src/routes/overlay/+page.svelte
@@ -35,7 +35,7 @@
 	import { mergeUpdates, checkAndApplyStageTransition } from '$lib/engine/state-updates';
 	import {
 		retrieveRelevantContext,
-		addTurnToWorkingMemory,
+		recordTurn,
 		hydrateWorkingMemory,
 		memoryApi,
 		determineFactCategory,
@@ -153,8 +153,9 @@
 			}
 		}
 
-		addTurnToWorkingMemory({ role: 'user', content: userMessage, createdAt: new Date() });
-		addTurnToWorkingMemory({ role: 'assistant', content: dialogue, createdAt: new Date() });
+		// Persist the exchange (and mirror into working memory) so it survives reloads
+		await recordTurn({ role: 'user', content: userMessage });
+		await recordTurn({ role: 'assistant', content: dialogue });
 
 		const potentialFacts = extractPotentialFacts(dialogue, userMessage);
 		for (const factContent of potentialFacts.slice(0, 2)) {


### PR DESCRIPTION
## The bug

The chat pipeline recorded each turn only into in-RAM working memory via `addTurnToWorkingMemory`. `memoryApi.saveTurn` and `memoryApi.createSession` existed but were never called, so the `conversationTurns` and `sessions` tables were always empty. Consequences:

- `hydrateWorkingMemory` (run on load) always read an empty table, so conversation history never survived a reload.
- Session-based context ("last time you talked", recent sessions) could never fire.
- Save-file exports always contained zero messages.

## The fix

Add `recordTurn(turn)` in the memory engine. It opens a session lazily on the first turn of a run, persists each turn to IndexedDB with its `sessionId`, mirrors it into working memory, and keeps the session's `messageCount`/`endedAt` current. Both the app and overlay pipelines now `await recordTurn(...)` for the user and assistant turns instead of the in-RAM-only call. A page reload starts a fresh session while `hydrateWorkingMemory` restores recent turns for context.

## Verification

Manual, driving real chat turns against a local Ollama model and inspecting IndexedDB directly:
- After a turn, `conversationTurns` holds the user + assistant messages under a session, and the session's `messageCount` reflects them (was: always empty).
- The turns survive a full page reload.
- A turn sent after reload is grouped under a new session, with the prior run's turns still present.

Also: `pnpm test` 86/86 pass, `pnpm check` 0 errors.
