### PR TITLE
Refresh docs for local STT and add a Local STT Setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@
 - **Model-Centric UI**: Full-screen 3D model with unobtrusive overlay controls
 - **3D Speech Bubbles**: Chat responses appear as bubbles that track the model's head in 3D space
 - **Chat Interface**: Bottom-centered input bar with streaming responses
-- **Voice Input**: Speech-to-text via Groq (Whisper) or Web Speech API with real-time audio visualization
+- **Voice Input**: Speech-to-text via a local Whisper server (Speaches, faster-whisper-server, whisper.cpp), Groq (Whisper), or the browser's Web Speech API, with real-time audio visualization
 - **Show Her Photos**: Show your companion an image via the camera button or drag-and-drop. Vision-capable models (GPT-4o, Claude, Gemini, or local ones like LLaVA) actually see it and can remember the moment, and kept photos live on a scrapbook-style board. Images stay on your device and only ever reach vision-capable models
 - **LLM Integration**: Support for 7 LLM providers including OpenAI, Anthropic, Google, xAI, DeepSeek, Ollama, and LM Studio
 - **Local Model Discovery**: Ollama and LM Studio discover installed local models directly from your device
 - **Text-to-Speech**: Support for ElevenLabs and OpenAI TTS, plus local voices via any OpenAI-compatible server (Kokoro-FastAPI, openedai-speech)
+- **Fully Local Option**: Run the whole stack offline — local LLM (Ollama/LM Studio), local TTS, and local Whisper STT — so nothing leaves your device
 - **Lip-sync**: Audio-driven mouth animation synced to TTS playback
 - **Animations**: VRMA-based idle and talking animations with automatic blinking
 - **Character Customization**: Customize your companion's name, personality, and system prompt
@@ -122,14 +123,15 @@ The desktop app uses the same codebase as the web version, and your save files a
 | **Cloud** | ElevenLabs, OpenAI TTS |
 | **Local** | Local TTS (Kokoro-FastAPI, openedai-speech, any OpenAI-compatible server) |
 
-### STT Providers (2)
+### STT Providers (3)
 
 | Category | Providers |
 |----------|-----------|
+| **Local** | Local STT (Speaches, faster-whisper-server, whisper.cpp, any OpenAI-compatible `/v1/audio/transcriptions` server) |
 | **Cloud** | Groq (Whisper) |
 | **Browser** | Web Speech API (no API key required) |
 
-Voice input is accessed via the microphone button in the chat bar. Groq STT uses Whisper for accurate transcription on any platform (including desktop). Web Speech API works without an API key in Chrome, Edge, and Safari. If a Groq API key is configured, it takes priority automatically.
+Voice input is accessed via the microphone button in the chat bar. Selection is automatic by priority: a configured local Whisper server wins, then Groq, then the browser's Web Speech API. A local server or Groq works on any platform including desktop; Web Speech API works without an API key in Chrome, Edge, and Safari. See [Local STT Setup](https://docs.utsuwa.ai/docs/guides/local-stt-setup) to run a local Whisper server.
 
 ## Getting Started
 
@@ -284,7 +286,7 @@ pnpm tauri build  # Build desktop app installer
 - [x] Time-based mood and relationship decay/recovery
 - [x] Local-first IndexedDB storage with export/import
 - [x] Theme system with light/dark modes
-- [x] Voice input via Groq STT (Whisper) and Web Speech API
+- [x] Voice input via local Whisper server, Groq STT (Whisper), and Web Speech API
 - [x] Desktop application with transparent overlay mode (macOS, Windows, and Linux)
 - [x] Cross-platform desktop builds via CI (macOS, Windows, Linux)
 - [x] In-app auto-updates for the desktop app
@@ -293,7 +295,7 @@ pnpm tauri build  # Build desktop app installer
 
 - [ ] **File, Image, and Video Uploads** - Add support for attaching files, images, and videos for multimodal LLM workflows and providers that can use richer context or web-aware tools
 - [ ] **OpenAI-Compatible Models** - Add a configurable option for OpenAI-compatible model endpoints beyond the currently listed providers
-- [ ] **Multi-provider STT** - Support for additional speech-to-text providers beyond Groq and Web Speech API
+- [ ] **More STT providers** - Additional dedicated speech-to-text integrations beyond local Whisper, Groq, and Web Speech API
 - [ ] **Live2D Support** - Alternative to VRM for 2D animated avatars
 
 ## Contributing

--- a/src/content/docs/guides/desktop-guide.md
+++ b/src/content/docs/guides/desktop-guide.md
@@ -155,7 +155,7 @@ The camera is locked in overlay mode. If the character appears rotated, exit ove
 
 ### Voice input not working
 
