### PR TITLE
Block SSRF through client-supplied provider base URLs

### DIFF
--- a/src/lib/services/providers/url-guard.test.ts
+++ b/src/lib/services/providers/url-guard.test.ts
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isPrivateHost, assertSafeProviderUrl } from './url-guard.ts';
+
+test('loopback and localhost hosts are private', () => {
+	for (const h of ['localhost', 'foo.localhost', '127.0.0.1', '127.5.5.5', '::1', '0.0.0.0']) {
+		assert.equal(isPrivateHost(h), true, h);
+	}
+});
+
+test('private IPv4 ranges are blocked', () => {
+	for (const h of ['10.0.0.1', '172.16.0.1', '172.31.255.255', '192.168.1.1', '169.254.169.254']) {
+		assert.equal(isPrivateHost(h), true, h);
+	}
+});
+
+test('public-range IPv4 near private blocks is allowed', () => {
+	for (const h of ['172.32.0.1', '192.169.0.1', '11.0.0.1', '8.8.8.8']) {
+		assert.equal(isPrivateHost(h), false, h);
+	}
+});
+
+test('IPv6 link-local and unique-local are blocked; mapped loopback too', () => {
+	assert.equal(isPrivateHost('fe80::1'), true);
+	assert.equal(isPrivateHost('fd00::1'), true);
+	assert.equal(isPrivateHost('[::1]'), true);
+	assert.equal(isPrivateHost('::ffff:127.0.0.1'), true);
+});
+
+test('real provider hosts are allowed', () => {
+	for (const h of ['api.openai.com', 'api.anthropic.com', 'generativelanguage.googleapis.com', 'api.x.ai']) {
+		assert.equal(isPrivateHost(h), false, h);
+	}
+});
+
+test('assertSafeProviderUrl accepts public https provider URLs', () => {
+	const url = assertSafeProviderUrl('https://api.openai.com/v1');
+	assert.equal(url.hostname, 'api.openai.com');
+});
+
+test('assertSafeProviderUrl rejects private hosts and non-http schemes', () => {
+	assert.throws(() => assertSafeProviderUrl('http://169.254.169.254/latest/meta-data/'));
+	assert.throws(() => assertSafeProviderUrl('http://localhost:11434/v1'));
+	assert.throws(() => assertSafeProviderUrl('file:///etc/passwd'));
+	assert.throws(() => assertSafeProviderUrl('not a url'));
+});
+
+test('allowPrivate lets self-hosters reach local models', () => {
+	const url = assertSafeProviderUrl('http://localhost:11434/v1', true);
+	assert.equal(url.hostname, 'localhost');
+});

--- a/src/lib/services/providers/url-guard.ts
+++ b/src/lib/services/providers/url-guard.ts
@@ -1,0 +1,56 @@
+// Server-side SSRF guard for provider requests. The web deployment proxies
+// model-list and chat requests to a client-supplied base URL; without this,
+// anyone could point it at internal addresses (cloud metadata, localhost
+// services, private ranges). The desktop build talks to providers directly and
+// never hits these routes, so this only gates the hosted web path.
+
+// Literal IPv4/IPv6 hosts and hostnames that must not be reachable through the
+// proxy. Covers loopback, private ranges, link-local (incl. 169.254.169.254
+// cloud metadata), and unspecified addresses.
+export function isPrivateHost(hostname: string): boolean {
+	const host = hostname.toLowerCase().replace(/^\[|\]$/g, ''); // strip IPv6 brackets
+
+	if (host === 'localhost' || host.endsWith('.localhost')) return true;
+	if (host === '' || host === '0.0.0.0' || host === '::' || host === '::1') return true;
+
+	// IPv6 loopback/link-local/unique-local
+	if (host.startsWith('fe80:') || host.startsWith('fc') || host.startsWith('fd')) return true;
+	// IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) — fall through to the IPv4 check
+	const mapped = host.startsWith('::ffff:') ? host.slice(7) : host;
+
+	const v4 = mapped.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+	if (v4) {
+		const [a, b] = [Number(v4[1]), Number(v4[2])];
+		if (a === 127) return true; // loopback
+		if (a === 10) return true; // private
+		if (a === 172 && b >= 16 && b <= 31) return true; // private
+		if (a === 192 && b === 168) return true; // private
+		if (a === 169 && b === 254) return true; // link-local + metadata
+		if (a === 0) return true; // "this" network
+	}
+
+	return false;
+}
+
+// Validate a resolved provider base URL before the server fetches it. Returns the
+// parsed URL, or throws if it uses a non-HTTP scheme or targets a private host.
+// Set allowPrivate (self-hosters running local models behind the web server) to
+// permit loopback/private targets.
+export function assertSafeProviderUrl(rawUrl: string, allowPrivate = false): URL {
+	let url: URL;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		throw new Error('Invalid provider URL');
+	}
+
+	if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+		throw new Error('Provider URL must use http or https');
+	}
+
+	if (!allowPrivate && isPrivateHost(url.hostname)) {
+		throw new Error('Provider URL host is not allowed');
+	}
+
+	return url;
+}

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -1,7 +1,9 @@
 import { streamText } from '@xsai/stream-text';
