### PR TITLE
Correct README acknowledgments and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,10 +290,11 @@ pnpm tauri build  # Build desktop app installer
 - [x] Desktop application with transparent overlay mode (macOS, Windows, and Linux)
 - [x] Cross-platform desktop builds via CI (macOS, Windows, Linux)
 - [x] In-app auto-updates for the desktop app
+- [x] Show companion images (multimodal vision) with a keepsake photo board
 
 ### In Progress / Planned
 
-- [ ] **File, Image, and Video Uploads** - Add support for attaching files, images, and videos for multimodal LLM workflows and providers that can use richer context or web-aware tools
+- [ ] **File and Video Uploads** - Add support for attaching files and videos for multimodal LLM workflows and providers that can use richer context or web-aware tools (image support has shipped)
 - [ ] **OpenAI-Compatible Models** - Add a configurable option for OpenAI-compatible model endpoints beyond the currently listed providers
 - [ ] **More STT providers** - Additional dedicated speech-to-text integrations beyond local Whisper, Groq, and Web Speech API
 - [ ] **Live2D Support** - Alternative to VRM for 2D animated avatars
@@ -319,7 +320,7 @@ Utsuwa is built on the shoulders of these excellent projects:
 ### Core Technologies
 
 - **[@pixiv/three-vrm](https://github.com/pixiv/three-vrm)** - VRM model loading and rendering for Three.js
-- **[xsAI](https://github.com/moeru-ai/xsai)** - Unified LLM and TTS provider integration
+- **[xsAI](https://github.com/moeru-ai/xsai)** - `@xsai/stream-text` streams cloud LLM responses on the hosted web deployment
 - **[Three.js](https://github.com/mrdoob/three.js)** - 3D graphics engine
 - **[Threlte](https://github.com/threlte/threlte)** - Svelte components for Three.js
 - **[SvelteKit](https://github.com/sveltejs/kit)** - Web application framework


### PR DESCRIPTION
Two factual inaccuracies found in a README audit:

- **xsAI acknowledgment** said "Unified LLM and TTS provider integration." xsAI was never used for TTS, and after the earlier dependency cleanup only `@xsai/stream-text` remains — used solely server-side to stream cloud LLM responses on the hosted web deployment. Reworded to match reality.
- **Roadmap** listed "File, Image, and Video Uploads" as planned, but image uploads ("Show Her Photos") already shipped. Moved image support to Completed and narrowed the planned item to files and video.

The rest of the README checked out against the code: 7 LLM / 3 TTS / 3 STT providers, 8 relationship stages, `static/models/`, scripts, auto-updates, and no removed dependencies still credited.