### PR TITLE
fix: memory dedup, bounded retrieval, and session summaries

### DIFF
--- a/src/lib/ai/prompt-builder.ts
+++ b/src/lib/ai/prompt-builder.ts
@@ -219,8 +219,10 @@ function buildMemoryLayer(ctx: PromptContext): string {
 	if (mem.recentSessions.length > 0 && ctx.state.lastInteraction) {
 		const hoursSince = (ctx.systemTime.getTime() - new Date(ctx.state.lastInteraction).getTime()) / (1000 * 60 * 60);
 		if (hoursSince > 6) {
-			const lastSession = mem.recentSessions[0];
-			if (lastSession.summary) {
+			// The current run's session has an empty summary, so pick the most recent
+			// session that actually has one (the previous, summarized visit).
+			const lastSession = mem.recentSessions.find((s) => s.summary);
+			if (lastSession?.summary) {
 				sections.push(`Last time you talked: ${lastSession.summary}`);
 			}
 		}

--- a/src/lib/engine/memory.ts
+++ b/src/lib/engine/memory.ts
@@ -10,6 +10,7 @@ import type {
 import { MAX_WORKING_MEMORY_TURNS, MAX_RELEVANT_FACTS, MAX_RECENT_SESSIONS, DEFAULT_FACT_IMPORTANCE, DEFAULT_FACT_CONFIDENCE } from '$lib/types/memory';
 import * as memoryStorage from '$lib/services/storage/memory';
 import { embedText, findSimilarFacts, isEmbeddingReady } from '$lib/services/embeddings';
+import { summarizeTurns } from './session-summary';
 
 // Working memory store (single instance for the session)
 let workingMemory: WorkingMemory = {
@@ -89,6 +90,34 @@ export async function hydrateWorkingMemory(): Promise<void> {
 	const recentTurns = await memoryStorage.getConversationTurns({ limit: 20 });
 	workingMemory.turns = recentTurns;
 	workingMemory.messageCount = recentTurns.length;
+
+	// Backfill summaries for past sessions that ended without one, so the
+	// "last time you talked" prompt context actually has something to read.
+	await finalizeStaleSessions();
+}
+
+// Generate summaries for any past session that has turns but no summary yet
+// (skipping the current run's session, which is still active). Runs on load so
+// summaries exist before the first message of a returning session builds its prompt.
+export async function finalizeStaleSessions(): Promise<void> {
+	try {
+		const sessions = await memoryStorage.getSessions();
+		for (const session of sessions) {
+			if (session.id === undefined) continue;
+			if (session.id === workingMemory.currentSessionId) continue;
+			if (session.summary && session.summary.length > 0) continue;
+
+			const turns = await memoryStorage.getConversationTurns({ sessionId: session.id });
+			if (turns.length === 0) continue;
+
+			const { summary, keyTopics, emotionalArc } = summarizeTurns(turns);
+			if (summary) {
+				await memoryStorage.updateSession(session.id, { summary, keyTopics, emotionalArc });
+			}
+		}
+	} catch (e) {
+		console.debug('[Memory] Failed to finalize stale sessions:', e);
+	}
 }
 
 // Memory API - uses IndexedDB storage directly
@@ -178,8 +207,9 @@ export async function retrieveRelevantContext(userMessage: string): Promise<Rele
 		if (isEmbeddingReady()) {
 			const queryEmbedding = await embedText(userMessage);
 			if (queryEmbedding) {
-				// Get all facts with embeddings for semantic search
-				const allFacts = await memoryStorage.getAllFactsWithEmbeddings();
+				// Bounded candidate pool (top-importance facts with embeddings) so
+				// scoring cost doesn't grow linearly with total memory count.
+				const allFacts = await memoryStorage.getFactsForSemanticSearch();
 				const semanticResults = findSimilarFacts(queryEmbedding, allFacts, MAX_RELEVANT_FACTS, {
 					similarityWeight: 0.7,
 					importanceWeight: 0.3,

--- a/src/lib/engine/session-summary.test.ts
+++ b/src/lib/engine/session-summary.test.ts
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { summarizeTurns } from './session-summary.ts';
+
+type Turn = { role: 'user' | 'assistant'; content: string };
+
+test('empty session yields empty summary', () => {
+	assert.deepEqual(summarizeTurns([]), { summary: '', keyTopics: [], emotionalArc: '' });
+});
+
+test('assistant-only turns yield empty summary (topics come from the user)', () => {
+	const turns: Turn[] = [{ role: 'assistant', content: 'Hello there, how are you feeling today?' }];
+	assert.equal(summarizeTurns(turns).summary, '');
+});
+
+test('extracts frequent topics from user turns and phrases a summary', () => {
+	const turns: Turn[] = [
+		{ role: 'user', content: 'I adopted a puppy this weekend! The puppy is so playful.' },
+		{ role: 'assistant', content: 'A puppy! Tell me more.' },
+		{ role: 'user', content: 'We went hiking with the puppy near the mountains.' }
+	];
+	const result = summarizeTurns(turns);
+	assert.ok(result.keyTopics.includes('puppy'), 'puppy is the dominant topic');
+	assert.ok(result.summary.startsWith('You talked about'), 'phrased summary');
+	assert.ok(result.summary.includes('puppy'));
+});
+
+test('stopwords and short words are excluded from topics', () => {
+	const turns: Turn[] = [
+		{ role: 'user', content: 'I think that you are so nice and I really like you a lot today' }
+	];
+	const result = summarizeTurns(turns);
+	for (const banned of ['think', 'that', 'you', 'nice', 'really', 'like', 'today']) {
+		assert.ok(!result.keyTopics.includes(banned), `${banned} should be filtered out`);
+	}
+});
+
+test('falls back to a trimmed first message when there are too few topics', () => {
+	const turns: Turn[] = [{ role: 'user', content: 'hey there' }];
+	const result = summarizeTurns(turns);
+	// no strong topics -> fall back to the first user message verbatim
+	assert.equal(result.summary, 'hey there');
+});
+
+test('long fallback message is truncated with an ellipsis', () => {
+	const long = 'x'.repeat(200);
+	const turns: Turn[] = [{ role: 'user', content: long }];
+	const result = summarizeTurns(turns);
+	assert.ok(result.summary.endsWith('…'));
+	assert.ok(result.summary.length <= 118);
+});

--- a/src/lib/engine/session-summary.ts
+++ b/src/lib/engine/session-summary.ts
@@ -1,0 +1,65 @@
+import type { ConversationTurn } from '../types/memory.ts';
+
+// Words too common to be useful topic signals.
+const STOPWORDS = new Set([
+	'the', 'a', 'an', 'and', 'or', 'but', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+	'to', 'of', 'in', 'on', 'at', 'for', 'with', 'about', 'as', 'by', 'from', 'up', 'out',
+	'i', 'you', 'he', 'she', 'it', 'we', 'they', 'me', 'him', 'her', 'us', 'them', 'my',
+	'your', 'his', 'its', 'our', 'their', 'this', 'that', 'these', 'those', 'here', 'there',
+	'what', 'which', 'who', 'when', 'where', 'why', 'how', 'all', 'any', 'both', 'each',
+	'few', 'more', 'most', 'some', 'such', 'no', 'nor', 'not', 'only', 'own', 'same', 'so',
+	'than', 'too', 'very', 'can', 'will', 'just', 'do', 'does', 'did', 'have', 'has', 'had',
+	'would', 'could', 'should', 'get', 'got', 'like', 'really', 'think', 'know', 'want',
+	'yeah', 'okay', 'hey', 'hi', 'hello', 'thanks', 'thank', 'well', 'good', 'nice',
+	'today', 'now', 'then', 'much', 'also', 'because', 'into', 'over', 'been'
+]);
+
+export interface SessionSummaryResult {
+	summary: string;
+	keyTopics: string[];
+	emotionalArc: string;
+}
+
+/**
+ * Build a lightweight, deterministic summary of a session from its turns.
+ * Intentionally dependency-free (no LLM, no storage) so it's cheap and testable —
+ * it exists so the "last time you talked" prompt context has something to read.
+ */
+export function summarizeTurns(turns: Pick<ConversationTurn, 'role' | 'content'>[]): SessionSummaryResult {
+	const userText = turns
+		.filter((t) => t.role === 'user' && t.content)
+		.map((t) => t.content)
+		.join(' ');
+
+	if (!userText.trim()) {
+		return { summary: '', keyTopics: [], emotionalArc: '' };
+	}
+
+	// Frequency-rank meaningful words as topics.
+	const counts = new Map<string, number>();
+	for (const raw of userText.toLowerCase().match(/[a-z][a-z'-]{2,}/g) ?? []) {
+		const word = raw.replace(/^['-]+|['-]+$/g, '');
+		if (word.length < 4 || STOPWORDS.has(word)) continue;
+		counts.set(word, (counts.get(word) ?? 0) + 1);
+	}
+
+	const keyTopics = Array.from(counts.entries())
+		.sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+		.slice(0, 4)
+		.map(([w]) => w);
+
+	let summary: string;
+	if (keyTopics.length >= 2) {
+		const list =
+			keyTopics.length === 2
+				? `${keyTopics[0]} and ${keyTopics[1]}`
+				: `${keyTopics.slice(0, -1).join(', ')}, and ${keyTopics[keyTopics.length - 1]}`;
+		summary = `You talked about ${list}.`;
+	} else {
+		// Not enough distinct topics — fall back to a trimmed first user message.
+		const first = turns.find((t) => t.role === 'user' && t.content)?.content ?? '';
+		summary = first.length > 120 ? `${first.slice(0, 117).trimEnd()}…` : first;
+	}
+
+	return { summary, keyTopics, emotionalArc: '' };
+}

--- a/src/lib/services/storage/memory.ts
+++ b/src/lib/services/storage/memory.ts
@@ -42,8 +42,30 @@ export async function getFacts(options: MemorySearchOptions = {}): Promise<Fact[
 	return filtered.map(deserializeFact);
 }
 
+// Normalize content for duplicate detection: trim, lowercase, collapse whitespace.
+function normalizeContent(content: string): string {
+	return content.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
 export async function saveFact(fact: NewFact): Promise<number> {
 	const now = new Date();
+	const normalized = normalizeContent(fact.content);
+
+	// Dedup: the runtime pipeline can persist the same observation every turn
+	// ("I'm tired", "I love you"), which grows the table unbounded and dilutes
+	// retrieval. If an equivalent fact already exists, bump its reference count
+	// and importance instead of adding a near-duplicate row.
+	const existing = (await db.facts.where('category').equals(fact.category).toArray()).find(
+		(f) => normalizeContent(f.content) === normalized
+	);
+	if (existing?.id !== undefined) {
+		await db.facts.update(existing.id, {
+			referenceCount: existing.referenceCount + 1,
+			importance: Math.min(100, Math.max(existing.importance, fact.importance ?? 50)),
+			lastAccessed: now
+		});
+		return existing.id;
+	}
 
 	// Generate embedding if model is ready
 	let embedding: number[] | undefined;
@@ -101,6 +123,19 @@ export async function getFactsWithoutEmbeddings(): Promise<Fact[]> {
 export async function getAllFactsWithEmbeddings(): Promise<Fact[]> {
 	const facts = await db.facts.toArray();
 	return facts.map(deserializeFact);
+}
+
+// Candidate pool for per-message semantic search. Bounded via the importance
+// index so cosine scoring stays O(cap) instead of scanning every fact on every
+// message — retrieval quality is unchanged for normal use, but a companion with
+// thousands of memories no longer pays a linearly growing cost per turn.
+const MAX_SEMANTIC_CANDIDATES = 500;
+
+export async function getFactsForSemanticSearch(
+	limit: number = MAX_SEMANTIC_CANDIDATES
+): Promise<Fact[]> {
+	const facts = await db.facts.orderBy('importance').reverse().limit(limit).toArray();
+	return facts.filter((f) => f.embedding && f.embedding.length > 0).map(deserializeFact);
 }
 
 // Sessions


### PR DESCRIPTION
## What

Two memory-layer fixes from the audit (BUG-3, BUG-4).

**BUG-3 — unbounded fact growth + full-table scans.** The runtime pipeline `add()`ed a fact every turn with no dedup, and per-message retrieval `toArray()`d the entire facts table for cosine scoring.
- `saveFact` now dedups on normalized content within a category: an equivalent fact bumps `referenceCount`/`importance` instead of inserting a duplicate.
- New `getFactsForSemanticSearch` scores a bounded (top-500 by importance, index-backed) candidate pool instead of every fact.

**BUG-4 — dead "returning after absence" prompt.** Sessions were always created with `summary: ''` and nothing wrote one, so `if (lastSession.summary)` never fired.
- New dependency-free `summarizeTurns` builds a topic summary; `finalizeStaleSessions` backfills it for past sessions on load; prompt-builder selects the most recent *summarized* session.

## Testing

- 121/121 unit tests pass (6 new for `summarizeTurns`).
- Live clickthrough: session summaries generated on load ("You talked about after, chat, check, and engine."); sending an identical factual message twice kept the fact count at 3 with `referenceCount` incremented to 2 (dedup working, no duplicate rows); chat round trip via OpenAI intact and she recalled the stated fact.