### PR TITLE
Fix onboarding defaults, stage restore, and truncated-JSON dialogue leak

### DIFF
--- a/src/lib/ai/response-parser.test.ts
+++ b/src/lib/ai/response-parser.test.ts
@@ -177,3 +177,35 @@ test('parses an extraction payload whether fenced or bare', () => {
 	assert.equal(bare.stateUpdates?.moodChange?.emotion, 'happy');
 	assert.equal(bare.stateUpdates?.affectionDelta, 4);
 });
+
+test('a truncated unterminated ```json fence never leaks into dialogue', () => {
+	const raw = [
+		"Hmph. Well, that's... something. A dog, huh? Congratulations, I suppose.",
+		'',
+		'```json',
+		'{',
+		'  "mood_change": { "emotion": "neutral", "intensity_delta": 2 },',
+		'  "affection_delta": -1,'
+		// note: no closing brace, no closing fence (hit max_tokens mid-block)
+	].join('\n');
+	const { dialogue } = parseResponse(raw);
+	assert.ok(!dialogue.includes('```'), 'fence markers must be stripped');
+	assert.ok(!dialogue.toLowerCase().includes('mood_change'), 'raw JSON keys must be stripped');
+	assert.ok(dialogue.startsWith('Hmph. Well'));
+});
+
+test('a truncated bare state block (no fence) never leaks into dialogue', () => {
+	const raw =
+		'Oh, that sounds lovely!\n{ "mood_change": { "emotion": "content", "intensity_delta": 3 }, "affection_delta":';
+	const { dialogue } = parseResponse(raw);
+	assert.ok(!dialogue.includes('mood_change'));
+	assert.ok(!dialogue.includes('{'));
+	assert.equal(dialogue, 'Oh, that sounds lovely!');
+});
+
+test('prose with a stray brace but no state keys is left intact', () => {
+	const raw = 'I was thinking { maybe we could get coffee sometime?';
+	const { dialogue } = parseResponse(raw);
+	assert.ok(dialogue.includes('coffee'));
+	assert.ok(dialogue.includes('{'));
+});

--- a/src/lib/ai/response-parser.ts
+++ b/src/lib/ai/response-parser.ts
@@ -258,6 +258,39 @@ function clampDelta(value: number | undefined, min: number, max: number): number
 }
 
 // Clean up dialogue text