+import { env } from '$env/dynamic/private';
 import type { RequestHandler } from './$types';
 import type { LLMProvider } from '$lib/types';
 import { getChatBaseUrl } from '$lib/services/providers/local-endpoints';
+import { assertSafeProviderUrl } from '$lib/services/providers/url-guard';
 
 // Provider base URLs
 const PROVIDER_BASE_URLS: Partial<Record<LLMProvider, string>> = {
@@ -62,6 +64,16 @@ export const POST: RequestHandler = async ({ request }) => {
 		} else {
 			// Use default base URL for provider
 			providerBaseURL = providerBaseURL || PROVIDER_BASE_URLS[typedProvider];
+		}
+
+		// Block SSRF: the base URL is client-supplied and fetched server-side.
+		try {
+			assertSafeProviderUrl(providerBaseURL, env.ALLOW_LOCAL_PROVIDER_HOSTS === 'true');
+		} catch (e) {
+			return new Response(
+				JSON.stringify({ error: e instanceof Error ? e.message : 'Invalid provider URL' }),
+				{ status: 400, headers: { 'Content-Type': 'application/json' } }
+			);
 		}
 
 		// Add system message (use provided systemPrompt or default)

--- a/src/routes/api/providers/models/+server.ts
+++ b/src/routes/api/providers/models/+server.ts
@@ -1,6 +1,8 @@
+import { env } from '$env/dynamic/private';
 import type { RequestHandler } from './$types';
 import type { LLMProvider } from '$lib/types';
 import { getModelsBaseUrl } from '$lib/services/providers/local-endpoints';
+import { assertSafeProviderUrl } from '$lib/services/providers/url-guard';
 
 interface ModelInfo {
 	id: string;
@@ -202,6 +204,19 @@ export const POST: RequestHandler = async ({ request }) => {
 			providerId === 'ollama' || providerId === 'lmstudio'
 				? getModelsBaseUrl(providerId, effectiveBaseUrl)
 				: effectiveBaseUrl.replace(/\/+$/, '');
+
+		// Block SSRF: the base URL is client-supplied and fetched server-side.
+		try {
+			assertSafeProviderUrl(cleanBaseUrl, env.ALLOW_LOCAL_PROVIDER_HOSTS === 'true');
+		} catch (e) {
+			return Response.json(
+				{
+					models: [],
+					error: e instanceof Error ? e.message : 'Invalid provider URL'
+				} as FetchModelsResponse,
+				{ status: 400 }
+			);
+		}
 
 		let models: ModelInfo[] = [];
 


### PR DESCRIPTION
## The bug

`/api/chat` and `/api/providers/models` both take a `baseURL`/`baseUrl` straight from the request body and `fetch` it server-side. On the hosted web deployment that turns the server into an SSRF vector: anyone can make it request internal addresses — cloud metadata (`http://169.254.169.254/...`), the server's own localhost services, or private ranges — and the failure path echoes the response status back.

## The fix

A small server-side guard (`assertSafeProviderUrl`) validates the resolved base URL before any fetch: it rejects non-http(s) schemes and hosts that are loopback, private (10/8, 172.16/12, 192.168/16), link-local (169.254/16, incl. metadata), or IPv6 equivalents. Both routes return a 400 instead of fetching. Public provider hosts are unaffected.

Local providers (Ollama/LM Studio) legitimately live on localhost, but the client only ever reaches them through the *direct* path (desktop, or `isLocalLLMProvider`), never these server routes — so blocking localhost here costs the app nothing. A self-hosted web deployment that does want to proxy local models can set `ALLOW_LOCAL_PROVIDER_HOSTS=true`.

The desktop build talks to providers directly and never hits these routes at all.

## Verification

- `pnpm test` — 101/101 pass (new `url-guard` unit tests cover private ranges, IPv6, metadata, and the allow-private opt-in)
- `pnpm check` — 0 errors
- Manual against the running dev server:
  - `POST /api/providers/models` with `baseUrl: http://169.254.169.254/...` → **400 "Provider URL host is not allowed"**
  - same with `http://localhost:8080` → **400 blocked**
  - default OpenAI host with a real key → **200, 98 models** (unaffected)