-The desktop app uses Tauri's webview, which does not support the browser's Web Speech API. You need a Groq API key for voice input on desktop. Add it in **Settings > Character** under the Voice Input (STT) section.
+The desktop app uses Tauri's webview, which does not support the browser's Web Speech API. For voice input on desktop, configure either a local Whisper server or a Groq API key in **Settings > Character** under the Voice Input (STT) section.
 
 ### Can't interact with overlay UI
 

--- a/src/content/docs/guides/local-stt-setup.md
+++ b/src/content/docs/guides/local-stt-setup.md
@@ -1,0 +1,84 @@
+---
+title: Local STT Setup
+description: Run speech-to-text entirely on your machine with an OpenAI-compatible Whisper server (Speaches, faster-whisper-server, whisper.cpp).
+---
+
+# Local STT Setup
+
+If you already run local LLMs with Ollama or LM Studio and a local voice with Local TTS, you can transcribe your voice locally too. The audio is processed on your machine, so nothing leaves the device and there are no API keys or per-minute costs.
+
+Utsuwa talks to any server that exposes the OpenAI `/v1/audio/transcriptions` endpoint. It records from your microphone, sends the clip to that endpoint, and uses the returned text as your message.
+
+## Speaches (recommended)
+
+[Speaches](https://github.com/speaches-ai/speaches) (formerly faster-whisper-server) serves Whisper transcription through the OpenAI API and runs well on CPU.
+
+### Installation
+
+The quickest path is Docker:
+
+```bash
+docker run -p 8000:8000 ghcr.io/speaches-ai/speaches:latest-cpu
+```
+
+If you have an NVIDIA GPU, use the CUDA image instead. See the project README for non-Docker installs.
+
+This serves the API at `http://localhost:8000/v1`.
+
+### Connecting to Utsuwa
+
+1. Open **Settings** (gear icon)
+2. Navigate to the **Character** tab
+3. Open **AI Services** and scroll to **Voice Input (STT)**
+4. Under **Local server**, enter the base URL — leave it as `http://localhost:8000/v1/` unless you changed the port
+5. Set the **Model** field to a model your server exposes (e.g. `Systran/faster-whisper-large-v3`)
+6. Click the microphone button in the chat bar and speak
+
+A configured local server takes priority over Groq and the browser's Web Speech API automatically — there's no separate toggle.
+
+### Models
+
+Speaches uses Hugging Face model IDs such as `Systran/faster-whisper-large-v3` (best quality) or `Systran/faster-whisper-medium` (faster). The server downloads the model on first use. Check the models your server has with `curl http://localhost:8000/v1/models`.
+
+## faster-whisper-server and whisper.cpp
+
+Any OpenAI-compatible transcription server works. [whisper.cpp](https://github.com/ggerganov/whisper.cpp) ships a server (`whisper-server`) that exposes the same endpoint — point Utsuwa's Local STT base URL at it and use the model name it serves. Older [faster-whisper-server](https://github.com/fedirz/faster-whisper-server) installs behave like Speaches.
+
+## Custom Base URL
+
+Running the server on a different machine or port? Enter the full URL in the Local STT base URL field. Utsuwa normalizes it to end in `/v1`, so `http://localhost:8000`, `http://localhost:8000/v1`, and `http://localhost:8000/v1/` all work. Examples:
+
+- Custom port: `http://localhost:9000/v1/`
+- Remote machine: `http://192.168.1.50:8000/v1/` (desktop app only, see below)
+
+## Desktop app vs hosted website
+
+Local STT works best in the **desktop app**, where it needs no extra setup. The desktop app talks to your local server directly, with no browser origin, mixed-content, or local-network restrictions.
+
+On the **hosted website** (`https://www.utsuwa.ai`) it can still work, but because a public HTTPS page is reaching a server on your own machine, the browser adds a few rules:
+
+- **Same machine only.** The server has to be on `localhost` / `127.0.0.1`. A server on another machine over plain `http://` is blocked by the browser as mixed content. (`localhost` is exempt, which is the only reason the local case works.) The remote-machine base URL above therefore works in the desktop app but not on the hosted site.
+- **The server must allow the site's origin.** Your STT server needs to send CORS headers permitting `https://www.utsuwa.ai`. A hardened or proxied server may need the origin added explicitly.
+- **Your browser may ask permission.** Recent versions of Chrome treat a public site reaching `localhost` as a local-network request and may prompt you to allow it. Allow it if asked.
+
+None of this applies to the desktop app. It's the same set of rules local LLMs and Local TTS follow on the hosted site.
+
+## Troubleshooting
+
+### "Could not reach a local STT server"
+
+The server isn't running or isn't reachable at the base URL. Confirm it's up:
+
+```bash
+curl http://localhost:8000/v1/models
+```
+
+If that returns data but Utsuwa still can't reach it from a browser, it's almost certainly an origin or local-network block. On the hosted site the server has to allow the `https://www.utsuwa.ai` origin, and your browser may prompt to allow access to local-network devices. See [Desktop app vs hosted website](#desktop-app-vs-hosted-website). None of this applies to the **desktop app**, which is the smoothest way to run local STT.
+
+### 400 or 404 from the server
+
+The model name isn't valid for that server. Check the available models with `curl http://localhost:8000/v1/models` and set the Model field to one of them.
+
+### No transcription after speaking
+
+Make sure your microphone is allowed for the site (browser permission prompt), and that the Model field is set. Watch the microphone button — it shows a transcribing state after you stop speaking while the server processes the clip.

--- a/src/content/docs/guides/troubleshooting.md
+++ b/src/content/docs/guides/troubleshooting.md
@@ -144,10 +144,10 @@ See [Local TTS Setup](/docs/guides/local-tts-setup#desktop-app-vs-hosted-website
 
 ### Mic button not responding (desktop)
 
-The desktop app uses Tauri's webview, which does not support the browser's Web Speech API. You need to configure Groq Whisper for voice input on desktop:
+The desktop app uses Tauri's webview, which does not support the browser's Web Speech API. Configure a local Whisper server or Groq for voice input on desktop:
 
 1. Go to **Settings > Character**
-2. Under **Voice Input (STT)**, enter your Groq API key
+2. Under **Voice Input (STT)**, either point Local STT at your Whisper server's base URL (default `http://localhost:8000/v1/`) or enter your Groq API key
 
 ### Mic button not responding (web)
 
@@ -155,7 +155,7 @@ If the mic button shows an error in the browser:
 
 1. **Check browser support** - Web Speech API works in Chrome, Edge, and Safari. Firefox has limited support.
 2. **Allow microphone access** - Your browser may be blocking the microphone permission.
-3. **Use Groq Whisper** - For better quality or broader browser support, add a Groq API key in **Settings > Character** under Voice Input (STT). When configured, it automatically overrides Web Speech API.
+3. **Use a local Whisper server or Groq** - For better quality or broader browser support, configure Local STT (a self-hosted OpenAI-compatible Whisper server) or add a Groq API key in **Settings > Character** under Voice Input (STT). A configured local server takes top priority, then Groq, then Web Speech API.
 
 ### "Microphone access denied"
 

--- a/src/content/docs/guides/web-guide.md
+++ b/src/content/docs/guides/web-guide.md
@@ -63,12 +63,15 @@ If TTS is enabled, the avatar will speak the response with lip-synced animation.
 
 ## Voice Input
 
-Click the microphone button in the chat bar to use speech-to-text. Two providers are available:
+Click the microphone button in the chat bar to use speech-to-text. Three options are available:
 
-- **Web Speech API** — Built into your browser (Chrome, Edge, Safari). No API key required. This is the default in the browser.
-- **Groq Whisper** — Higher quality transcription via Groq's Whisper API. Requires a Groq API key, which you can add in **Settings > Character** under the Voice Input (STT) section. When a Groq key is configured, it automatically becomes the active STT provider.
+- **Local Whisper server** — Self-hosted, OpenAI-compatible transcription (Speaches, faster-whisper-server, whisper.cpp) via the `/v1/audio/transcriptions` endpoint. Audio never leaves your machine. Configure it in **Settings > Character** under Voice Input (STT) with a base URL (default `http://localhost:8000/v1/`) and a model name.
+- **Groq Whisper** — Higher-quality cloud transcription via Groq's Whisper API. Requires a Groq API key, added in the same Voice Input (STT) section.
+- **Web Speech API** — Built into your browser (Chrome, Edge, Safari). No API key required. The default in the browser when nothing else is configured.
 
-On the desktop app, Web Speech API is not available — you'll need to configure a Groq API key for voice input.
+Selection is automatic by priority: a configured local server wins, then Groq, then Web Speech. On the desktop app the Web Speech API is unavailable, so configure either a local Whisper server or a Groq key for voice input.
+
+See [Local STT Setup](/docs/guides/local-stt-setup) for running a local Whisper server.
 
 ## Data Management
 

--- a/src/content/docs/overview/introduction.md
+++ b/src/content/docs/overview/introduction.md
@@ -19,7 +19,7 @@ Most AI companions today are either text-only chat interfaces or locked behind p
 
 Utsuwa takes a different approach. It gives you a 3D avatar that speaks, remembers your conversations, and develops a relationship with you over time. No accounts, no subscriptions. Your data stays on your device.
 
-Connect any LLM provider you want — OpenAI, Anthropic, Google, DeepSeek, xAI, or a local model through Ollama or LM Studio. Add voice with ElevenLabs or OpenAI TTS. Use Groq or your browser's built-in speech recognition for voice input. Load any VRM model as your companion's body. Everything is modular and swappable.
+Connect any LLM provider you want — OpenAI, Anthropic, Google, DeepSeek, xAI, or a local model through Ollama or LM Studio. Add voice with ElevenLabs, OpenAI TTS, or a local TTS server. For voice input, use a local Whisper server, Groq, or your browser's built-in speech recognition. Load any VRM model as your companion's body. Everything is modular and swappable — and can run entirely on your own machine.
 
 "Utsuwa" means "vessel" in Japanese — a container for AI to inhabit visually. The app is the vessel; you choose what goes inside.
 

--- a/src/content/docs/technology/architecture.md
+++ b/src/content/docs/technology/architecture.md
@@ -45,7 +45,7 @@ Utsuwa is a client-side application that combines 3D avatar rendering, LLM chat,
               │       External APIs           │
               │  LLM: OpenAI / Anthropic / etc│
               │  TTS: ElevenLabs / OpenAI TTS │
-              │  STT: Web Speech / Groq       │
+              │  STT: Web Speech / Groq / Local│
               └───────────────────────────────┘
 ```
 
@@ -160,6 +160,22 @@ Text-to-speech converts LLM responses to audio with lip-sync.
 3. Web Audio API plays the audio
 4. Audio analyzer extracts volume/frequency data
 5. VRM model maps audio data to mouth blend shapes in real-time
+
+### Speech-to-Text (STT)
+
+Voice input converts microphone audio to text through one of three providers, chosen automatically by priority.
+
+**Key files:**
+- `src/lib/services/stt/openai-stt.ts` — OpenAI-compatible transcription client (Groq and local Whisper servers via `/v1/audio/transcriptions`)
+- `src/lib/services/stt/web-speech.ts` — Browser Web Speech API provider
+- `src/lib/stores/stt.svelte.ts` — Active-provider selection and session state
+
+**Supported providers (priority order):**
+- **Local STT** — any OpenAI-compatible Whisper server (Speaches, faster-whisper-server, whisper.cpp). No key; defaults to `http://localhost:8000/v1`
+- **Groq (Whisper)** — cloud transcription, requires an API key
+- **Web Speech API** — browser built-in, no key, unavailable in the desktop webview
+
+Selection: a configured local server wins, then Groq, then Web Speech.
 
 ### Memory System
 

--- a/src/lib/config/docs-nav.ts
+++ b/src/lib/config/docs-nav.ts
@@ -23,6 +23,7 @@ export const docsNav: DocsNavSection[] = [
 			{ title: 'Desktop Guide', slug: 'guides/desktop-guide' },
 			{ title: 'Local LLM Setup', slug: 'guides/local-llm-setup' },
 			{ title: 'Local TTS Setup', slug: 'guides/local-tts-setup' },
+			{ title: 'Local STT Setup', slug: 'guides/local-stt-setup' },
 			{ title: 'Troubleshooting', slug: 'guides/troubleshooting' }
 		]
 	},


### PR DESCRIPTION
Sweeps the README and site docs for anything left stale after today's work. The main thing was voice input: every doc described speech-to-text as "Groq or Web Speech only," which is now wrong with the new local Whisper support.

**Updated**
- **README** — features Voice Input line, STT providers table (2 → 3, adds Local STT), roadmap items, and a new "Fully Local Option" feature bullet tying together local LLM + TTS + STT.
- **overview/introduction** — provider prose now mentions local TTS and local STT, and that the whole stack can run on your own machine.
- **guides/web-guide** — Voice Input section rewritten for the three options and the local > Groq > Web Speech priority.
- **guides/desktop-guide** and **guides/troubleshooting** — the "no voice input on desktop, use Groq" notes now offer a local Whisper server as the alternative.
- **technology/architecture** — the external-APIs diagram now shows Local STT, and there's a new Speech-to-Text section paralleling the TTS one.
- **New: guides/local-stt-setup** — a full setup guide (Speaches, faster-whisper-server, whisper.cpp; base URL, model, desktop-vs-hosted rules, troubleshooting) mirroring the Local TTS guide, registered in the docs nav after Local TTS Setup.

**Confirmed already accurate (a doc audit cross-checked these):** conversation persistence is already reflected in the architecture/companion-system docs; Node 22 is correct everywhere; the relationship stages are already documented as all reachable.

## Verification
- `pnpm build` — succeeds; docs render and are indexed
- `pnpm check` — 0 errors; `pnpm test` — 111/111 pass
- Manual: the new Local STT Setup guide renders in the app, appears in the docs nav after Local TTS Setup, with a correct breadcrumb, table of contents, and code formatting.
