### PR TITLE
Consolidate provider default base URLs into one source of truth

### DIFF
--- a/src/lib/services/chat/client-chat.ts
+++ b/src/lib/services/chat/client-chat.ts
@@ -4,6 +4,7 @@ import {
 	getLocalProviderConnectionHint,
 	isLocalLLMProvider
 } from '$lib/services/providers/local-endpoints';
+import { DEFAULT_CHAT_BASE_URLS } from '$lib/services/providers/provider-defaults';
 import { type MessageContent, toOpenAIContent, toAnthropicContent } from './content';
 
 interface ChatMessage {
@@ -19,17 +20,6 @@ interface ChatOptions {
 	baseURL?: string;
 	systemPrompt: string;
 }
-
-// Provider base URLs (mirrors server route)
-const PROVIDER_BASE_URLS: Partial<Record<LLMProvider, string>> = {
-	openai: 'https://api.openai.com/v1/',
-	anthropic: 'https://api.anthropic.com/v1/',
-	google: 'https://generativelanguage.googleapis.com/v1beta/openai/',
-	deepseek: 'https://api.deepseek.com/',
-	xai: 'https://api.x.ai/v1/',
-	ollama: 'http://localhost:11434/v1/',
-	lmstudio: 'http://localhost:1234/v1/'
-};
 
 function getCurrentSiteOrigin(): string | undefined {
 	return typeof window !== 'undefined' ? window.location.origin : undefined;
@@ -55,7 +45,7 @@ export async function streamChatDirect(
 
 	const providerBaseURL = isLocal
 		? getChatBaseUrl(provider, baseURL)
-		: baseURL || PROVIDER_BASE_URLS[provider];
+		: baseURL || DEFAULT_CHAT_BASE_URLS[provider];
 	if (!providerBaseURL) {
 		onError(`Unknown provider: ${provider}`);
 		return;
@@ -194,7 +184,7 @@ export async function extractStateUpdates(options: ExtractOptions): Promise<stri
 	const isLocal = isLocalLLMProvider(provider);
 	if (!apiKey && !isLocal) return null;
 
-	const base = isLocal ? getChatBaseUrl(provider, baseURL) : baseURL || PROVIDER_BASE_URLS[provider];
+	const base = isLocal ? getChatBaseUrl(provider, baseURL) : baseURL || DEFAULT_CHAT_BASE_URLS[provider];
 	if (!base) return null;
 
 	const trimmedBase = base.replace(/\/+$/, '');

--- a/src/lib/services/providers/client-models.ts
+++ b/src/lib/services/providers/client-models.ts
@@ -4,23 +4,12 @@ import {
 	getModelsBaseUrl,
 	isLocalLLMProvider
 } from './local-endpoints';
+import { DEFAULT_MODELS_BASE_URLS } from './provider-defaults.ts';
 
 interface ModelInfo {
 	id: string;
 	name: string;
 }
-
-const DEFAULT_BASE_URLS: Record<string, string> = {
-	openai: 'https://api.openai.com/v1',
-	anthropic: 'https://api.anthropic.com/v1',
-	ollama: 'http://localhost:11434',
-	lmstudio: 'http://localhost:1234/v1',
-	deepseek: 'https://api.deepseek.com',
-	xai: 'https://api.x.ai/v1',
-	google: 'https://generativelanguage.googleapis.com/v1beta',
-	elevenlabs: 'https://api.elevenlabs.io/v1',
-	'openai-tts': 'https://api.openai.com/v1'
-};
 
 const MODEL_FILTERS: Record<string, RegExp> = {
 	openai: /^(gpt-|o1-|o3-|chatgpt-4o-)/,
@@ -64,7 +53,7 @@ export async function fetchModelsDirect(
 	const cleanBaseUrl =
 		providerId === 'ollama' || providerId === 'lmstudio'
 			? getModelsBaseUrl(providerId, baseUrl)
-			: (baseUrl || DEFAULT_BASE_URLS[providerId] || '').replace(/\/+$/, '');
+			: (baseUrl || DEFAULT_MODELS_BASE_URLS[providerId] || '').replace(/\/+$/, '');
 
 	try {
 		let models: ModelInfo[] = [];

--- a/src/lib/services/providers/local-endpoints.ts
+++ b/src/lib/services/providers/local-endpoints.ts
@@ -1,11 +1,7 @@
+import { DEFAULT_LOCAL_BASE_URLS as DEFAULT_BASE_URLS } from './provider-defaults.ts';
+
 const LOCAL_LLM_PROVIDERS = new Set(['ollama', 'lmstudio']);
 const LOCAL_TTS_PROVIDERS = new Set(['local-tts']);
-
-const DEFAULT_BASE_URLS: Record<string, string> = {
-	ollama: 'http://localhost:11434',
-	lmstudio: 'http://localhost:1234/v1',
-	'local-tts': 'http://localhost:8880/v1'
-};
 
 const OLLAMA_ORIGINS_DOC_URL =
 	'https://docs.ollama.com/faq#how-can-i-allow-additional-web-origins-to-access-ollama';

--- a/src/lib/services/providers/provider-defaults.ts
+++ b/src/lib/services/providers/provider-defaults.ts
@@ -1,0 +1,43 @@
+// Single source of truth for provider default base URLs. Previously these were
+// duplicated across the chat client, the chat server route, the models client,
+// the models server route, the local-endpoint helpers, and the registry — and a
+// drift between any two recreated the old Ollama base-URL bug class.
+//
+// Chat and model-listing endpoints legitimately differ for some providers:
+// Google uses an OpenAI-compatible path for chat (/v1beta/openai/) but its native
+// path for listing models (/v1beta), and local servers need per-provider
+// normalization (see local-endpoints.ts). So both sets are expressed here rather
+// than collapsed into one.
+
+// Base URL used for chat/streaming. Cloud providers only — local providers route
+// through getChatBaseUrl(), which normalizes DEFAULT_LOCAL_BASE_URLS.
+export const DEFAULT_CHAT_BASE_URLS: Record<string, string> = {
+	openai: 'https://api.openai.com/v1/',
+	anthropic: 'https://api.anthropic.com/v1/',
+	google: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+	deepseek: 'https://api.deepseek.com/',
+	xai: 'https://api.x.ai/v1/',
+	ollama: 'http://localhost:11434',
+	lmstudio: 'http://localhost:1234/v1/'
+};
+
+// Base URL used for listing models. Includes the TTS providers that expose a
+// model list. Local providers route through getModelsBaseUrl().
+export const DEFAULT_MODELS_BASE_URLS: Record<string, string> = {
+	openai: 'https://api.openai.com/v1',
+	anthropic: 'https://api.anthropic.com/v1',
+	google: 'https://generativelanguage.googleapis.com/v1beta',
+	deepseek: 'https://api.deepseek.com',
+	xai: 'https://api.x.ai/v1',
+	ollama: 'http://localhost:11434',
+	lmstudio: 'http://localhost:1234/v1',
+	elevenlabs: 'https://api.elevenlabs.io/v1',
+	'openai-tts': 'https://api.openai.com/v1'
+};
+
+// Base URLs for self-hosted/local providers, before per-provider normalization.
+export const DEFAULT_LOCAL_BASE_URLS: Record<string, string> = {
+	ollama: 'http://localhost:11434',
+	lmstudio: 'http://localhost:1234/v1',
+	'local-tts': 'http://localhost:8880/v1'
+};

--- a/src/lib/services/providers/registry.ts
+++ b/src/lib/services/providers/registry.ts
@@ -1,4 +1,5 @@
 // Provider Registry - All LLM and TTS providers
+import { DEFAULT_CHAT_BASE_URLS } from './provider-defaults.ts';
 
 export interface ProviderMetadata {
 	id: string;
@@ -32,7 +33,7 @@ export const LLM_PROVIDERS: ProviderMetadata[] = [
 		icon: '🤖',
 		requiresApiKey: true,
 		supportsVision: true,
-		defaultBaseUrl: 'https://api.openai.com/v1/'
+		defaultBaseUrl: DEFAULT_CHAT_BASE_URLS.openai
 	},
 	{
 		id: 'anthropic',
@@ -42,7 +43,7 @@ export const LLM_PROVIDERS: ProviderMetadata[] = [
 		icon: '🧠',
 		requiresApiKey: true,
 		supportsVision: true,
-		defaultBaseUrl: 'https://api.anthropic.com/v1/'
+		defaultBaseUrl: DEFAULT_CHAT_BASE_URLS.anthropic
 	},
 	{
 		id: 'google',
@@ -53,7 +54,7 @@ export const LLM_PROVIDERS: ProviderMetadata[] = [
 		iconColor: '#4285F4',
 		requiresApiKey: true,
 		supportsVision: true,
-		defaultBaseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai/'
+		defaultBaseUrl: DEFAULT_CHAT_BASE_URLS.google
 	},
 	{
 		id: 'deepseek',
@@ -62,7 +63,7 @@ export const LLM_PROVIDERS: ProviderMetadata[] = [
 		category: 'llm',
 		icon: '🔍',
 		requiresApiKey: true,
-		defaultBaseUrl: 'https://api.deepseek.com/'
+		defaultBaseUrl: DEFAULT_CHAT_BASE_URLS.deepseek
 	},
 	{
 		id: 'xai',
@@ -72,7 +73,7 @@ export const LLM_PROVIDERS: ProviderMetadata[] = [
 		icon: '𝕏',
 		requiresApiKey: true,
 		supportsVision: true,
-		defaultBaseUrl: 'https://api.x.ai/v1/'
+		defaultBaseUrl: DEFAULT_CHAT_BASE_URLS.xai
 	},
 	// Local LLMs discover installed models from the user's running local server.
 	{
@@ -83,7 +84,7 @@ export const LLM_PROVIDERS: ProviderMetadata[] = [
 		icon: '🦙',
 		requiresApiKey: false,
 		isLocal: true,
-		defaultBaseUrl: 'http://localhost:11434',
+		defaultBaseUrl: DEFAULT_CHAT_BASE_URLS.ollama,
 		models: []
 	},
 	{
@@ -94,7 +95,7 @@ export const LLM_PROVIDERS: ProviderMetadata[] = [
 		icon: '🖥️',
 		requiresApiKey: false,
 		isLocal: true,
-		defaultBaseUrl: 'http://localhost:1234/v1/',
+		defaultBaseUrl: DEFAULT_CHAT_BASE_URLS.lmstudio,
 		models: []
 	},
 ];

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -4,19 +4,7 @@ import type { RequestHandler } from './$types';
 import type { LLMProvider } from '$lib/types';
 import { getChatBaseUrl } from '$lib/services/providers/local-endpoints';
 import { assertSafeProviderUrl } from '$lib/services/providers/url-guard';
-
-// Provider base URLs
-const PROVIDER_BASE_URLS: Partial<Record<LLMProvider, string>> = {
-	// Cloud
-	openai: 'https://api.openai.com/v1/',
-	anthropic: 'https://api.anthropic.com/v1/',
-	google: 'https://generativelanguage.googleapis.com/v1beta/openai/',
-	deepseek: 'https://api.deepseek.com/',
-	xai: 'https://api.x.ai/v1/',
-	// Local
-	ollama: 'http://localhost:11434/v1/',
-	lmstudio: 'http://localhost:1234/v1/',
-};
+import { DEFAULT_CHAT_BASE_URLS } from '$lib/services/providers/provider-defaults';
 
 // Providers that don't require API keys
 const LOCAL_PROVIDERS: LLMProvider[] = ['ollama', 'lmstudio'];
@@ -57,13 +45,13 @@ export const POST: RequestHandler = async ({ request }) => {
 
 		// Handle special provider configurations
 		if (typedProvider === 'anthropic') {
-			providerBaseURL = providerBaseURL || PROVIDER_BASE_URLS.anthropic;
+			providerBaseURL = providerBaseURL || DEFAULT_CHAT_BASE_URLS.anthropic;
 			headers['anthropic-dangerous-direct-browser-access'] = 'true';
 		} else if (isLocalProvider) {
 			providerBaseURL = getChatBaseUrl(typedProvider, providerBaseURL);
 		} else {
 			// Use default base URL for provider
-			providerBaseURL = providerBaseURL || PROVIDER_BASE_URLS[typedProvider];
+			providerBaseURL = providerBaseURL || DEFAULT_CHAT_BASE_URLS[typedProvider];
 		}
 
 		// Block SSRF: the base URL is client-supplied and fetched server-side.

--- a/src/routes/api/providers/models/+server.ts
+++ b/src/routes/api/providers/models/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import type { LLMProvider } from '$lib/types';
 import { getModelsBaseUrl } from '$lib/services/providers/local-endpoints';
 import { assertSafeProviderUrl } from '$lib/services/providers/url-guard';
+import { DEFAULT_MODELS_BASE_URLS } from '$lib/services/providers/provider-defaults';
 
 interface ModelInfo {
 	id: string;
@@ -14,20 +15,6 @@ interface FetchModelsResponse {
 	error?: string;
 }
 
-// Default base URLs per provider (LLM and TTS)
-const DEFAULT_BASE_URLS: Record<string, string> = {
-	// LLM providers
-	openai: 'https://api.openai.com/v1',
-	anthropic: 'https://api.anthropic.com/v1',
-	ollama: 'http://localhost:11434',
-	lmstudio: 'http://localhost:1234/v1',
-	deepseek: 'https://api.deepseek.com',
-	xai: 'https://api.x.ai/v1',
-	google: 'https://generativelanguage.googleapis.com/v1beta',
-	// TTS providers
-	elevenlabs: 'https://api.elevenlabs.io/v1',
-	'openai-tts': 'https://api.openai.com/v1'
-};
 
 // Model filter patterns - only keep chat-compatible models
 // Note: Google IDs have 'models/' prefix stripped before filtering
@@ -197,7 +184,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		}
 
 		const effectiveBaseUrl =
-			baseUrl || DEFAULT_BASE_URLS[providerId as LLMProvider] || '';
+			baseUrl || DEFAULT_MODELS_BASE_URLS[providerId as LLMProvider] || '';
 
 		// Remove trailing slash for consistency
 		const cleanBaseUrl =


### PR DESCRIPTION
Provider default base URLs were duplicated across **six** places — the chat client, the chat server route, the models client, the models server route, the local-endpoint helpers, and the registry. A drift between any two of them recreated the old Ollama base-URL bug class (e.g. one table gets `/v1` appended, another doesn't).

This moves them into one `provider-defaults.ts` module and points every consumer at it. Rather than collapsing to a single map, it keeps the three sets that legitimately differ:

- **`DEFAULT_CHAT_BASE_URLS`** — chat/streaming endpoints (Google uses its OpenAI-compat path `/v1beta/openai/` here)
- **`DEFAULT_MODELS_BASE_URLS`** — model-listing endpoints (Google uses its native path `/v1beta`; also includes the TTS providers that expose a model list)
- **`DEFAULT_LOCAL_BASE_URLS`** — local providers, before per-provider normalization in `local-endpoints.ts`

Values are unchanged from what each consumer used before, so this is behavior-preserving. The registry's LLM `defaultBaseUrl` fields now reference the chat map too, so the display/fallback value can't drift from the resolution value.

## Verification
- `pnpm test` — 104/104 pass (existing registry + local-endpoint tests exercise the resolution paths)
- `pnpm check` — 0 errors; `pnpm build` — succeeds
- Manual against the running app:
  - Cloud model fetch via the server route (OpenAI) → 98 models
  - Local model fetch via the direct path (Ollama) → its 3 installed models
  - A live chat turn (OpenAI, server route) completed normally
