### PR TITLE
feat: WebXR AR mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@
 
 ## Features
 
-- **VRM Model Viewer**: Load and display VRM 3D avatar models with orbit controls
+- **VRM Model Viewer**: Load and display VRM 3D avatar models with orbit controls, automatic camera framing per model, and live camera settings (zoom, height, field of view)
+- **AR Mode**: On WebXR-capable devices (Android Chrome, headset browsers), place your companion on your real floor, drag her around, and pinch to resize
 - **Model-Centric UI**: Full-screen 3D model with unobtrusive overlay controls
 - **3D Speech Bubbles**: Chat responses appear as bubbles that track the model's head in 3D space
 - **Chat Interface**: Bottom-centered input bar with streaming responses

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"@tauri-apps/plugin-process": "^2.3.1",
 		"@tauri-apps/plugin-updater": "^2.10.1",
 		"@threlte/core": "^8.3.1",
+		"@threlte/xr": "^1.6.1",
 		"@xenova/transformers": "^2.17.2",
 		"@xsai/stream-text": "^0.4.2",
 		"bits-ui": "^2.15.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@threlte/core':
         specifier: ^8.3.1
         version: 8.3.1(svelte@5.48.2)(three@0.182.0)
+      '@threlte/xr':
+        specifier: ^1.6.1
+        version: 1.6.1(svelte@5.48.2)(three@0.182.0)
       '@xenova/transformers':
         specifier: ^2.17.2
         version: 2.17.2
@@ -842,6 +845,12 @@ packages:
 
   '@threlte/core@8.3.1':
     resolution: {integrity: sha512-qKjjNCQ+40hyeBcfOMh/8ef5x/j5PG5Wmo/L9Ye0aDCcdD6fCewWxfp7tV/J3CxPzX1dEp1JGK7sjyc7ntZSrg==}
+    peerDependencies:
+      svelte: '>=5'
+      three: '>=0.160'
+
+  '@threlte/xr@1.6.1':
+    resolution: {integrity: sha512-24S0K/47rHtmhlOHNdUrMin6CeEKJYyOlhtvwtbI+ovi5bwX12dEpzVmnSlj/FA/L3mitgQT3KzOkvd5YqK8Hg==}
     peerDependencies:
       svelte: '>=5'
       three: '>=0.160'
@@ -2306,6 +2315,11 @@ snapshots:
   '@threlte/core@8.3.1(svelte@5.48.2)(three@0.182.0)':
     dependencies:
       mitt: 3.0.1
+      svelte: 5.48.2
+      three: 0.182.0
+
+  '@threlte/xr@1.6.1(svelte@5.48.2)(three@0.182.0)':
+    dependencies:
       svelte: 5.48.2
       three: 0.182.0
 

--- a/src/lib/components/ui/TopRightButtons.svelte
+++ b/src/lib/components/ui/TopRightButtons.svelte
@@ -4,6 +4,7 @@
 	import CameraSettingsPanel from '$lib/components/ui/CameraSettingsPanel.svelte';
 	import { localPath } from '$lib/config/links';
 	import { isTauri } from '$lib/services/platform';
+	import { arStore } from '$lib/stores/ar.svelte';
 	import { getColorMode, cycleColorMode, type ColorMode } from '$lib/utils/color-mode';
 	import { onMount } from 'svelte';
 
@@ -112,6 +113,18 @@
 			>
 				<Icon name={themeIcon} size={20} />
 			</button>
