### PR TITLE
Make save import atomic and dedupe merge re-imports

### DIFF
--- a/src/lib/db/export.ts
+++ b/src/lib/db/export.ts
@@ -1,5 +1,6 @@
 import { db } from '$lib/db';
 import { characterStore } from '$lib/stores/character.svelte';
+import { partitionNewRecords, factKey, sessionKey, turnKey, eventKey } from './import-dedup';
 import type {
 	CharacterState,
 	MoodState,
@@ -100,71 +101,80 @@ export async function importSave(
 
 	const isV2 = saveFile.version.startsWith('2.');
 
-	if (mode === 'replace') {
-		// Clear all existing data
-		await Promise.all([
-			db.characterStates.clear(),
-			db.facts.clear(),
-			db.sessions.clear(),
-			db.conversationTurns.clear(),
-			db.completedEvents.clear()
-		]);
+	// Insert a collection with merge-mode dedup. In merge mode existing records
+	// are keyed first so re-importing the same save is a no-op; replace mode starts
+	// from empty (tables cleared) but still dedupes within the incoming file.
+	async function importCollection<T>(
+		table: {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			add: (r: T) => Promise<any>;
+			toArray: () => Promise<T[]>;
+		},
+		records: T[],
+		keyOf: (r: T) => string
+	): Promise<void> {
+		const existingKeys =
+			mode === 'merge' ? new Set((await table.toArray()).map(keyOf)) : new Set<string>();
+		const { toAdd, skipped: dupes } = partitionNewRecords(records, keyOf, existingKeys);
+		for (const record of toAdd) {
+			await table.add(record);
+		}
+		imported += toAdd.length;
+		skipped += dupes;
 	}
 
-	if (isV2) {
-		// V2 format - single character
-		const v2File = saveFile as SaveFile;
-
-		if (mode === 'replace') {
-			await db.characterStates.add(v2File.data.character);
-			imported++;
-		} else {
-			// Merge mode - skip character if one exists
-			const existing = await db.characterStates.toCollection().first();
-			if (!existing) {
-				await db.characterStates.add(v2File.data.character);
-				imported++;
-			} else {
-				skipped++;
+	// Wrap the whole import in one transaction so a mid-import failure rolls back
+	// instead of leaving cleared tables with partially-written data.
+	await db.transaction(
+		'rw',
+		[db.characterStates, db.facts, db.sessions, db.conversationTurns, db.completedEvents],
+		async () => {
+			if (mode === 'replace') {
+				// Clear all existing data
+				await Promise.all([
+					db.characterStates.clear(),
+					db.facts.clear(),
+					db.sessions.clear(),
+					db.conversationTurns.clear(),
+					db.completedEvents.clear()
+				]);
 			}
-		}
 
-		// Import facts
-		for (const fact of v2File.data.facts) {
-			await db.facts.add(fact);
-			imported++;
-		}
+			if (isV2) {
+				// V2 format - single character
+				const v2File = saveFile as SaveFile;
 
-		// Import sessions
-		for (const session of v2File.data.sessions) {
-			await db.sessions.add(session);
-			imported++;
-		}
+				if (mode === 'replace') {
+					await db.characterStates.add(v2File.data.character);
+					imported++;
+				} else {
+					// Merge mode - skip character if one exists
+					const existing = await db.characterStates.toCollection().first();
+					if (!existing) {
+						await db.characterStates.add(v2File.data.character);
+						imported++;
+					} else {
+						skipped++;
+					}
+				}
 
-		// Import conversation turns
-		for (const turn of v2File.data.conversationTurns) {
-			await db.conversationTurns.add(turn);
-			imported++;
-		}
+				await importCollection(db.facts, v2File.data.facts, factKey);
+				await importCollection(db.sessions, v2File.data.sessions, sessionKey);
+				await importCollection(db.conversationTurns, v2File.data.conversationTurns, turnKey);
+				await importCollection(db.completedEvents, v2File.data.completedEvents, eventKey);
+			} else {
+				// V1 format - migrate to single character
+				const v1File = saveFile as LegacySaveFile;
 
-		// Import completed events
-		for (const event of v2File.data.completedEvents) {
-			await db.completedEvents.add(event);
-			imported++;
-		}
-	} else {
-		// V1 format - migrate to single character
-		const v1File = saveFile as LegacySaveFile;
+				// Take the first character state and first persona, merge them
+				const firstCharState = v1File.data.characterStates?.[0];
+				const firstPersona = v1File.data.personas?.[0];
 
-		// Take the first character state and first persona, merge them
-		const firstCharState = v1File.data.characterStates?.[0];
-		const firstPersona = v1File.data.personas?.[0];
-
-		if (firstCharState || firstPersona) {
-			const existing = await db.characterStates.toCollection().first();
-			if (!existing || mode === 'replace') {
-				// Build merged character state
-				const mergedState = {
+				if (firstCharState || firstPersona) {
+					const existing = await db.characterStates.toCollection().first();
+					if (!existing || mode === 'replace') {
+						// Build merged character state
+						const mergedState = {
 					// Persona fields from persona or defaults
 					name: (firstPersona?.name as string) || 'Utsuwa',
 					systemPrompt:
@@ -213,30 +223,26 @@ export async function importSave(
 			}
 		}
 
-		// Import facts (cast from legacy format)
-		for (const fact of v1File.data.facts) {
-			await db.facts.add(fact as unknown as Fact);
-			imported++;
+				// Import facts/sessions/turns/events (cast from legacy format)
+				await importCollection(db.facts, v1File.data.facts as unknown as Fact[], factKey);
+				await importCollection(
+					db.sessions,
+					v1File.data.sessions as unknown as SessionSummary[],
+					sessionKey
+				);
+				await importCollection(
+					db.conversationTurns,
+					v1File.data.conversationTurns as unknown as ConversationTurn[],
+					turnKey
+				);
+				await importCollection(
+					db.completedEvents,
+					v1File.data.completedEvents as unknown as CompletedEventRecord[],
+					eventKey
+				);
+			}
 		}
-
-		// Import sessions (cast from legacy format)
-		for (const session of v1File.data.sessions) {
-			await db.sessions.add(session as unknown as SessionSummary);
-			imported++;
-		}
-
-		// Import conversation turns (cast from legacy format)
-		for (const turn of v1File.data.conversationTurns) {
-			await db.conversationTurns.add(turn as unknown as ConversationTurn);
-			imported++;
-		}
-
-		// Import completed events (cast from legacy format)
-		for (const event of v1File.data.completedEvents) {
-			await db.completedEvents.add(event as unknown as CompletedEventRecord);
-			imported++;
-		}
-	}
+	);
 
 	// Reload character store to pick up imported data
 	await characterStore.loadState();

--- a/src/lib/db/import-dedup.test.ts
+++ b/src/lib/db/import-dedup.test.ts
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { partitionNewRecords, factKey, sessionKey, turnKey, eventKey } from './import-dedup.ts';
+
+// --- key functions ---
+
+test('factKey distinguishes by category and content', () => {
+	assert.equal(factKey({ category: 'user', content: 'likes tea' }), 'user|likes tea');
+	assert.notEqual(
+		factKey({ category: 'user', content: 'a' }),
+		factKey({ category: 'relationship', content: 'a' })
+	);
+});
+
+test('date-based keys normalize Date objects and ISO strings to the same value', () => {
+	const iso = '2026-07-03T12:00:00.000Z';
+	const date = new Date(iso);
+	assert.equal(sessionKey({ startedAt: iso }), sessionKey({ startedAt: date }));
+	assert.equal(
+		turnKey({ createdAt: iso, role: 'user', content: 'hi' }),
+		turnKey({ createdAt: date, role: 'user', content: 'hi' })
+	);
+	assert.equal(
+		eventKey({ eventId: 'confession_event', completedAt: iso }),
+		eventKey({ eventId: 'confession_event', completedAt: date })
+	);
+});
+
+test('missing dates produce a stable empty key rather than NaN', () => {
+	assert.equal(sessionKey({}), '');
+	assert.equal(turnKey({ role: 'user', content: 'x' }), '|user|x');
+});
+
+// --- partitionNewRecords (the merge dedup) ---
+
+test('with no existing keys, all unique records are added', () => {
+	const recs = [{ content: 'a' }, { content: 'b' }, { content: 'c' }];
+	const { toAdd, skipped } = partitionNewRecords(recs, (r) => r.content, new Set());
+	assert.equal(toAdd.length, 3);
+	assert.equal(skipped, 0);
+});
+
+test('regression: re-importing records already present adds nothing', () => {
+	const recs = [
+		{ category: 'user', content: 'a' },
+		{ category: 'user', content: 'b' }
+	];
+	const existing = new Set(recs.map(factKey));
+	const { toAdd, skipped } = partitionNewRecords(recs, factKey, existing);
+	assert.equal(toAdd.length, 0);
+	assert.equal(skipped, 2);
+});
+
+test('duplicates within the same batch are only added once', () => {
+	const recs = [
+		{ category: 'user', content: 'a' },
+		{ category: 'user', content: 'a' },
+		{ category: 'user', content: 'b' }
+	];
+	const { toAdd, skipped } = partitionNewRecords(recs, factKey, new Set());
+	assert.equal(toAdd.length, 2);
+	assert.equal(skipped, 1);
+});
+
+test('mixed present-and-new: only the new records are added', () => {
+	const recs = [
+		{ category: 'user', content: 'old' },
+		{ category: 'user', content: 'new' }
+	];
+	const existing = new Set([factKey({ category: 'user', content: 'old' })]);
+	const { toAdd, skipped } = partitionNewRecords(recs, factKey, existing);
+	assert.deepEqual(
+		toAdd.map((r) => r.content),
+		['new']
+	);
+	assert.equal(skipped, 1);
+});

--- a/src/lib/db/import-dedup.ts
+++ b/src/lib/db/import-dedup.ts
@@ -1,0 +1,41 @@
+// Dedup helpers for save-file import. Kept dependency-free (no Dexie, no stores)
+// so they can be unit tested. Exported records have their auto-increment ids
+// stripped, so merge-mode re-import must dedup on natural content keys instead.
+
+const asTime = (v: unknown): string => {
+	const t = v == null ? NaN : new Date(v as string | number | Date).getTime();
+	return Number.isNaN(t) ? '' : String(t);
+};
+
+export const factKey = (f: { content?: unknown; category?: unknown }): string =>
+	`${f.category ?? ''}|${f.content ?? ''}`;
+
+export const sessionKey = (s: { startedAt?: unknown }): string => asTime(s.startedAt);
+
+export const turnKey = (t: { createdAt?: unknown; role?: unknown; content?: unknown }): string =>
+	`${asTime(t.createdAt)}|${t.role ?? ''}|${t.content ?? ''}`;
+
+export const eventKey = (e: { eventId?: unknown; completedAt?: unknown }): string =>
+	`${e.eventId ?? ''}|${asTime(e.completedAt)}`;
+
+// Split incoming records into those to insert vs. duplicates to skip. Dedupes
+// against records already present AND within the incoming batch itself.
+export function partitionNewRecords<T>(
+	records: T[],
+	keyOf: (r: T) => string,
+	existingKeys: Set<string>
+): { toAdd: T[]; skipped: number } {
+	const seen = new Set(existingKeys);
+	const toAdd: T[] = [];
+	let skipped = 0;
+	for (const record of records) {
+		const key = keyOf(record);
+		if (seen.has(key)) {
+			skipped++;
+			continue;
+		}
+		seen.add(key);
+		toAdd.push(record);
+	}
+	return { toAdd, skipped };
+}


### PR DESCRIPTION
Two problems with save-file import, both fixed here.

## 1. Replace-mode import wasn't atomic (data loss)

`importSave` in `replace` mode cleared all five tables up front, then added records one at a time with individual `await db.X.add(...)` calls — no transaction. If any add threw partway (corrupt/hand-edited record, quota exceeded), the old data was already gone and only some new data was written, with nothing rolled back.

Fix: wrap the entire import (clears + all adds) in a single `db.transaction('rw', ...)`, so a mid-import failure rolls back to the pre-import state.

## 2. Merge-mode import duplicated everything on re-import

`merge` mode added facts, sessions, turns, and events unconditionally, so importing the same save twice doubled the data (polluting fact retrieval, etc.).

Fix: dedupe on natural content keys (exported records have their ids stripped, so there's no stable id). Facts key on category+content, sessions on startedAt, turns on createdAt+role+content, events on eventId+completedAt. Dates are normalized so a `Date` and its ISO string compare equal. Dedup also applies within a single file. The decision logic is a pure `partitionNewRecords` helper in a dependency-free `import-dedup` module.

## Verification

- `pnpm test` — 93/93 pass (7 new unit tests for the dedup + key functions, including the re-import-is-a-no-op regression)
- `pnpm check` — 0 errors
- Manual, against live IndexedDB via the app's own module: exported the current data, then re-imported it in merge mode twice → `imported: 0, skipped: 18` both times, counts unchanged. A replace-mode round-trip cleared and re-added all 18 records atomically with the counts preserved exactly.
