### PR TITLE
Share one companion-turn pipeline between app and overlay

### DIFF
--- a/src/lib/services/chat/companion-turn.ts
+++ b/src/lib/services/chat/companion-turn.ts
@@ -1,0 +1,152 @@
+import { characterStore } from '$lib/stores/character.svelte';
+import { parseResponse, validateStateUpdates, extractPotentialFacts } from '$lib/ai/response-parser';
+import { buildExtractionSystemPrompt } from '$lib/ai/prompt-builder';
+import { calculateBaselineUpdates, analyzeMessage } from '$lib/engine/heuristics';
+import { mergeUpdates, checkAndApplyStageTransition } from '$lib/engine/state-updates';
+import {
+	recordTurn,
+	memoryApi,
+	determineFactCategory,
+	calculateFactImportance
+} from '$lib/engine/memory';
+import { checkAllEvents, eventsApi } from '$lib/engine/events';
+import { allEvents } from '$lib/data/events';
+import { extractStateUpdates } from './client-chat';
+import type { LLMProvider } from '$lib/types';
+import type { EventDefinition } from '$lib/types/events';
+
+export interface CompanionTurnInput {
+	userMessage: string;
+	companionResponse: string;
+	llm: {
+		provider: string;
+		model: string;
+		apiKey?: string;
+		baseURL?: string;
+		hasImages: boolean;
+	};
+	// DEV-only console logging of the raw/parsed model output.
+	debug?: boolean;
+}
+
+export interface CompanionTurnResult {
+	// Cleaned dialogue to display/speak.
+	dialogue: string;
+	// Memory the model produced this turn, if any (the app attaches it to kept photos).
+	newMemory?: string;
+	// An event that should be shown after this turn, if one triggered.
+	triggeredEvent: EventDefinition | null;
+}
+
+// Runs the full companion turn: parse the model output (with a forced-JSON
+// extraction fallback for models that skip the inline state block), apply state
+// and mood updates, persist the exchange and any extracted facts, run a stage
+// transition, and check for triggered events. Shared by the main app and the
+// overlay so their pipelines can't drift (the overlay previously lacked the
+// extraction fallback). Page-specific side effects — showing the event modal,
+// keeping photos — stay in the pages via the return value.
+export async function processCompanionTurn(input: CompanionTurnInput): Promise<CompanionTurnResult> {
+	const { userMessage, companionResponse, llm, debug = false } = input;
+
+	const state = characterStore.state;
+	const baselineUpdates = calculateBaselineUpdates(userMessage, state);
+
+	const parsed = parseResponse(companionResponse);
+	const dialogue = parsed.dialogue;
+	let llmUpdates = parsed.stateUpdates;
+
+	if (debug) {
+		console.log('%c[LLM raw response]', 'color:#00b2ff;font-weight:bold', companionResponse);
+		console.log('%c[LLM parsed]', 'color:#22c55e;font-weight:bold', {
+			stateUpdates: llmUpdates,
+			new_memory: llmUpdates?.newMemory ?? null
+		});
+	}
+
+	// Decoupled fallback: the model skipped the inline JSON, so ask a dedicated
+	// forced-JSON call to extract mood + memory from the exchange.
+	if (!llmUpdates) {
+		const extracted = await extractStateUpdates({
+			provider: llm.provider as LLMProvider,
+			model: llm.model,
+			apiKey: llm.apiKey,
+			baseURL: llm.baseURL,
+			system: buildExtractionSystemPrompt(llm.hasImages),
+			userMessage,
+			reply: dialogue
+		});
+		if (extracted) {
+			// parseResponse handles both bare JSON (OpenAI json_object) and a
+			// model-added ```json fence (Anthropic). Don't re-wrap.
+			llmUpdates = parseResponse(extracted).stateUpdates;
+			if (debug) {
+				console.log('%c[extraction fallback]', 'color:#f59e0b;font-weight:bold', extracted, '->', llmUpdates);
+			}
+		}
+	}
+
+	let validatedLLMUpdates = null;
+	if (llmUpdates) {
+		validatedLLMUpdates = validateStateUpdates(llmUpdates).sanitized;
+	}
+
+	const finalUpdates = mergeUpdates(baselineUpdates, validatedLLMUpdates || {});
+	characterStore.applyUpdates(finalUpdates);
+
+	// Save the model's memory observation
+	if (finalUpdates.newMemory) {
+		try {
+			await memoryApi.createFact({
+				content: finalUpdates.newMemory,
+				category: determineFactCategory(finalUpdates.newMemory),
+				importance: calculateFactImportance(finalUpdates.newMemory)
+			});
+		} catch (e) {
+			console.debug('[Memory] Failed to save LLM observation:', e);
+		}
+	}
+
+	// Stage transitions (Dating Sim Mode only)
+	if (characterStore.appMode === 'dating_sim') {
+		const completedEventIds = characterStore.state.completedEvents || [];
+		const transition = checkAndApplyStageTransition(characterStore.state, completedEventIds);
+		if (transition.transitioned && transition.toStage) {
+			characterStore.setRelationshipStage(transition.toStage);
+		}
+	}
+
+	// Persist the exchange (and mirror into working memory) so it survives reloads
+	await recordTurn({ role: 'user', content: userMessage });
+	await recordTurn({ role: 'assistant', content: dialogue });
+
+	// Extract and persist facts from the exchange
+	const potentialFacts = extractPotentialFacts(dialogue, userMessage);
+	for (const factContent of potentialFacts.slice(0, 2)) {
+		try {
+			const userAnalysis = analyzeMessage(userMessage);
+			await memoryApi.createFact({
+				content: factContent,
+				category: determineFactCategory(factContent),
+				importance: calculateFactImportance(factContent, userAnalysis.sentiment)
+			});
+		} catch (e) {
+			console.debug('Failed to save fact:', e);
+		}
+	}
+
+	// Check for triggered events (Dating Sim Mode only)
+	let triggeredEvent: EventDefinition | null = null;
+	if (characterStore.appMode === 'dating_sim') {
+		try {
+			const completedEvents = await eventsApi.getCompletedEvents();
+			const triggeredEvents = checkAllEvents(allEvents, characterStore.state, completedEvents, userMessage);
+			if (triggeredEvents.length > 0) {
+				triggeredEvent = triggeredEvents[0];
+			}
+		} catch (e) {
+			console.debug('Event check failed:', e);
+		}
+	}
+
+	return { dialogue, newMemory: finalUpdates.newMemory || undefined, triggeredEvent };
+}

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -20,7 +20,8 @@
 	import { getLLMProvider, getTTSProvider, providerSupportsVision } from '$lib/services/providers/registry';
 	import { isLocalLLMProvider } from '$lib/services/providers/local-endpoints';
 	import { canShowImages } from '$lib/services/providers/vision';
