### PR TITLE
fix: readable errors when a provider base URL points at a website

### DIFF
--- a/src/lib/services/chat/client-chat.ts
+++ b/src/lib/services/chat/client-chat.ts
@@ -5,6 +5,11 @@ import {
 	isLocalLLMProvider
 } from '$lib/services/providers/local-endpoints';
 import { DEFAULT_CHAT_BASE_URLS } from '$lib/services/providers/provider-defaults';
+import {
+	htmlEndpointError,
+	looksLikeHtml,
+	sanitizeProviderError
+} from '$lib/services/providers/provider-errors';
 import { type MessageContent, toOpenAIContent, toAnthropicContent } from './content';
 
 interface ChatMessage {
@@ -99,11 +104,26 @@ export async function streamChatDirect(
 		const response = await fetch(url, { method: 'POST', headers, body });
 
 		if (!response.ok) {
-			const errorData = await response.json().catch(() => ({}));
-			const msg =
-				(errorData as { error?: { message?: string } })?.error?.message ||
-				`Provider error (${response.status})`;
+			const bodyText = await response.text().catch(() => '');
+			let msg = `Provider error (${response.status})`;
+			if (looksLikeHtml(bodyText)) {
+				msg = htmlEndpointError(providerBaseURL);
+			} else {
+				try {
+					msg = JSON.parse(bodyText)?.error?.message || msg;
+				} catch {
+					// Not JSON — keep the status-based message
+				}
+			}
+			msg = sanitizeProviderError(msg, providerBaseURL);
 			onError(isLocal && response.status === 404 ? `${msg}. Pull or select an installed model.` : msg);
+			return;
+		}
+
+		// A 200 with an HTML content-type means the URL points at a website, not an API
+		const contentType = response.headers.get('content-type') || '';
+		if (contentType.includes('text/html')) {
+			onError(htmlEndpointError(providerBaseURL));
 			return;
 		}
 

--- a/src/lib/services/providers/provider-errors.ts
+++ b/src/lib/services/providers/provider-errors.ts
@@ -1,0 +1,24 @@
+// Turns raw provider failures into short, readable messages. A misconfigured
+// base URL usually points at a website, so the failure body is a full HTML
+// page — never show that to the user.
+
+const HTML_MARKERS = ['<!doctype', '<html', '<head>', '<body'];
+const MAX_ERROR_LENGTH = 240;
+
+export function looksLikeHtml(text: string | null | undefined): boolean {
+	if (!text) return false;
+	const head = text.slice(0, 500).trim().toLowerCase();
+	return HTML_MARKERS.some((marker) => head.includes(marker));
+}
+
+export function htmlEndpointError(baseURL?: string): string {
+	const at = baseURL ? ` at ${baseURL}` : '';
+	return `The endpoint${at} returned a web page instead of an API response. Double-check the base URL (for OpenAI it's https://api.openai.com/v1/).`;
+}
+
+/** Collapse HTML dumps and cap length so an error can't flood the UI. */
+export function sanitizeProviderError(message: string, baseURL?: string): string {
+	if (looksLikeHtml(message)) return htmlEndpointError(baseURL);
+	if (message.length > MAX_ERROR_LENGTH) return `${message.slice(0, MAX_ERROR_LENGTH)}…`;
+	return message;
+}

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -4,6 +4,7 @@ import type { RequestHandler } from './$types';
 import type { LLMProvider } from '$lib/types';
 import { getChatBaseUrl } from '$lib/services/providers/local-endpoints';
 import { assertSafeProviderUrl } from '$lib/services/providers/url-guard';
+import { sanitizeProviderError } from '$lib/services/providers/provider-errors';
 import { DEFAULT_CHAT_BASE_URLS } from '$lib/services/providers/provider-defaults';
 
 // Providers that don't require API keys
@@ -86,7 +87,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			});
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : 'Failed to connect to provider';
-			return new Response(JSON.stringify({ error: msg }), {
+			return new Response(JSON.stringify({ error: sanitizeProviderError(msg, providerBaseURL) }), {
 				status: 502,
 				headers: { 'Content-Type': 'application/json' }
 			});
@@ -114,7 +115,9 @@ export const POST: RequestHandler = async ({ request }) => {
 					reader = textStream.getReader();
 				} catch (err) {
 					const msg = err instanceof Error ? err.message : 'Failed to start stream';
-					controller.enqueue(encoder.encode(`e:${JSON.stringify({ error: msg })}\n`));
+					controller.enqueue(
+						encoder.encode(`e:${JSON.stringify({ error: sanitizeProviderError(msg, providerBaseURL) })}\n`)
+					);
 					controller.close();
 					return;
 				}
@@ -130,7 +133,11 @@ export const POST: RequestHandler = async ({ request }) => {
 				} catch (error) {
 					console.error('Stream error:', error);
 					const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-					controller.enqueue(encoder.encode(`e:${JSON.stringify({ error: errorMessage })}\n`));
+					controller.enqueue(
+						encoder.encode(
+							`e:${JSON.stringify({ error: sanitizeProviderError(errorMessage, providerBaseURL) })}\n`
+						)
+					);
 					controller.close();
 				} finally {
 					reader.releaseLock();
@@ -147,12 +154,10 @@ export const POST: RequestHandler = async ({ request }) => {
 		});
 	} catch (error) {
 		console.error('Chat API error:', error);
-		return new Response(
-			JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error' }),
-			{
-				status: 500,
-				headers: { 'Content-Type': 'application/json' }
-			}
-		);
+		const msg = error instanceof Error ? error.message : 'Unknown error';
+		return new Response(JSON.stringify({ error: sanitizeProviderError(msg, baseURL) }), {
+			status: 500,
+			headers: { 'Content-Type': 'application/json' }
+		});
 	}
 };

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -249,7 +249,10 @@
 					})
 				});
 
-				if (!response.ok) throw new Error('Failed to get response');
+				if (!response.ok) {
+					const errBody = await response.json().catch(() => null);
+					throw new Error(errBody?.error || 'Failed to get response');
+				}
 
 				const reader = response.body?.getReader();
 				const decoder = new TextDecoder();

--- a/src/routes/overlay/+page.svelte
+++ b/src/routes/overlay/+page.svelte
@@ -203,7 +203,10 @@
 					})
 				});
 
-				if (!response.ok) throw new Error('Failed to get response');
+				if (!response.ok) {
+					const errBody = await response.json().catch(() => null);
+					throw new Error(errBody?.error || 'Failed to get response');
+				}
 
 				const reader = response.body?.getReader();
 				const decoder = new TextDecoder();


### PR DESCRIPTION
## What

Typing a slightly-wrong OpenAI-compatible base URL (e.g. `https://openai.com/v1/` instead of `https://api.openai.com/v1/`) used to produce a wall of raw HTML in the error toast, or worse, a silent empty reply when the site answered 200.

## How

- New `provider-errors.ts` helper: detects HTML response bodies, replaces them with a short "check your base URL" hint, and caps error message length.
- `streamChatDirect`: handles non-OK bodies safely (text-then-parse instead of assuming JSON) and rejects 200 responses with an HTML content-type before streaming.
- `/api/chat`: sanitizes every error surface (502, stream-start, mid-stream, 500) before it reaches the client.
- App + overlay pages: surface the server's sanitized error message instead of a generic "Failed to get response".

Verified end-to-end against a misconfigured endpoint locally.