### PR TITLE
Wire up the developer animation dropdown

### DIFF
--- a/src/lib/stores/vrm.svelte.ts
+++ b/src/lib/stores/vrm.svelte.ts
@@ -71,7 +71,18 @@ function createVrmStore() {
 		'/animations/idle_5.vrma'
 	];
 
-	const availableAnimations: { id: string; name: string; url: string }[] = [];
+	// Selectable one-shot emotes (played via the developer tools). These are the
+	// VRMA files shipped in static/animations/ that aren't part of the idle cycle
+	// or the talking loop.
+	const availableAnimations: { id: string; name: string; url: string }[] = [
+		{ id: 'vrma_01', name: 'Emote 1', url: '/animations/VRMA_01.vrma' },
+		{ id: 'vrma_02', name: 'Emote 2', url: '/animations/VRMA_02.vrma' },
+		{ id: 'vrma_03', name: 'Emote 3', url: '/animations/VRMA_03.vrma' },
+		{ id: 'vrma_04', name: 'Emote 4', url: '/animations/VRMA_04.vrma' },
+		{ id: 'vrma_05', name: 'Emote 5', url: '/animations/VRMA_05.vrma' },
+		{ id: 'vrma_06', name: 'Emote 6', url: '/animations/VRMA_06.vrma' },
+		{ id: 'vrma_07', name: 'Emote 7', url: '/animations/VRMA_07.vrma' }
+	];
 
 	// Guard against saveToStorage running before init completes
 	let storageReady = false;

--- a/src/routes/app/settings/developer/+page.svelte
+++ b/src/routes/app/settings/developer/+page.svelte
@@ -282,8 +282,9 @@
 					value={vrmStore.currentAnimation || 'none'}
 					onchange={(e) => vrmStore.setCurrentAnimation(e.currentTarget.value === 'none' ? null : e.currentTarget.value)}
 				>
+					<option value="none">None (idle)</option>
 					{#each vrmStore.availableAnimations as anim}
-						<option value={anim.id}>{anim.name}</option>
+						<option value={anim.url}>{anim.name}</option>
 					{/each}
 				</select>
 			</div>


### PR DESCRIPTION
The developer **Animation** dropdown showed no options at all.

`availableAnimations` in the VRM store was hardcoded to `[]` and never populated, so the dropdown rendered zero options — even though the emote-playing system in `VrmModel.svelte` (load a `.vrma`, play it once, return to idle) was fully built and seven emote files (`VRMA_01.vrma` … `VRMA_07.vrma`) were already shipping in `static/animations/`. The one line connecting the assets to the UI was just never written.

This populates the list with the seven emote clips and adds a **None (idle)** option to stop an emote. The select options now key on the resolved animation URL (matching what `currentAnimation` holds) so the current selection displays correctly.

## Verification
- `pnpm test` — 104/104 pass
- `pnpm check` — 0 errors
- Manual, in the running app: opened Settings → Developer, selected an emote from the dropdown — the avatar loaded and played the emote (pose changed from idle), `createVRMAnimationClip` ran cleanly, and it returned to idle when the one-shot finished (dropdown back to None). The seven previously-orphaned VRMA assets are now used.