-	import { streamChatDirect, extractStateUpdates } from '$lib/services/chat/client-chat';
+	import { streamChatDirect } from '$lib/services/chat/client-chat';
+	import { processCompanionTurn } from '$lib/services/chat/companion-turn';
 	import { keepImage, type PreparedImage } from '$lib/services/storage/keepsakes';
 	import { type ContentPart, toOpenAIContent } from '$lib/services/chat/content';
 	import { isTauri } from '$lib/services/platform';
@@ -31,24 +32,16 @@
 	import { pop, fadeFast } from '$lib/utils/motion';
 
 	// V2 companion system imports
-	import { buildSystemPrompt, buildExtractionSystemPrompt, type PromptContext } from '$lib/ai/prompt-builder';
-	import { parseResponse, validateStateUpdates, extractPotentialFacts } from '$lib/ai/response-parser';
-	import { calculateBaselineUpdates, analyzeMessage } from '$lib/engine/heuristics';
-	import { mergeUpdates, checkAndApplyStageTransition } from '$lib/engine/state-updates';
+	import { buildSystemPrompt, type PromptContext } from '$lib/ai/prompt-builder';
 	import {
 		retrieveRelevantContext,
-		recordTurn,
 		hydrateWorkingMemory,
-		memoryApi,
-		determineFactCategory,
-		calculateFactImportance,
 		backfillEmbeddings,
 		getEmbeddingBackfillStatus
 	} from '$lib/engine/memory';
 	import { initEmbeddingModel } from '$lib/services/embeddings';
