### PR TITLE
Add a custom OpenAI-compatible LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,11 +291,11 @@ pnpm tauri build  # Build desktop app installer
 - [x] Cross-platform desktop builds via CI (macOS, Windows, Linux)
 - [x] In-app auto-updates for the desktop app
 - [x] Show companion images (multimodal vision) with a keepsake photo board
+- [x] Custom OpenAI-compatible LLM endpoint (OpenRouter, Together, Mistral, vLLM, LiteLLM, ...)
 
 ### In Progress / Planned
 
 - [ ] **File and Video Uploads** - Add support for attaching files and videos for multimodal LLM workflows and providers that can use richer context or web-aware tools (image support has shipped)
-- [ ] **OpenAI-Compatible Models** - Add a configurable option for OpenAI-compatible model endpoints beyond the currently listed providers
 - [ ] **More STT providers** - Additional dedicated speech-to-text integrations beyond local Whisper, Groq, and Web Speech API
 - [ ] **Live2D Support** - Alternative to VRM for 2D animated avatars
 

--- a/src/lib/services/chat/client-chat.ts
+++ b/src/lib/services/chat/client-chat.ts
@@ -38,7 +38,8 @@ export async function streamChatDirect(
 	const { messages, provider, model, apiKey, baseURL, systemPrompt } = options;
 
 	const isLocal = isLocalLLMProvider(provider);
-	if (!apiKey && !isLocal) {
+	// Custom OpenAI-compatible endpoints may or may not need a key, so don't force one.
+	if (!apiKey && !isLocal && provider !== 'openai-compatible') {
 		onError('API key required');
 		return;
 	}
@@ -182,7 +183,7 @@ interface ExtractOptions {
 export async function extractStateUpdates(options: ExtractOptions): Promise<string | null> {
 	const { provider, model, apiKey, baseURL, system, userMessage, reply } = options;
 	const isLocal = isLocalLLMProvider(provider);
-	if (!apiKey && !isLocal) return null;
+	if (!apiKey && !isLocal && provider !== 'openai-compatible') return null;
 
 	const base = isLocal ? getChatBaseUrl(provider, baseURL) : baseURL || DEFAULT_CHAT_BASE_URLS[provider];
 	if (!base) return null;

--- a/src/lib/services/providers/registry.ts
+++ b/src/lib/services/providers/registry.ts
@@ -11,6 +11,10 @@ export interface ProviderMetadata {
 	requiresApiKey: boolean;
 	defaultBaseUrl?: string;
 	isLocal?: boolean;
+	// A user-configured OpenAI-compatible endpoint (base URL + optional key +
+	// hand-entered model), rather than a fixed provider. The settings UI shows a
+	// base-URL field and a manual model input for these.
+	custom?: boolean;
 	// Whether this provider's models are broadly vision-capable. Coarse, cloud
 	// only. Local providers (Ollama/LM Studio) leave this unset and rely on a
 	// per-model heuristic, since vision depends on the installed model.
@@ -98,6 +102,16 @@ export const LLM_PROVIDERS: ProviderMetadata[] = [
 		defaultBaseUrl: DEFAULT_CHAT_BASE_URLS.lmstudio,
 		models: []
 	},
+	{
+		id: 'openai-compatible',
+		name: 'OpenAI-Compatible',
+		description: 'Any OpenAI-compatible endpoint (OpenRouter, Together, Mistral, vLLM, LiteLLM, ...)',
+		category: 'llm',
+		icon: '🔌',
+		requiresApiKey: false,
+		custom: true,
+		models: []
+	}
 ];
 
 // ============================================

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -11,7 +11,9 @@ export type LLMProvider =
 	| 'xai'
 	// Local
 	| 'ollama'
-	| 'lmstudio';
+	| 'lmstudio'
+	// User-configured OpenAI-compatible endpoint
+	| 'openai-compatible';
 
 // TTS Provider IDs
 export type TTSProvider = 'elevenlabs' | 'openai-tts' | 'local-tts';

--- a/src/routes/app/settings/persona/+page.svelte
+++ b/src/routes/app/settings/persona/+page.svelte
@@ -293,6 +293,11 @@
 		if (provider && !provider.isLocal && provider.models?.length) {
 			modulesStore.setModuleSetting('consciousness', 'activeModel', provider.models[0].id);
 		}
+		// Custom endpoints have no preset models; clear any stale selection so the
+		// manual model field starts empty.
+		if (provider?.custom) {
+			modulesStore.setModuleSetting('consciousness', 'activeModel', '');
+		}
 		// Mark local providers as added immediately (they don't need API keys)
 		if (provider?.isLocal || !provider?.requiresApiKey) {
 			settingsStore.markProviderAdded(providerId);
@@ -534,37 +539,23 @@
 
 								{#if consciousnessSettings.activeProvider}
 									{@const provider = getLLMProvider(consciousnessSettings.activeProvider as string)}
-									{#if provider?.requiresApiKey}
+
+									{#if provider?.requiresApiKey || provider?.custom}
 										<div class="api-key-row">
 											<input
 												type="password"
 												class="api-key-input"
 												class:error={llmFetchError}
-												placeholder="API Key"
+												placeholder={provider?.custom ? 'API Key (optional)' : 'API Key'}
 												value={settingsStore.getProviderConfig(provider.id).apiKey ?? ''}
 												oninput={(e) => handleApiKeyChange(provider.id, e.currentTarget.value, 'llm')}
-												onblur={handleLLMApiKeyBlur}
+												onblur={provider?.custom ? undefined : handleLLMApiKeyBlur}
 											/>
 										</div>
 									{/if}
-								{/if}
 
-								{#if consciousnessSettings.activeProvider}
-									<ModelDropdown
-										models={llmModels}
-										value={consciousnessSettings.activeModel as string}
-										onSelect={handleLLMModelChange}
-										placeholder="Select model..."
-										isLoading={llmIsLoading}
-										onRefresh={llmHasApiKey ? fetchLLMModels : undefined}
-										disabled={!llmHasApiKey}
-										disabledMessage="Enter API key first"
-									/>
-								{/if}
-
-								{#if consciousnessSettings.activeProvider}
-									{@const provider = getLLMProvider(consciousnessSettings.activeProvider as string)}
-									{#if provider?.isLocal}
+									<!-- Base URL for local providers and custom OpenAI-compatible endpoints -->
+									{#if provider?.isLocal || provider?.custom}
 										{#if llmFetchError}
 											<p class="provider-note error">
 												<Icon name="alert-circle" size={14} />
@@ -575,12 +566,38 @@
 											<input
 												type="text"
 												class="api-key-input"
-												placeholder={provider.defaultBaseUrl || 'http://localhost:11434/v1/'}
+												placeholder={provider.custom
+													? 'https://api.openai.com/v1/ or your endpoint'
+													: provider.defaultBaseUrl || 'http://localhost:11434/v1/'}
 												value={settingsStore.getProviderConfig(provider.id).baseUrl ?? ''}
 												oninput={(e) => handleLLMBaseUrlChange(provider.id, e.currentTarget.value)}
-												onblur={fetchLLMModels}
+												onblur={provider.custom ? undefined : fetchLLMModels}
 											/>
 										</div>
+									{/if}
+
+									<!-- Model: manual entry for custom endpoints, discovered dropdown otherwise -->
+									{#if provider?.custom}
+										<div class="api-key-row">
+											<input
+												type="text"
+												class="api-key-input"
+												placeholder="Model (e.g. gpt-4o-mini, meta-llama/llama-3-70b)"
+												value={(consciousnessSettings.activeModel as string) ?? ''}
+												oninput={(e) => handleLLMModelChange(e.currentTarget.value.trim())}
+											/>
+										</div>
+									{:else}
+										<ModelDropdown
+											models={llmModels}
+											value={consciousnessSettings.activeModel as string}
+											onSelect={handleLLMModelChange}
+											placeholder="Select model..."
+											isLoading={llmIsLoading}
+											onRefresh={llmHasApiKey ? fetchLLMModels : undefined}
+											disabled={!llmHasApiKey}
+											disabledMessage="Enter API key first"
+										/>
 									{/if}
 								{/if}
 							{/if}


### PR DESCRIPTION
Knocks the **OpenAI-Compatible Models** item off the roadmap. Adds a single `openai-compatible` LLM provider so users can point Utsuwa at any endpoint that speaks the OpenAI chat format — OpenRouter, Together, Mistral, Groq (LLM), Perplexity, a local vLLM, LiteLLM, etc.

Because the chat path already treats every non-Anthropic provider as OpenAI-format, this is mostly wiring:
- A `custom` flag on the provider metadata; the provider is added to the registry (it was already listed in the "Aggregators" group of the provider dropdown, just unbacked).
- Settings UI: shows an optional API-key field, a base-URL field, and a **hand-entered model** field (custom endpoints vary too much for a reliable model dropdown).
- Relaxed the "API key required" guards so keyless endpoints (local vLLM, some proxies) work.
- `openai-compatible` added to the `LLMProvider` type.

Cloud endpoints route through the server chat route on web (and direct on desktop), so the SSRF guard still applies. Local custom endpoints work on the desktop app.

## Verification
- `pnpm test` — 111/111 pass; `pnpm check` — 0 errors; `pnpm build` — succeeds
- Manual, in the running app: selected **OpenAI-Compatible**, confirmed the key / base-URL / manual-model fields render, pointed it at `https://api.openai.com/v1` with a model of `gpt-4o-mini`, and sent chat turns — got coherent replies ("Whirlwind!") with state parsing and event triggering, proving the custom endpoint routes correctly through the pipeline.