+			{#if arStore.supported}
+				<button
+					class="icon-btn cluster-item"
+					class:active={arStore.active}
+					style="--i: 3"
+					onclick={() => (arStore.active ? arStore.exit() : arStore.enter())}
+					aria-label={arStore.active ? 'Exit AR' : 'Enter AR'}
+					title={arStore.active ? 'Exit AR' : 'View in AR'}
+				>
+					<Icon name="cube" size={20} />
+				</button>
+			{/if}
 		</div>
 
 		{#if showCamera}

--- a/src/lib/components/vrm/ArPlacement.svelte
+++ b/src/lib/components/vrm/ArPlacement.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+	// Places the avatar on the real floor during an AR session and handles
+	// touch gestures via the DOM overlay: one finger drags her around the
+	// floor plane, two fingers pinch to resize. Mounted only while presenting;
+	// resets the model root transform on unmount.
+	import { T, useThrelte } from '@threlte/core';
+	import { useHitTest } from '@threlte/xr';
+	import { Group, Matrix4, Quaternion, Vector3 } from 'three';
+	import { onMount } from 'svelte';
+
+	interface Props {
+		/** The group wrapping the avatar; this component drives its transform */
+		root: Group;
+	}
+
+	let { root }: Props = $props();
+
+	const { camera } = useThrelte();
+
+	let reticle = $state<Group | undefined>();
+	let placed = $state(false);
+	let reticleVisible = $state(false);
+
+	const hitPos = new Vector3();
+	const hitQuat = new Quaternion();
+	const hitScale = new Vector3();
+
+	// Center-screen hit test: places the avatar on the first detected floor
+	// point, and keeps the reticle glued to whatever the camera aims at.
+	useHitTest((hitMatrix: Matrix4, hit) => {
+		if (!hit) {
+			reticleVisible = false;
+			return;
+		}
+		hitMatrix.decompose(hitPos, hitQuat, hitScale);
+		reticleVisible = true;
+		reticle?.position.copy(hitPos);
+
+		if (!placed) {
+			root.position.copy(hitPos);
+			placed = true;
+		}
+	});
+
+	// --- DOM-overlay touch gestures ---
+	let dragging = false;
+	let lastX = 0;
+	let lastY = 0;
+	let pinchStartDist = 0;
+	let pinchStartScale = 1;
+
+	const forward = new Vector3();
+	const right = new Vector3();
+
+	function isUiTarget(target: EventTarget | null): boolean {
+		return (
+			target instanceof Element &&
+			target.closest('button, input, textarea, a, select, [role="dialog"]') !== null
+		);
+	}
+
+	function onTouchStart(e: TouchEvent) {
+		if (isUiTarget(e.target)) return;
+		if (e.touches.length === 1) {
+			dragging = true;
+			lastX = e.touches[0].clientX;
+			lastY = e.touches[0].clientY;
+		} else if (e.touches.length === 2) {
+			dragging = false;
+			pinchStartDist = touchDistance(e);
+			pinchStartScale = root.scale.x;
+		}
+	}
+
+	function onTouchMove(e: TouchEvent) {
+		if (e.touches.length === 1 && dragging) {
+			const dx = e.touches[0].clientX - lastX;
+			const dy = e.touches[0].clientY - lastY;
+			lastX = e.touches[0].clientX;
+			lastY = e.touches[0].clientY;
+
+			// Move in the floor plane relative to where the camera faces:
+			// screen-x slides along camera-right, screen-y along camera-forward
+			const cam = camera.current;
+			cam.getWorldDirection(forward);
+			forward.y = 0;
+			forward.normalize();
+			right.crossVectors(forward, new Vector3(0, -1, 0)).normalize();
+
+			// Scale finger motion by distance so dragging feels 1:1-ish
+			const dist = Math.max(0.5, cam.position.distanceTo(root.position));
+			const factor = dist * 0.0022;
+			root.position.addScaledVector(right, dx * factor);
+			root.position.addScaledVector(forward, -dy * factor);
+		} else if (e.touches.length === 2 && pinchStartDist > 0) {
+			const ratio = touchDistance(e) / pinchStartDist;
+			const next = Math.min(2.5, Math.max(0.3, pinchStartScale * ratio));
+			root.scale.setScalar(next);
+		}
+	}
+
+	function onTouchEnd(e: TouchEvent) {
+		if (e.touches.length === 0) {
+			dragging = false;
+			pinchStartDist = 0;
+		}
+	}
+
+	function touchDistance(e: TouchEvent): number {
+		const [a, b] = [e.touches[0], e.touches[1]];
+		return Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+	}
+
+	onMount(() => {
+		window.addEventListener('touchstart', onTouchStart, { passive: true });
+		window.addEventListener('touchmove', onTouchMove, { passive: true });
+		window.addEventListener('touchend', onTouchEnd, { passive: true });
+
+		return () => {
+			window.removeEventListener('touchstart', onTouchStart);
+			window.removeEventListener('touchmove', onTouchMove);
+			window.removeEventListener('touchend', onTouchEnd);
+			// Hand the model back to the normal scene untouched
+			root.position.set(0, 0, 0);
+			root.scale.setScalar(1);
+		};
+	});
+</script>
+
+<!-- Placement reticle: a soft ring on the detected floor until she's placed -->
+{#if reticleVisible && !placed}
+	<T.Group bind:ref={reticle}>
+		<T.Mesh rotation.x={-Math.PI / 2}>
+			<T.RingGeometry args={[0.08, 0.1, 32]} />
+			<T.MeshBasicMaterial color="#38bdf8" transparent opacity={0.8} />
+		</T.Mesh>
+	</T.Group>
+{/if}

--- a/src/lib/components/vrm/Scene.svelte
+++ b/src/lib/components/vrm/Scene.svelte
@@ -2,9 +2,11 @@
 	// Minimal viewer scene: one white directional light, flat backdrop,
 	// grid + axes helpers, free orbit controls. No post-processing.
 	import { T, useThrelte, useTask } from '@threlte/core';
+	import { useXR } from '@threlte/xr';
 	import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-	import { ShaderMaterial, Color, Box3, Vector3, PerspectiveCamera } from 'three';
+	import { ShaderMaterial, Color, Box3, Vector3, PerspectiveCamera, Group } from 'three';
 	import type { VRM } from '@pixiv/three-vrm';
+	import ArPlacement from './ArPlacement.svelte';
 	import VrmModel from './VrmModel.svelte';
 	import OverlayRaycastHandler from '$lib/components/overlay/OverlayRaycastHandler.svelte';
 	import { vrmStore } from '$lib/stores/vrm.svelte';
@@ -49,7 +51,9 @@
 	const modelUrl = $derived(vrmStore.modelUrl);
 
 	const { camera, renderer, scene } = useThrelte();
+	const { isPresenting } = useXR();
 	let controls: OrbitControls | null = null;
+	let modelRoot = $state<Group | undefined>();
 
 	// Dark mode detection
 	let isDarkMode = $state(false);
@@ -121,9 +125,13 @@
 		const box = new Box3().setFromObject(vrm.scene);
 		const headTop = box.max.y;
 
-		// Thigh line from the humanoid rig; fall back to a proportional guess
+		// Thigh line from the raw skeleton (world matrices are valid right after
+		// updateWorldMatrix, unlike the normalized rig at load time); fall back
+		// to a proportional guess
 		let thighY = headTop * 0.45;
-		const upperLeg = vrm.humanoid?.getNormalizedBoneNode('leftUpperLeg');
+		const upperLeg =
+			vrm.humanoid?.getRawBoneNode('leftUpperLeg') ??
+			vrm.humanoid?.getNormalizedBoneNode('leftUpperLeg');
 		if (upperLeg) {
 			const p = new Vector3();
 			upperLeg.getWorldPosition(p);
@@ -135,6 +143,8 @@
 	}
 
 	function applyCamera() {
+		// The XR session owns the camera while presenting
+		if (renderer?.xr.isPresenting) return;
 		const cam = camera.current;
 		if (!(cam instanceof PerspectiveCamera)) return;
 
@@ -180,8 +190,16 @@
 		}
 	});
 
+	// Orbit controls fight the XR camera; disable them while presenting and
+	// re-apply the fitted framing when the session ends
+	$effect(() => {
+		if (!controls) return;
+		controls.enabled = !$isPresenting;
+		if (!$isPresenting) applyCamera();
+	});
+
 	useTask(() => {
-		controls?.update();
+		if (controls?.enabled) controls.update();
 	});
 </script>
 
@@ -193,8 +211,8 @@
 	<OverlayRaycastHandler />
 {/if}
 
-<!-- Backdrop + floor (hidden in overlay mode for transparency) -->
-{#if !overlay}
+<!-- Backdrop + floor (hidden in overlay mode and AR passthrough) -->
+{#if !overlay && !$isPresenting}
 	<T.Color attach="background" args={[backgroundColor]} />
 	<T.Mesh rotation.x={-Math.PI / 2} position.y={0}>
 		<T.CircleGeometry args={[2.5, 64]} />
@@ -206,7 +224,13 @@
      intensity 1 the classic three-vrm viewers were tuned against. -->
 <T.DirectionalLight intensity={Math.PI} position={[1, 1, 1]} />
 
-<!-- VRM Model -->
-{#if modelUrl}
-	<VrmModel url={modelUrl} />
+<!-- VRM Model, wrapped so AR placement can move/scale it without remounting -->
+<T.Group bind:ref={modelRoot}>
+	{#if modelUrl}
+		<VrmModel url={modelUrl} />
+	{/if}
+</T.Group>
+
+{#if $isPresenting && modelRoot}
+	<ArPlacement root={modelRoot} />
 {/if}

--- a/src/lib/components/vrm/VrmScene.svelte
+++ b/src/lib/components/vrm/VrmScene.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { Canvas } from '@threlte/core';
+	import { XR } from '@threlte/xr';
 	import { WebGLRenderer, SRGBColorSpace, NoToneMapping } from 'three';
 	import { onMount } from 'svelte';
 	import Scene from './Scene.svelte';
 	import { vrmStore } from '$lib/stores/vrm.svelte';
+	import { arStore } from '$lib/stores/ar.svelte';
 	import { preGenerateThumbnails } from '$lib/utils/vrmThumbnail';
 
 	interface Props {
@@ -58,6 +60,14 @@
 <div class="vrm-scene">
 	{#if mounted}
 		<Canvas {createRenderer} toneMapping={NoToneMapping}>
+			<!-- Session management only: XR renders children solely while presenting,
+			     so the scene lives beside it and stays mounted in both modes -->
+			<XR
+				offerSession={false}
+				enterGrantedSession={false}
+				onsessionstart={() => arStore.setActive(true)}
+				onsessionend={() => arStore.setActive(false)}
+			/>
 			<Scene {centered} {locked} {overlay} />
 		</Canvas>
 	{/if}

--- a/src/lib/stores/ar.svelte.ts
+++ b/src/lib/stores/ar.svelte.ts
@@ -1,0 +1,57 @@
+import { browser } from '$app/environment';
+import { getXRSupportState, toggleXRSession } from '@threlte/xr';
+
+// WebXR immersive-ar is available on Android Chrome and headset browsers.
+// Desktop and iOS Safari report unsupported, so the AR button stays hidden there.
+function createArStore() {
+	let supported = $state(false);
+	let active = $state(false);
+
+	if (browser) {
+		getXRSupportState('immersive-ar')
+			.then((state) => (supported = state === 'supported'))
+			.catch(() => (supported = false));
+	}
+
+	async function enter() {
+		try {
+			await toggleXRSession(
+				'immersive-ar',
+				{
+					requiredFeatures: ['hit-test'],
+					optionalFeatures: ['dom-overlay'],
+					domOverlay: { root: document.body }
+				},
+				'enter'
+			);
+		} catch (e) {
+			console.error('Failed to start AR session:', e);
+		}
+	}
+
+	async function exit() {
+		try {
+			await toggleXRSession('immersive-ar', undefined, 'exit');
+		} catch (e) {
+			console.error('Failed to end AR session:', e);
+		}
+	}
+
+	function setActive(value: boolean) {
+		active = value;
+	}
+
+	return {
+		get supported() {
+			return supported;
+		},
+		get active() {
+			return active;
+		},
+		enter,
+		exit,
+		setActive
+	};
+}
+
+export const arStore = createArStore();


### PR DESCRIPTION
## What

An AR button joins the settings cluster on devices that support WebXR `immersive-ar` (Android Chrome, headset browsers); it stays hidden elsewhere. In a session:

- Passthrough camera feed (scene backdrop and studio floor hide automatically)
- The avatar auto-places on the first detected floor point (hit-test), with a placement reticle until she lands
- One-finger drag moves her around the floor plane, camera-relative; two-finger pinch resizes (0.3×–2.5×)
- Speech/thinking bubbles and the chat bar remain visible via DOM overlay
- Exiting restores the normal scene, camera framing, and orbit controls

## How

- `@threlte/xr` for session management and per-frame hit-testing; the `<XR>` manager mounts as a sibling of the scene since its children only render while presenting
- The model root is wrapped in a persistent group, so entering/exiting AR never remounts (or re-downloads) the VRM
- Orbit controls and the camera auto-fit disengage while presenting and re-apply on session end
- Also fixes first-load auto-fit reading the normalized rig before its matrices update (now uses the raw skeleton)

## Testing

- Desktop: AR button correctly hidden, scene/chat/camera settings unaffected (verified in-browser)
- Faked `navigator.xr` in a Playwright run: AR button appears when supported, a failing session start logs cleanly and the app keeps running
- Production build passes (SSR-safe imports)
- Real-device AR (hit-test, drag, pinch) needs an Android phone: code paths are gated so nothing activates on unsupported devices