-	import { checkAllEvents, eventsApi } from '$lib/engine/events';
+	import { eventsApi } from '$lib/engine/events';
 	import { completionMarkers } from '$lib/engine/event-completion';
-	import { allEvents } from '$lib/data/events';
 
 	let canvasRef: HTMLCanvasElement | null = null;
 
@@ -135,117 +128,6 @@
 		}
 	});
 
-	// Process companion response with v2 system
-	async function processCompanionResponse(
-		userMessage: string,
-		companionResponse: string,
-		llm: { provider: string; model: string; apiKey?: string; baseURL?: string; hasImages: boolean }
-	): Promise<string> {
-		const state = characterStore.state;
-
-		const baselineUpdates = calculateBaselineUpdates(userMessage, state);
-
-		const parsed = parseResponse(companionResponse);
-		const dialogue = parsed.dialogue;
-		let llmUpdates = parsed.stateUpdates;
-
-		if (import.meta.env.DEV) {
-			console.log('%c[LLM raw response]', 'color:#00b2ff;font-weight:bold', companionResponse);
-			console.log('%c[LLM parsed]', 'color:#22c55e;font-weight:bold', {
-				stateUpdates: llmUpdates,
-				new_memory: llmUpdates?.newMemory ?? null
-			});
-		}
-
-		// Decoupled fallback: the model skipped the inline JSON, so ask a dedicated
-		// forced-JSON call to extract mood + memory from the exchange.
-		if (!llmUpdates) {
-			const extracted = await extractStateUpdates({
-				provider: llm.provider as import('$lib/types').LLMProvider,
-				model: llm.model,
-				apiKey: llm.apiKey,
-				baseURL: llm.baseURL,
-				system: buildExtractionSystemPrompt(llm.hasImages),
-				userMessage,
-				reply: dialogue
-			});
-			if (extracted) {
-				// parseResponse handles both bare JSON (OpenAI json_object) and a
-				// model-added ```json fence (Anthropic). Don't re-wrap — double
-				// fencing makes the non-greedy fence regex capture an empty block.
-				llmUpdates = parseResponse(extracted).stateUpdates;
-				if (import.meta.env.DEV) {
-					console.log('%c[extraction fallback]', 'color:#f59e0b;font-weight:bold', extracted, '->', llmUpdates);
-				}
-			}
-		}
-
-		let validatedLLMUpdates = null;
-		if (llmUpdates) {
-			const validation = validateStateUpdates(llmUpdates);
-			validatedLLMUpdates = validation.sanitized;
-		}
-
-		const finalUpdates = mergeUpdates(baselineUpdates, validatedLLMUpdates || {});
-		characterStore.applyUpdates(finalUpdates);
-		lastNewMemory = finalUpdates.newMemory || undefined;
-
-		// Save LLM memory observation
-		if (finalUpdates.newMemory) {
-			try {
-				await memoryApi.createFact({
-					content: finalUpdates.newMemory,
-					category: determineFactCategory(finalUpdates.newMemory),
-					importance: calculateFactImportance(finalUpdates.newMemory)
-				});
-			} catch (e) {
-				console.debug('[Memory] Failed to save LLM observation:', e);
-			}
-		}
-
-		// Check stage transitions (only in Dating Sim Mode)
-		if (characterStore.appMode === 'dating_sim') {
-			const completedEventIds = characterStore.state.completedEvents || [];
-			const transition = checkAndApplyStageTransition(characterStore.state, completedEventIds);
-			if (transition.transitioned && transition.toStage) {
-				characterStore.setRelationshipStage(transition.toStage);
-			}
-		}
-
-		// Persist the exchange (and mirror into working memory) so it survives reloads
-		await recordTurn({ role: 'user', content: userMessage });
-		await recordTurn({ role: 'assistant', content: dialogue });
-
-		// Extract facts
-		const potentialFacts = extractPotentialFacts(dialogue, userMessage);
-		for (const factContent of potentialFacts.slice(0, 2)) {
-			try {
-				const userAnalysis = analyzeMessage(userMessage);
-				await memoryApi.createFact({
-					content: factContent,
-					category: determineFactCategory(factContent),
-					importance: calculateFactImportance(factContent, userAnalysis.sentiment)
-				});
-			} catch (e) {
-				console.debug('Failed to save fact:', e);
-			}
-		}
-
-		// Check for events (only in Dating Sim Mode)
-		if (characterStore.appMode === 'dating_sim') {
-			try {
-				const completedEvents = await eventsApi.getCompletedEvents();
-				const triggeredEvents = checkAllEvents(allEvents, characterStore.state, completedEvents, userMessage);
-				if (triggeredEvents.length > 0) {
-					activeEvent = triggeredEvents[0];
-				}
-			} catch (e) {
-				console.debug('Event check failed:', e);
-			}
-		}
-
-		return dialogue;
-	}
 
 	// Build system prompt
 	async function buildCompanionSystemPrompt(userMessage: string, hasImages = false): Promise<string> {
@@ -402,13 +284,21 @@
 			}
 
 			isTyping = false;
