### PR TITLE
Add local/self-hosted speech-to-text support

### DIFF
--- a/src/lib/services/providers/local-endpoints.test.ts
+++ b/src/lib/services/providers/local-endpoints.test.ts
@@ -8,8 +8,37 @@ import {
 	getLocalProviderConnectionHint,
 	isLocalTTSProvider,
 	getTTSBaseUrl,
-	getLocalTTSConnectionHint
+	getLocalTTSConnectionHint,
+	isLocalSTTProvider,
+	getSTTBaseUrl,
+	getLocalSTTConnectionHint
 } from './local-endpoints.ts';
+
+test('identifies local STT providers', () => {
+	assert.equal(isLocalSTTProvider('local-stt'), true);
+	assert.equal(isLocalSTTProvider('groq-stt'), false);
+});
+
+test('local STT base URL is normalized to end in /v1', () => {
+	assert.equal(getSTTBaseUrl('local-stt', 'http://localhost:8000'), 'http://localhost:8000/v1');
+	assert.equal(getSTTBaseUrl('local-stt', 'http://localhost:8000/'), 'http://localhost:8000/v1');
+	assert.equal(getSTTBaseUrl('local-stt', 'http://localhost:8000/v1'), 'http://localhost:8000/v1');
+	// Falls back to the default when no base URL is given
+	assert.equal(getSTTBaseUrl('local-stt'), 'http://localhost:8000/v1');
+});
+
+test('cloud STT base URL is only trimmed, not path-normalized', () => {
+	assert.equal(
+		getSTTBaseUrl('groq-stt', 'https://api.groq.com/openai/v1/'),
+		'https://api.groq.com/openai/v1'
+	);
+});
+
+test('local STT connection hint names the endpoint and origin', () => {
+	const hint = getLocalSTTConnectionHint('http://localhost:8000/v1', 'https://utsuwa.ai');
+	assert.match(hint, /audio\/transcriptions/);
+	assert.match(hint, /utsuwa\.ai/);
+});
 
 test('identifies local LLM providers', () => {
 	assert.equal(isLocalLLMProvider('ollama'), true);

--- a/src/lib/services/providers/local-endpoints.ts
+++ b/src/lib/services/providers/local-endpoints.ts
@@ -2,6 +2,7 @@ import { DEFAULT_LOCAL_BASE_URLS as DEFAULT_BASE_URLS } from './provider-default
 
 const LOCAL_LLM_PROVIDERS = new Set(['ollama', 'lmstudio']);
 const LOCAL_TTS_PROVIDERS = new Set(['local-tts']);
+const LOCAL_STT_PROVIDERS = new Set(['local-stt']);
 
 const OLLAMA_ORIGINS_DOC_URL =
 	'https://docs.ollama.com/faq#how-can-i-allow-additional-web-origins-to-access-ollama';
@@ -25,6 +26,26 @@ export function isLocalLLMProvider(providerId: string): boolean {
 
 export function isLocalTTSProvider(providerId: string): boolean {
 	return LOCAL_TTS_PROVIDERS.has(providerId);
+}
+
+export function isLocalSTTProvider(providerId: string): boolean {
+	return LOCAL_STT_PROVIDERS.has(providerId);
+}
+
+// OpenAI-compatible STT clients POST to "{base}/audio/transcriptions", so the
+// base must end with "/v1". Local Whisper servers (Speaches, faster-whisper-
+// server, whisper.cpp) mount there; users routinely paste the bare host.
+export function getSTTBaseUrl(providerId: string, baseUrl?: string): string {
+	const cleanUrl = trimTrailingSlashes(baseUrl || DEFAULT_BASE_URLS[providerId] || '');
+	return isLocalSTTProvider(providerId) ? ensureOpenAIPath(cleanUrl) : cleanUrl;
+}
+
+export function getLocalSTTConnectionHint(baseUrl?: string, siteOrigin?: string): string {
+	const sttBaseUrl = getSTTBaseUrl('local-stt', baseUrl);
+	const originHint = siteOrigin
+		? ` If the server blocks this site (${siteOrigin}), enable CORS for that origin.`
+		: ' If the server blocks this site, enable CORS for the app origin.';
+	return `Could not reach a local STT server at ${sttBaseUrl}. Make sure it is running and exposes the OpenAI /v1/audio/transcriptions endpoint (e.g. Speaches, faster-whisper-server, or whisper.cpp).${originHint}`;
 }
 
 // OpenAI-compatible TTS clients append "audio/speech" to the base URL, so the

--- a/src/lib/services/providers/provider-defaults.ts
+++ b/src/lib/services/providers/provider-defaults.ts
@@ -39,5 +39,6 @@ export const DEFAULT_MODELS_BASE_URLS: Record<string, string> = {
 export const DEFAULT_LOCAL_BASE_URLS: Record<string, string> = {
 	ollama: 'http://localhost:11434',
 	lmstudio: 'http://localhost:1234/v1',
-	'local-tts': 'http://localhost:8880/v1'
+	'local-tts': 'http://localhost:8880/v1',
+	'local-stt': 'http://localhost:8000/v1'
 };

--- a/src/lib/services/providers/registry.ts
+++ b/src/lib/services/providers/registry.ts
@@ -194,6 +194,21 @@ export const STT_PROVIDERS: ProviderMetadata[] = [
 		icon: '🎤',
 		requiresApiKey: true,
 		defaultBaseUrl: 'https://api.groq.com/openai/v1/'
+	},
+	{
+		id: 'local-stt',
+		name: 'Local STT',
+		description: 'Run Whisper locally (Speaches, faster-whisper-server, whisper.cpp)',
+		category: 'stt',
+		icon: '🏠',
+		requiresApiKey: false,
+		isLocal: true,
+		defaultBaseUrl: 'http://localhost:8000/v1/',
+		models: [
+			{ id: 'Systran/faster-whisper-large-v3', name: 'faster-whisper large-v3' },
+			{ id: 'Systran/faster-whisper-medium', name: 'faster-whisper medium' },
+			{ id: 'whisper-1', name: 'whisper-1 (OpenAI-named)' }
+		]
 	}
 ];
 
@@ -204,6 +219,10 @@ export function getLLMProvider(id: string): ProviderMetadata | undefined {
 
 export function getTTSProvider(id: string): ProviderMetadata | undefined {
 	return TTS_PROVIDERS.find((p) => p.id === id);
+}
+
+export function getSTTProvider(id: string): ProviderMetadata | undefined {
+	return STT_PROVIDERS.find((p) => p.id === id);
 }
 
 /** Whether an LLM provider's models are broadly vision-capable (cloud providers). */

--- a/src/lib/services/stt/openai-stt.test.ts
+++ b/src/lib/services/stt/openai-stt.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildTranscriptionRequest, type OpenAiSttConfig } from './openai-stt.ts';
+
+function formToObject(form: FormData): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const [k, v] of form.entries()) out[k] = v;
+	return out;
+}
+
+const audio = new Blob(['fake-audio'], { type: 'audio/webm' });
+
+test('posts to {base}/audio/transcriptions with the model and file', () => {
+	const config: OpenAiSttConfig = {
+		baseUrl: 'https://api.groq.com/openai/v1',
+		model: 'whisper-large-v3-turbo',
+		apiKey: 'gsk_test',
+		label: 'Groq'
+	};
+	const req = buildTranscriptionRequest(config, audio, 'recording.webm');
+	assert.equal(req.url, 'https://api.groq.com/openai/v1/audio/transcriptions');
+	const fields = formToObject(req.body);
+	assert.equal(fields.model, 'whisper-large-v3-turbo');
+	assert.ok(fields.file, 'file part present');
+	assert.equal(req.headers.Authorization, 'Bearer gsk_test');
+});
+
+test('trailing slashes on the base URL are trimmed', () => {
+	const req = buildTranscriptionRequest(
+		{ baseUrl: 'http://localhost:8000/v1///', model: 'whisper-1', label: 'the local STT server' },
+		audio,
+		'recording.m4a'
+	);
+	assert.equal(req.url, 'http://localhost:8000/v1/audio/transcriptions');
+});
+
+test('no Authorization header is sent when there is no API key (local servers)', () => {
+	const req = buildTranscriptionRequest(
+		{ baseUrl: 'http://localhost:8000/v1', model: 'Systran/faster-whisper-large-v3', label: 'the local STT server' },
+		audio,
+		'recording.m4a'
+	);
+	assert.equal(req.headers.Authorization, undefined);
+	assert.equal(Object.keys(req.headers).length, 0);
+	assert.equal(formToObject(req.body).model, 'Systran/faster-whisper-large-v3');
+});

--- a/src/lib/services/stt/openai-stt.ts
+++ b/src/lib/services/stt/openai-stt.ts
@@ -1,7 +1,45 @@
 import type { SpeechRecognitionCallbacks } from './web-speech';
 
-class GroqSttService {
-	private apiKey: string | null = null;
+export interface OpenAiSttConfig {
+	// Base URL ending in /v1 (or a full custom URL). Trailing slashes are trimmed.
+	baseUrl: string;
+	model: string;
+	// Omitted for local servers that don't require auth.
+	apiKey?: string;
+	// Shown in error messages, e.g. "Groq" or "the local STT server".
+	label: string;
+	// Optional richer message for a network failure (CORS/unreachable hints).
+	connectionHint?: string;
+}
+
+// The transcription request shape, split out so it can be unit tested without a
+// browser (MediaRecorder/getUserMedia). OpenAI-compatible servers — OpenAI,
+// Groq, Speaches, faster-whisper-server, whisper.cpp — all accept this.
+export function buildTranscriptionRequest(
+	config: OpenAiSttConfig,
+	audio: Blob,
+	filename: string
+): { url: string; headers: Record<string, string>; body: FormData } {
+	const base = config.baseUrl.replace(/\/+$/, '');
+	const form = new FormData();
+	form.append('file', audio, filename);
+	form.append('model', config.model);
+
+	const headers: Record<string, string> = {};
+	// Local servers usually need no key; only send auth when one is set.
+	if (config.apiKey) {
+		headers.Authorization = `Bearer ${config.apiKey}`;
+	}
+
+	return { url: `${base}/audio/transcriptions`, headers, body: form };
+}
+
+// Records mic audio and transcribes it via any OpenAI-compatible
+// /v1/audio/transcriptions endpoint. Groq and local servers (Speaches,
+// faster-whisper-server, whisper.cpp) share this exact client — only the base
+// URL, model, and whether an API key is sent differ.
+class OpenAiSttService {
+	private config: OpenAiSttConfig | null = null;
 	private mediaRecorder: MediaRecorder | null = null;
 	private audioChunks: Blob[] = [];
 	private stream: MediaStream | null = null;
@@ -13,8 +51,8 @@ class GroqSttService {
 	private listening = false;
 	private transcribing = false;
 
-	setApiKey(key: string) {
-		this.apiKey = key;
+	configure(config: OpenAiSttConfig) {
+		this.config = config;
 	}
 
 	isSupported(): boolean {
@@ -22,7 +60,7 @@ class GroqSttService {
 	}
 
 	isConfigured(): boolean {
-		return !!this.apiKey;
+		return !!this.config?.baseUrl && !!this.config?.model;
 	}
 
 	getIsListening(): boolean {
@@ -35,8 +73,8 @@ class GroqSttService {
 
 	async startListening(callbacks: SpeechRecognitionCallbacks): Promise<boolean> {
 		if (this.listening) return true;
-		if (!this.apiKey) {
-			callbacks.onError('Groq API key not configured. Go to Settings > Persona to add it.');
+		if (!this.config) {
+			callbacks.onError('Speech-to-text is not configured. Set it up in Settings > Persona.');
 			return false;
 		}
 
@@ -86,7 +124,7 @@ class GroqSttService {
 			this.mediaRecorder = mimeType
 				? new MediaRecorder(this.stream, { mimeType })
 				: new MediaRecorder(this.stream);
-		} catch (err) {
+		} catch {
 			callbacks.onError('Audio recording not supported on this platform');
 			this.releaseStream();
 			return false;
@@ -135,7 +173,6 @@ class GroqSttService {
 		const tick = () => {
 			if (!this.analyser || !this.listening) return;
 			this.analyser.getByteFrequencyData(dataArray);
-			// Average amplitude normalized to 0-1
 			let sum = 0;
 			for (let i = 0; i < dataArray.length; i++) sum += dataArray[i];
 			const level = sum / (dataArray.length * 255);
@@ -151,7 +188,7 @@ class GroqSttService {
 		this.releaseStream();
 
 		// abort() was called — don't transcribe or fire callbacks
-		if (!this.callbacks) return;
+		if (!this.callbacks || !this.config) return;
 
 		if (this.audioChunks.length === 0) {
 			this.callbacks?.onEnd();
@@ -169,14 +206,16 @@ class GroqSttService {
 		const timeoutId = setTimeout(() => this.abortController?.abort(), 30000);
 
 		try {
-			const formData = new FormData();
-			formData.append('file', audioBlob, `recording.${ext}`);
-			formData.append('model', 'whisper-large-v3-turbo');
+			const { url, headers, body } = buildTranscriptionRequest(
+				this.config,
+				audioBlob,
+				`recording.${ext}`
+			);
 
-			const response = await fetch('https://api.groq.com/openai/v1/audio/transcriptions', {
+			const response = await fetch(url, {
 				method: 'POST',
-				headers: { Authorization: `Bearer ${this.apiKey}` },
-				body: formData,
+				headers,
+				body,
 				signal: this.abortController.signal
 			});
 
@@ -184,7 +223,9 @@ class GroqSttService {
 
 			if (!response.ok) {
 				const errorData = await response.json().catch(() => ({}));
-				const msg = (errorData as { error?: { message?: string } })?.error?.message || `Groq API error (${response.status})`;
+				const msg =
+					(errorData as { error?: { message?: string } })?.error?.message ||
+					`${this.config.label} error (${response.status})`;
 				this.callbacks?.onError(msg);
 				this.transcribing = false;
 				return;
@@ -206,7 +247,11 @@ class GroqSttService {
 				this.callbacks?.onEnd();
 				return;
 			}
-			const msg = err instanceof Error ? err.message : 'Failed to transcribe audio';
+			// A thrown fetch means the server was unreachable/blocked (vs. an HTTP
+			// error, handled above), so prefer the connection hint when we have one.
+			const msg =
+				this.config.connectionHint ||
+				(err instanceof Error ? err.message : `Failed to reach ${this.config.label}`);
 			this.callbacks?.onError(msg);
 		} finally {
 			this.abortController = null;
@@ -243,4 +288,6 @@ class GroqSttService {
 	}
 }
 
-export const groqSttService = new GroqSttService();
+// A single shared recorder. The store configures it for whichever OpenAI-compatible
+// STT provider (Groq or a local server) is active before each session.
+export const openAiSttService = new OpenAiSttService();

--- a/src/lib/stores/stt.svelte.ts
+++ b/src/lib/stores/stt.svelte.ts
@@ -1,6 +1,8 @@
 import { browser } from '$app/environment';
 import { webSpeechService } from '$lib/services/stt/web-speech';
-import { groqSttService } from '$lib/services/stt/groq-stt';
+import { openAiSttService } from '$lib/services/stt/openai-stt';
+import { getSTTBaseUrl, getLocalSTTConnectionHint } from '$lib/services/providers/local-endpoints';
+import { getSTTProvider } from '$lib/services/providers/registry';
 import { isTauri } from '$lib/services/platform/platform';
 import { settingsStore } from '$lib/stores/settings.svelte';
 
@@ -13,8 +15,37 @@ function createSttStore() {
 	let audioLevel = $state(0);
 	let errorTimeout: ReturnType<typeof setTimeout> | null = null;
 
-	// Use Groq if API key is configured (works on any platform), otherwise Web Speech
-	const useGroq = $derived(browser && !!settingsStore.getProviderConfig('groq-stt').apiKey);
+	// Which OpenAI-compatible STT provider to use, if any. A configured local
+	// server wins over Groq (mirrors how a Groq key wins over Web Speech), and
+	// both fall back to the browser's Web Speech API when neither is set up.
+	const activeOpenAiStt = $derived.by<string | null>(() => {
+		if (!browser) return null;
+		if (settingsStore.isProviderAdded('local-stt')) return 'local-stt';
+		if (settingsStore.getProviderConfig('groq-stt').apiKey) return 'groq-stt';
+		return null;
+	});
+	const useOpenAiStt = $derived(activeOpenAiStt !== null);
+
+	// Point the shared recorder at the active provider's endpoint before a session.
+	function configureOpenAiStt(providerId: string) {
+		const config = settingsStore.getProviderConfig(providerId);
+		const meta = getSTTProvider(providerId);
+		const baseUrl = getSTTBaseUrl(providerId, config.baseUrl || meta?.defaultBaseUrl);
+		const model =
+			config.modelId ||
+			meta?.models?.[0]?.id ||
+			(providerId === 'groq-stt' ? 'whisper-large-v3-turbo' : 'whisper-1');
+		const isLocal = providerId === 'local-stt';
+		openAiSttService.configure({
+			baseUrl,
+			model,
+			apiKey: config.apiKey || undefined,
+			label: isLocal ? 'the local STT server' : 'Groq',
+			connectionHint: isLocal
+				? getLocalSTTConnectionHint(baseUrl, browser ? window.location.origin : undefined)
+				: undefined
+		});
+	}
 
 	async function startListening(onComplete: (text: string) => void) {
 		if (!browser) return;
@@ -25,14 +56,11 @@ function createSttStore() {
 		interimTranscript = '';
 		audioLevel = 0.2;
 
-		if (useGroq) {
-			// Feed the latest API key to the service
-			const config = settingsStore.getProviderConfig('groq-stt');
-			if (config.apiKey) {
-				groqSttService.setApiKey(config.apiKey);
-			}
+		if (useOpenAiStt && activeOpenAiStt) {
+			// Point the recorder at the active provider (local server or Groq)
+			configureOpenAiStt(activeOpenAiStt);
 
-			const started = await groqSttService.startListening({
+			const started = await openAiSttService.startListening({
 				onResult: (text, isFinal) => {
 					if (isFinal) {
 						transcript = transcript ? transcript + ' ' + text : text;
@@ -108,18 +136,18 @@ function createSttStore() {
 	}
 
 	function stopListening() {
-		if (useGroq) {
-			// Groq: stop recording → triggers async transcription
+		if (useOpenAiStt) {
+			// Recorded audio is transcribed on stop
 			isTranscribing = true;
-			groqSttService.stopListening();
+			openAiSttService.stopListening();
 		} else {
 			webSpeechService.stopListening();
 		}
 	}
 
 	function cancel() {
-		if (useGroq) {
-			groqSttService.abort();
+		if (useOpenAiStt) {
+			openAiSttService.abort();
 		} else {
 			webSpeechService.abort();
 		}
@@ -132,9 +160,8 @@ function createSttStore() {
 
 	function isSupported() {
 		if (!browser) return false;
-		// Groq works if API key is configured and mic access available
-		const groqReady = groqSttService.isSupported() && !!settingsStore.getProviderConfig('groq-stt').apiKey;
-		if (groqReady) return true;
+		// A local or Groq server works on any platform if a mic is available
+		if (useOpenAiStt && openAiSttService.isSupported()) return true;
 		// Web Speech only works in browsers (not Tauri's webview)
 		if (!isTauri() && webSpeechService.isSupported()) return true;
 		return false;
@@ -142,9 +169,9 @@ function createSttStore() {
 
 	function showUnsupportedError() {
 		if (isTauri()) {
-			setError('Add your Groq API key in Settings → Persona for voice input on desktop.');
+			setError('Add a Groq key or a local STT server in Settings → Persona for voice input on desktop.');
 		} else {
-			setError('Voice input is not supported in this browser. Add a Groq API key in Settings → Persona, or try Chrome/Edge.');
+			setError('Voice input is not supported in this browser. Add a Groq key or a local STT server in Settings → Persona, or try Chrome/Edge.');
 		}
 	}
 

--- a/src/routes/app/settings/persona/+page.svelte
+++ b/src/routes/app/settings/persona/+page.svelte
@@ -698,7 +698,9 @@
 								<Icon name="mic" size={14} />
 								<span>Voice Input (STT)</span>
 							</div>
-							<p class="stt-hint">Higher quality voice input via Groq's Whisper API. Required on desktop, optional in browser (falls back to Web Speech API).</p>
+							<p class="stt-hint">Higher quality voice input via Whisper. A local server is used if configured, otherwise Groq, otherwise the browser's built-in recognition. Required on desktop (which has no built-in recognition).</p>
+
+							<span class="stt-sublabel">Groq API Key</span>
 							<div class="api-key-row">
 								<input
 									type="password"
@@ -708,6 +710,33 @@
 									oninput={(e) => {
 										settingsStore.setProviderConfig('groq-stt', { apiKey: e.currentTarget.value });
 										settingsStore.markProviderAdded('groq-stt');
+									}}
+								/>
+							</div>
+
+							<span class="stt-sublabel">Local server (Speaches, faster-whisper-server, whisper.cpp)</span>
+							<div class="api-key-row">
+								<input
+									type="text"
+									class="api-key-input"
+									placeholder="http://localhost:8000/v1/"
+									value={settingsStore.getProviderConfig('local-stt').baseUrl ?? ''}
+									oninput={(e) => {
+										const v = e.currentTarget.value.trim();
+										settingsStore.setProviderConfig('local-stt', { baseUrl: v });
+										if (v) settingsStore.markProviderAdded('local-stt');
+										else settingsStore.removeProvider('local-stt');
+									}}
+								/>
+							</div>
+							<div class="api-key-row">
+								<input
+									type="text"
+									class="api-key-input"
+									placeholder="Model (e.g. Systran/faster-whisper-large-v3)"
+									value={settingsStore.getProviderConfig('local-stt').modelId ?? ''}
+									oninput={(e) => {
+										settingsStore.setProviderConfig('local-stt', { modelId: e.currentTarget.value.trim() });
 									}}
 								/>
 							</div>
@@ -1908,6 +1937,14 @@
 		color: var(--text-tertiary);
 		margin: 0;
 		line-height: 1.4;
+	}
+
+	.stt-sublabel {
+		display: block;
+		font-size: 0.7rem;
+		font-weight: 600;
+		color: var(--text-secondary);
+		margin-top: 0.25rem;
 	}
 
 	.service-header {


### PR DESCRIPTION
Voice input previously supported only Groq's cloud Whisper or the browser's Web Speech API — there was no way to run speech-to-text locally. This adds a local/self-hosted STT provider, mirroring how local-TTS reuses the OpenAI-compatible client.

The Groq recorder was already an OpenAI-compatible `/v1/audio/transcriptions` client with a hardcoded URL/model/auth. It's now generalized into a configurable `openai-stt.ts` service that both Groq and local Whisper servers (Speaches, faster-whisper-server, whisper.cpp) share — only the base URL, model, and whether an API key is sent differ.

**What's included**
- `openai-stt.ts` — configurable recorder + a pure `buildTranscriptionRequest` helper (unit tested).
- `local-stt` provider in the registry (localhost:8000, no key, model presets) and `DEFAULT_LOCAL_BASE_URLS`.
- `getSTTBaseUrl` / `isLocalSTTProvider` / `getLocalSTTConnectionHint` in local-endpoints (base-URL normalization + a CORS/unreachable hint).
- STT store selection: a configured local server wins, then Groq, then Web Speech (mirrors how a Groq key already wins over Web Speech).
- Settings UI: a Groq key field plus a local server base-URL and model field, with a clear priority hint.

**Verification**
- `pnpm test` — 111/111 pass (new tests for the transcription request shape and the local base-URL normalization)
- `pnpm check` — 0 errors, 0 warnings; `pnpm build` — succeeds
- Manual against the running app:
  - The Voice Input (STT) settings section renders the Groq key, local base-URL, and model fields.
  - Drove a full STT session at the service level with the media APIs and `fetch` stubbed: configuring a local server (`http://localhost:8000`) normalized the base to `/v1`, POSTed to `http://localhost:8000/v1/audio/transcriptions` with **no Authorization header** and the configured model, and the returned transcript flowed back through `onResult`. (True mic-driven transcription can't be automated here — same limitation as the existing Groq STT.)
