### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-07-03
+
+### Fixed
+- **Onboarding now configures OpenAI-compatible endpoints**: selecting the OpenAI-Compatible provider during setup showed no fields to fill in. It now offers an optional API key, a base URL, and a model, and won't let you continue until a base URL and model are set.
+
+### Added
+- **Voice input during onboarding**: a new optional Voice Input (STT) step lets you set up a local Whisper server, Groq, or OpenAI while getting started, matching what the settings page already offered.
+
 ## [0.7.0] - 2026-07-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.7.0"
+version = "0.7.1"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "pnpm build",


### PR DESCRIPTION
Patch release bumping 0.7.0 → 0.7.1 across `package.json`, `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock`, with a CHANGELOG entry.

0.7.1 ships the onboarding fix (#63): the OpenAI-compatible provider is now configurable during setup (base URL + optional key + model), and onboarding gains a Voice Input (STT) step for local Whisper / Groq / OpenAI.

Tagging `v0.7.1` after merge to build and draft the release.