-			const cleanedResponse = await processCompanionResponse(content, fullContent, {
-				provider,
-				model: selectedModel,
-				apiKey: apiKey || undefined,
-				baseURL: providerConfig.baseUrl || providerMeta?.defaultBaseUrl,
-				hasImages: images.length > 0
+			const turn = await processCompanionTurn({
+				userMessage: content,
+				companionResponse: fullContent,
+				llm: {
+					provider,
+					model: selectedModel,
+					apiKey: apiKey || undefined,
+					baseURL: providerConfig.baseUrl || providerMeta?.defaultBaseUrl,
+					hasImages: images.length > 0
+				},
+				debug: import.meta.env.DEV
 			});
+			const cleanedResponse = turn.dialogue;
+			lastNewMemory = turn.newMemory;
+			if (turn.triggeredEvent) activeEvent = turn.triggeredEvent;
 
 			// She's seen it and responded; keep the shown images as local keepsakes
 			if (images.length > 0) {

--- a/src/routes/overlay/+page.svelte
+++ b/src/routes/overlay/+page.svelte
@@ -22,24 +22,17 @@
 	import { isTauri, startDragging } from '$lib/services/platform';
 	import { getLLMProvider, getTTSProvider } from '$lib/services/providers/registry';
 	import { streamChatDirect } from '$lib/services/chat/client-chat';
-	import { allEvents } from '$lib/data/events';
-	import { checkAllEvents, eventsApi } from '$lib/engine/events';
+	import { processCompanionTurn } from '$lib/services/chat/companion-turn';
+	import { eventsApi } from '$lib/engine/events';
 	import { completionMarkers } from '$lib/engine/event-completion';
 	import type { TTSProvider } from '$lib/types';
 	import type { EventDefinition } from '$lib/types/events';
 	import type { StateUpdates } from '$lib/types/character';
 
 	import { buildSystemPrompt, type PromptContext } from '$lib/ai/prompt-builder';
-	import { parseResponse, validateStateUpdates, extractPotentialFacts } from '$lib/ai/response-parser';
-	import { calculateBaselineUpdates, analyzeMessage } from '$lib/engine/heuristics';
-	import { mergeUpdates, checkAndApplyStageTransition } from '$lib/engine/state-updates';
 	import {
 		retrieveRelevantContext,
-		recordTurn,
 		hydrateWorkingMemory,
-		memoryApi,
-		determineFactCategory,
-		calculateFactImportance,
 		backfillEmbeddings,
 		getEmbeddingBackfillStatus
 	} from '$lib/engine/memory';
@@ -117,75 +110,6 @@
 		}
 	}
 
-	async function processCompanionResponse(userMessage: string, companionResponse: string): Promise<string> {
-		const state = characterStore.state;
-		const baselineUpdates = calculateBaselineUpdates(userMessage, state);
-		const parsed = parseResponse(companionResponse);
-		const dialogue = parsed.dialogue;
-		const llmUpdates = parsed.stateUpdates;
-
-		let validatedLLMUpdates = null;
-		if (llmUpdates) {
-			const validation = validateStateUpdates(llmUpdates);
-			validatedLLMUpdates = validation.sanitized;
-		}
-
-		const finalUpdates = mergeUpdates(baselineUpdates, validatedLLMUpdates || {});
-		characterStore.applyUpdates(finalUpdates);
-
-		if (finalUpdates.newMemory) {
-			try {
-				await memoryApi.createFact({
-					content: finalUpdates.newMemory,
-					category: determineFactCategory(finalUpdates.newMemory),
-					importance: calculateFactImportance(finalUpdates.newMemory)
-				});
-			} catch (e) {
-				console.debug('[Memory] Failed to save LLM observation:', e);
-			}
-		}
-
-		if (characterStore.appMode === 'dating_sim') {
-			const completedEventIds = characterStore.state.completedEvents || [];
-			const transition = checkAndApplyStageTransition(characterStore.state, completedEventIds);
-			if (transition.transitioned && transition.toStage) {
-				characterStore.setRelationshipStage(transition.toStage);
-			}
-		}
-
-		// Persist the exchange (and mirror into working memory) so it survives reloads
-		await recordTurn({ role: 'user', content: userMessage });
-		await recordTurn({ role: 'assistant', content: dialogue });
-
-		const potentialFacts = extractPotentialFacts(dialogue, userMessage);
-		for (const factContent of potentialFacts.slice(0, 2)) {
-			try {
-				const userAnalysis = analyzeMessage(userMessage);
-				await memoryApi.createFact({
-					content: factContent,
-					category: determineFactCategory(factContent),
-					importance: calculateFactImportance(factContent, userAnalysis.sentiment)
-				});
-			} catch (e) {
-				console.debug('Failed to save fact:', e);
-			}
-		}
-
-		// Check for events (dating sim mode only)
-		if (characterStore.appMode === 'dating_sim') {
-			try {
-				const completedEvents = await eventsApi.getCompletedEvents();
-				const triggeredEvents = checkAllEvents(allEvents, characterStore.state, completedEvents, userMessage);
-				if (triggeredEvents.length > 0) {
-					activeEvent = triggeredEvents[0];
-				}
-			} catch (e) {
-				console.debug('Event check failed:', e);
-			}
-		}
-
-		return dialogue;
-	}
 
 	async function buildCompanionSystemPrompt(userMessage: string): Promise<string> {
 		const state = characterStore.state;
@@ -314,7 +238,20 @@
 			}
 
 			isTyping = false;
-			const cleanedResponse = await processCompanionResponse(content, fullContent);
+			const turn = await processCompanionTurn({
+				userMessage: content,
+				companionResponse: fullContent,
+				llm: {
+					provider,
+					model: selectedModel,
+					apiKey: apiKey || undefined,
+					baseURL: providerConfig.baseUrl || providerMeta?.defaultBaseUrl,
+					hasImages: false
+				},
+				debug: import.meta.env.DEV
+			});
+			const cleanedResponse = turn.dialogue;
+			if (turn.triggeredEvent) activeEvent = turn.triggeredEvent;
 			chatStore.updateLastMessage(cleanedResponse);
 			latestResponse = cleanedResponse;
 


### PR DESCRIPTION
The main app and the overlay each carried a near-duplicate `processCompanionResponse`. Beyond the maintenance cost, they had drifted: the **overlay copy was missing the forced-JSON extraction fallback**, so a weak model that skips the inline state block silently lost its mood/memory updates in overlay mode (this is where the earlier local-TTS-style drift bugs come from).

This extracts the entire turn into one `processCompanionTurn` service — parse the model output, run the extraction fallback when there's no inline JSON, apply state/mood updates, persist the exchange and extracted facts, run a stage transition, and check for triggered events. Both pages now call it. It returns the cleaned dialogue, the new memory, and any triggered event, so the page-specific side effects (showing the event modal, keeping shown photos) stay in the pages. The overlay gets the extraction fallback for free.

Also removes the imports that each page no longer needs now that the logic moved.

## Verification
- `pnpm test` — 104/104 pass
- `pnpm check` — 0 errors; `pnpm build` — succeeds
- Manual against the running app:
  - **App** chat turn (OpenAI): runs through `companion-turn.ts` (logs now originate there), response rendered, and the extraction fallback fired on a response that omitted inline JSON.
  - **Overlay** chat turn: runs through the same `companion-turn.ts` module — confirming the overlay now uses the identical pipeline (with the fallback it previously lacked). Response rendered normally.
