### PR TITLE
fix: tighten output sanitizers to preserve legitimate replies

### DIFF
--- a/src/lib/ai/response-parser.test.ts
+++ b/src/lib/ai/response-parser.test.ts
@@ -157,9 +157,27 @@ test('does not cut a legit reply that just contains a colon line', () => {
 	assert.ok(dialogue.includes('First we get coffee'));
 });
 
-test('strips a leading self-label without nuking the reply', () => {
-	const { dialogue } = parseResponse('Luna: Hey, good to see you.');
+test('strips a leading self-label (the companion name) without nuking the reply', () => {
+	const { dialogue } = parseResponse('Luna: Hey, good to see you.', 'Luna');
 	assert.equal(dialogue, 'Hey, good to see you.');
+});
+
+test('preserves legit "Word:" line prefixes that are not speaker labels', () => {
+	const note = parseResponse('Note: I will remember that for you.', 'Luna');
+	assert.equal(note.dialogue, 'Note: I will remember that for you.');
+	const reminder = parseResponse('Reminder: your interview is Thursday.', 'Luna');
+	assert.equal(reminder.dialogue, 'Reminder: your interview is Thursday.');
+});
+
+test('does not clip a reply that quotes someone on a new line', () => {
+	const raw = 'She told me something sweet:\n"You always make me smile."';
+	const { dialogue } = parseResponse(raw, 'Luna');
+	assert.ok(dialogue.includes('You always make me smile'), 'a quoted line by a non-speaker must survive');
+});
+
+test('still cuts the companion impersonating a later turn as itself', () => {
+	const { dialogue } = parseResponse('Sure thing!\nLuna: and then I said more', 'Luna');
+	assert.equal(dialogue, 'Sure thing!');
 });
 
 // The extraction fallback feeds parseResponse the raw model output directly.

--- a/src/lib/ai/response-parser.ts
+++ b/src/lib/ai/response-parser.ts
@@ -83,17 +83,27 @@ function stripControlTokens(text: string): string {
 	return cut.replace(STRAY_TOKEN_RE, '');
 }
 
-// The model sometimes keeps writing past its own reply and starts a new
-// transcript turn as the user or a narrator (e.g. `CJ: "..."`, `They: ...`,
-// `User: ...`), often a third-person note it meant for the memory JSON. Cut at
-// the first such turn on a LATER line (anchored to \n, so the real reply on
-// line one is never the cut point). Names vary, so we key on a known transcript
-// label or any `Name: "` that opens a quoted line.
-const HALLUCINATED_TURN_RE =
-	/\n[ \t]*(?:(?:They|You|User|Human|Assistant|Narrator|System|AI)[ \t]*:[ \t]|[A-Z][\w'’.-]{0,19}[ \t]*:[ \t]*["“])/;
+function escapeRegExp(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
-function cutHallucinatedTurn(text: string): string {
-	const m = text.match(HALLUCINATED_TURN_RE);
+// Transcript labels the model bleeds through when it keeps writing past its own
+// reply as the user or a narrator.
+const TRANSCRIPT_LABELS = ['They', 'You', 'User', 'Human', 'Assistant', 'Narrator', 'System', 'AI', 'Companion'];
+
+// Cut at the first transcript turn on a LATER line (anchored to \n, so the real
+// reply on line one is never the cut point). Two triggers: a known transcript
+// label or the companion's own name followed by a colon, OR any capitalized
+// name that opens a quoted line (the model leaking a third-person memory note as
+// a fake turn, e.g. `CJ: "They asked how my day is going."`).
+function cutHallucinatedTurn(text: string, companionName?: string): string {
+	const labels = [...TRANSCRIPT_LABELS];
+	if (companionName?.trim()) labels.push(companionName.trim());
+	const labelAlt = labels.map(escapeRegExp).join('|');
+	const re = new RegExp(
+		`\\n[ \\t]*(?:(?:${labelAlt})[ \\t]*:[ \\t]|[A-Z][\\w'’.-]{0,19}[ \\t]*:[ \\t]*["“])`
+	);
+	const m = text.match(re);
 	return m && m.index !== undefined ? text.slice(0, m.index) : text;
 }
 
@@ -170,7 +180,7 @@ function tryParseJson(text: string): LLMStateOutput | null {
 }
 
 // Parse LLM response to extract dialogue and state updates
-export function parseResponse(rawResponse: string): ParsedResponse {
+export function parseResponse(rawResponse: string, companionName?: string): ParsedResponse {
 	const raw = stripReasoning(rawResponse);
 	let dialogue = raw.trim();
 	let stateUpdates: Partial<StateUpdates> | null = null;
@@ -199,7 +209,7 @@ export function parseResponse(rawResponse: string): ParsedResponse {
 		}
 	}
 
-	dialogue = cleanDialogue(dialogue);
+	dialogue = cleanDialogue(dialogue, companionName);
 	return { dialogue, stateUpdates, parseError };
 }
 
@@ -291,12 +301,12 @@ function stripTruncatedStateBlock(text: string): string {
 	return text;
 }
 
-function cleanDialogue(text: string): string {
+function cleanDialogue(text: string, companionName?: string): string {
 	// Cut runaway output at a leaked stop token and drop stray template tokens.
 	let cleaned = stripControlTokens(text);
 
 	// Cut if the model kept going as the user / a narrator instead of replying.
-	cleaned = cutHallucinatedTurn(cleaned);
+	cleaned = cutHallucinatedTurn(cleaned, companionName);
 
 	// Drop a trailing UNterminated state block first (small models truncated
 	// mid-JSON): it has no closing ``` or `}`, so the closed-object cleaner below
@@ -312,8 +322,16 @@ function cleanDialogue(text: string): string {
 	// Remove stage directions in parentheses
 	cleaned = cleaned.replace(/\([^)]*(?:smiles|laughs|sighs|blushes|looks|nods)[^)]*\)/gi, '');
 
-	// Remove character name prefixes (e.g., "Character: ")
-	cleaned = cleaned.replace(/^[A-Za-z]+:\s*/gm, '');
+	// Remove leading transcript/name labels only (e.g. "Luna: ", "User: "), NOT
+	// arbitrary "Word:" prefixes — legit replies like "Note: ..." or
+	// "Reminder: ..." must survive. Keyed on known labels + the companion's name.
+	const labels = [...TRANSCRIPT_LABELS];
+	if (companionName?.trim()) labels.push(companionName.trim());
+	const labelRe = new RegExp(`^[ \\t]*(?:${labels.map(escapeRegExp).join('|')})[ \\t]*:[ \\t]*`, 'i');
+	cleaned = cleaned
+		.split('\n')
+		.map((line) => line.replace(labelRe, ''))
+		.join('\n');
 
 	// Clean up whitespace
 	cleaned = cleaned.replace(/\n{3,}/g, '\n\n');

--- a/src/lib/engine/memory.ts
+++ b/src/lib/engine/memory.ts
@@ -309,8 +309,10 @@ function extractTriggerWords(message: string): string[] {
 		}
 	}
 
-	// Name extraction (might trigger facts about the user)
-	const namePattern = /\b([A-Z][a-z]+)\b/g;
+	// Name extraction (might trigger facts about the user). Only capture a
+	// capitalized word that follows another word — skipping sentence-initial
+	// words like "Today"/"Thanks" that aren't names but were being treated as such.
+	const namePattern = /(?<=[a-z,]\s+)([A-Z][a-z]+)\b/g;
 	let nameMatch;
 	while ((nameMatch = namePattern.exec(message)) !== null) {
 		triggers.push(nameMatch[1]);

--- a/src/lib/services/chat/companion-turn.ts
+++ b/src/lib/services/chat/companion-turn.ts
@@ -51,7 +51,7 @@ export async function processCompanionTurn(input: CompanionTurnInput): Promise<C
 	const state = characterStore.state;
 	const baselineUpdates = calculateBaselineUpdates(userMessage, state);
 
-	const parsed = parseResponse(companionResponse);
+	const parsed = parseResponse(companionResponse, state.name);
 	const dialogue = parsed.dialogue;
 	let llmUpdates = parsed.stateUpdates;
 


### PR DESCRIPTION
## What

BUG-5 and over-broad-regex cleanups from the audit.

**`cleanDialogue` nuked legit 'Word:' prefixes.** A blanket `replace(/^[A-Za-z]+:\s*/gm, '')` stripped the first word from any line starting `Word:`, so 'Note: ...' and 'Reminder: ...' were mangled. It now strips only known transcript labels and the companion's own name, threaded through `parseResponse(raw, companionName)`.

**`extractTriggerWords` treated every capitalized word as a name**, so sentence-initial 'Today'/'Thanks' polluted the trigger-memory query. It now only captures a capitalized word that follows another word.

## Testing
124/124 unit tests pass (4 new: label preservation, quoted-line survival, name-threaded self-label strip, self-impersonation cut). Live chat round trip produced a clean reply with no leaked labels.