### PR TITLE
Pin release workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,24 +28,24 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: './src-tauri -> target'
 
@@ -66,7 +66,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build and release
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Signs the updater artifacts so installed apps can verify updates.


### PR DESCRIPTION
The release workflow signs the updater artifacts (`TAURI_SIGNING_PRIVATE_KEY`) and has `contents: write`, but every action was referenced by a mutable tag (`@v0`, `@stable`, `@v4`). If any of those tags were repointed at malicious code, it would run with access to the signing key — a supply-chain compromise of signed auto-updates.

Pin each action to a full commit SHA, with the human-readable version kept in a trailing comment:

- `actions/checkout` → `34e1148…` (v4)
- `pnpm/action-setup` → `b906aff…` (v4)
- `actions/setup-node` → `49933ea…` (v4)
- `dtolnay/rust-toolchain` → `4be7066…` (stable)
- `Swatinem/rust-cache` → `e18b497…` (v2)
- `tauri-apps/tauri-action` → `84b9d35…` (v0)

No workflow logic changed. SHAs were resolved from each action's current tag; YAML validates. This is CI-only and runs on tag push, so there's nothing to exercise at runtime here.