+// State-block markers used to spot a truncated JSON block leaking into dialogue.
+const STATE_BLOCK_START =
+	/\{[^{}]*"(?:mood_change|affection_delta|trust_delta|intimacy_delta|comfort_delta|respect_delta|energy_delta|new_memory)"/i;
+
+// Cut a trailing state block that was never closed (unterminated ```json fence,
+// or a bare `{...` whose braces never balance) — the mark of a response truncated
+// mid-JSON. Balanced blocks and ordinary prose with a stray brace are left alone.
+function stripTruncatedStateBlock(text: string): string {
+	// Unterminated ```json fence: an opener with no matching closing fence.
+	const fence = text.search(/```json/i);
+	if (fence !== -1 && !/```json[\s\S]*?```/i.test(text)) {
+		return text.slice(0, fence).trimEnd();
+	}
+
+	// Bare block: find where a state object starts, then walk braces. If depth
+	// never returns to zero, the block is truncated and everything from it is cut.
+	const match = text.match(STATE_BLOCK_START);
+	if (match?.index !== undefined) {
+		let depth = 0;
+		let balanced = false;
+		for (const ch of text.slice(match.index)) {
+			if (ch === '{') depth++;
+			else if (ch === '}' && --depth === 0) {
+				balanced = true;
+				break;
+			}
+		}
+		if (!balanced) return text.slice(0, match.index).trimEnd();
+	}
+
+	return text;
+}
+
 function cleanDialogue(text: string): string {
 	// Cut runaway output at a leaked stop token and drop stray template tokens.
 	let cleaned = stripControlTokens(text);
@@ -265,7 +298,12 @@ function cleanDialogue(text: string): string {
 	// Cut if the model kept going as the user / a narrator instead of replying.
 	cleaned = cutHallucinatedTurn(cleaned);
 
-	// Remove any leftover JSON-like content
+	// Drop a trailing UNterminated state block first (small models truncated
+	// mid-JSON): it has no closing ``` or `}`, so the closed-object cleaner below
+	// would only fragment it and leave shards in the dialogue.
+	cleaned = stripTruncatedStateBlock(cleaned);
+
+	// Remove any leftover (closed) JSON-like content
 	cleaned = cleaned.replace(/\{[^}]*"(?:mood|delta|emotion)[^}]*\}/gi, '');
 
 	// Remove action asterisks (we want dialogue only)

--- a/src/lib/components/onboarding/OnboardingModal.svelte
+++ b/src/lib/components/onboarding/OnboardingModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { characterStore } from '$lib/stores/character.svelte';
-	import type { AppMode } from '$lib/types/character';
+	import { DEFAULT_SYSTEM_PROMPT, type AppMode } from '$lib/types/character';
 	import { pop, fadeFast } from '$lib/utils/motion';
 
 	import './onboarding.css';
@@ -26,7 +26,7 @@
 
 	// Form state
 	let characterName = $state('Utsuwa');
-	let systemPrompt = $state('You are a helpful, but rage-baity assistant named Utsuwa. You speak like a snarky anime girl.');
+	let systemPrompt = $state(DEFAULT_SYSTEM_PROMPT);
 	let appMode = $state<AppMode>('dating_sim');
 
 	const currentStepIndex = $derived(steps.indexOf(currentStep));
@@ -63,9 +63,11 @@
 	}
 </script>
 
-<div class="modal-overlay" out:fadeFast={{ duration: 200 }} onclick={handleComplete} role="presentation">
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div class="modal-container" out:pop={{ duration: 220, y: 12 }} onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()}>
+<!-- First-run onboarding is not dismissible by backdrop click: an accidental
+     click there used to permanently complete onboarding and skip the persona
+     save. Completion happens only via the final step's button. -->
+<div class="modal-overlay" out:fadeFast={{ duration: 200 }}>
+	<div class="modal-container" out:pop={{ duration: 220, y: 12 }}>
 		<!-- Progress dots (hidden on complete step) -->
 		{#if currentStep !== 'complete'}
 			<div class="progress-dots">

--- a/src/lib/engine/stages.ts
+++ b/src/lib/engine/stages.ts
@@ -1,7 +1,7 @@
 import type { RelationshipStage, CharacterState } from '$lib/types/character';
 
 // Stage order for comparison
-const STAGE_ORDER: RelationshipStage[] = [
+export const STAGE_ORDER: RelationshipStage[] = [
 	'stranger',
 	'acquaintance',
 	'friend',

--- a/src/lib/stores/character.svelte.ts
+++ b/src/lib/stores/character.svelte.ts
@@ -16,7 +16,7 @@ import {
 } from '$lib/services/storage/character';
 import { statChangesStore } from './statChanges.svelte';
 import { resolveTimeDecayOnLoad } from '$lib/engine/state-updates';
-import { calculateStage } from '$lib/engine/stages';
+import { calculateStage, STAGE_ORDER } from '$lib/engine/stages';
 
 // Single character state
 let state = $state<CharacterState>(createDefaultCharacterState() as CharacterState);
@@ -215,12 +215,21 @@ function createCharacterStore() {
 				updatedAt: new Date()
 			};
 		} else {
-			// Restore to dating sim - calculate stage from current stats
+			// Restore to dating sim. Prefer the stage saved when Companion Mode was
+			// entered so time spent there (and any decay during it) can't silently
+			// downgrade a hard-won stage; still allow an upgrade if stats have since
+			// grown past it.
 			const calculatedStage = calculateStage(state, state.completedEvents || []);
+			const saved = state.savedDatingSimStage;
+			const restoredStage =
+				saved && STAGE_ORDER.indexOf(saved) > STAGE_ORDER.indexOf(calculatedStage)
+					? saved
+					: calculatedStage;
 			state = {
 				...state,
 				appMode: mode,
-				relationshipStage: calculatedStage,
+				relationshipStage: restoredStage,
+				savedDatingSimStage: undefined,
 				updatedAt: new Date()
 			};
 		}

--- a/src/lib/types/character.ts
+++ b/src/lib/types/character.ts
@@ -158,7 +158,7 @@ export function createDefaultMood(): MoodState {
 }
 
 // Default system prompt for new characters
-const DEFAULT_SYSTEM_PROMPT =
+export const DEFAULT_SYSTEM_PROMPT =
 	'You are a friendly AI assistant named Utsuwa. You communicate through a VRM avatar and can express emotions through facial expressions and gestures. Be helpful, conversational, and engaging.';
 
 export function createDefaultCharacterState(): Omit<CharacterState, 'id'> {


### PR DESCRIPTION
Four smaller product-level bugs from the audit.

## Onboarding shipped a placeholder personality
The default system prompt was a leftover test string — "a helpful, but rage-baity assistant... snarky anime girl" — which every new user who didn't edit the field would ship with. Now uses the documented `DEFAULT_SYSTEM_PROMPT` (friendly assistant). Verified in the running onboarding flow.

## Clicking the onboarding backdrop permanently dismissed it
The backdrop's `onclick` called `handleComplete()`, which marks onboarding complete for good — and also skipped the persona save that only happens when advancing past the character step. An accidental click outside on step 1 ended onboarding forever. First-run onboarding is no longer dismissible by backdrop; completion happens only via the final step. Verified: clicking outside now keeps the modal open.

## Leaving Companion Mode could silently downgrade the relationship
`savedDatingSimStage` was written when entering Companion Mode but never read — switching back recomputed the stage from current (possibly decayed) stats, so time in Companion Mode could drop a hard-won stage. Now restores the saved stage, taking the higher of saved vs. recomputed so genuine growth still counts.

## Truncated model output leaked raw JSON into the chat bubble
When a response hit max_tokens mid-state-block, the unterminated ```json fence / unbalanced braces matched none of the cleaners, so `` ```json { "mood_change": ... `` showed up in the dialogue (common with small local models). Added a brace-balance-aware strip that removes an unterminated trailing state block while leaving balanced blocks and ordinary prose (a stray `{` in conversation) intact.

## Verification
- `pnpm test` — 104/104 pass (new parser regression tests for truncated fenced + bare blocks, and the "prose with a stray brace stays intact" case)
- `pnpm check` — 0 errors
- Manual: onboarding default prompt and non-dismissible backdrop confirmed in the running app.
