### PR TITLE
refactor: extract shared companion-chat pipeline from both pages

### DIFF
--- a/src/lib/services/chat/companion-chat.ts
+++ b/src/lib/services/chat/companion-chat.ts
@@ -1,0 +1,268 @@
+// The one companion send/stream pipeline, shared by the main app and the
+// desktop overlay. Both pages used to carry ~180 near-identical lines each,
+// which had already drifted (the overlay forgot to filter empty messages). This
+// centralizes prompt building, streaming (direct vs. server route), the
+// post-turn processing, keepsakes, TTS, and the talking animation. Pages provide
+// a small set of hooks to sync their own reactive state.
+import { characterStore } from '$lib/stores/character.svelte';
+import { chatStore } from '$lib/stores/chat.svelte';
+import { settingsStore } from '$lib/stores/settings.svelte';
+import { modulesStore } from '$lib/stores/modules.svelte';
+import { ttsStore } from '$lib/stores/tts.svelte';
+import { personaStore } from '$lib/stores/persona.svelte';
+import { vrmStore } from '$lib/stores/vrm.svelte';
+import { getLLMProvider, getTTSProvider } from '$lib/services/providers/registry';
+import { streamChatDirect } from '$lib/services/chat/client-chat';
+import { processCompanionTurn } from '$lib/services/chat/companion-turn';
+import { retrieveRelevantContext } from '$lib/engine/memory';
+import { buildSystemPrompt, type PromptContext } from '$lib/ai/prompt-builder';
+import { keepImage, type PreparedImage } from '$lib/services/storage/keepsakes';
+import { toOpenAIContent, type ContentPart } from '$lib/services/chat/content';
+import { isTauri } from '$lib/services/platform';
+import type { LLMProvider, TTSProvider } from '$lib/types';
+import type { EventDefinition } from '$lib/types/events';
+
+export interface CompanionChatHooks {
+	/** Toggle the typing indicator. */
+	setTyping: (typing: boolean) => void;
+	/** The latest cleaned reply, for the speech bubble. */
+	setLatestResponse: (response: string) => void;
+	/** A visual-novel event the reply triggered. */
+	setActiveEvent: (event: EventDefinition) => void;
+	/** Blob-URL previews of images shown this turn (main app scrapbook). */
+	onShownImages?: (shown: { id: string; url: string }[]) => void;
+	/** The new memory the model recorded, if any. */
+	onNewMemory?: (memory: string | undefined) => void;
+	/** Runs just before streaming starts (e.g. the overlay collapses its chat). */
+	beforeStream?: () => void;
+}
+
+async function buildCompanionPrompt(userMessage: string, hasImages: boolean): Promise<string> {
+	const context: PromptContext = {
+		persona: personaStore.activeCard,
+		state: characterStore.state,
+		memories: await retrieveRelevantContext(userMessage),
+		userMessage,
+		systemTime: new Date(),
+		hasImages
+	};
+	return buildSystemPrompt(context);
+}
+
+// Assemble the message history for the provider. The current turn carries the
+// image bytes; prior turns stay text. Empty messages are dropped (the assistant
+// placeholder, and any stray blank turn) so we never send an empty message.
+function buildMessages(images: PreparedImage[]) {
+	const history = chatStore.messages.slice(0, -1).filter((m) => m.content || m.images?.length);
+	return history.map((m, idx) => {
+		const isCurrentTurn = idx === history.length - 1 && images.length > 0;
+		if (!isCurrentTurn) {
+			return { role: m.role as 'user' | 'assistant', content: m.content };
+		}
+		const parts: ContentPart[] = [];
+		if (m.content) parts.push({ type: 'text', text: m.content });
+		for (const img of images) {
+			parts.push({ type: 'image', mimeType: img.mimeType, data: img.base64 });
+		}
+		return { role: m.role as 'user' | 'assistant', content: parts };
+	});
+}
+
+// Consume the server route's 0:/e: SSE framing, buffering partial lines. The
+// reader lock is always released, even on an e: error line (which used to leak).
+async function streamServerRoute(
+	body: unknown,
+	onDelta: (fullContent: string) => void
+): Promise<string> {
+	const response = await fetch('/api/chat', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body)
+	});
+
+	if (!response.ok) {
+		const errBody = await response.json().catch(() => null);
+		throw new Error(errBody?.error || 'Failed to get response');
+	}
+
+	const reader = response.body?.getReader();
+	if (!reader) throw new Error('No response body');
+
+	const decoder = new TextDecoder();
+	let fullContent = '';
+	const processLine = (line: string) => {
+		if (line.startsWith('0:')) {
+			fullContent += JSON.parse(line.slice(2));
+			onDelta(fullContent);
+		} else if (line.startsWith('e:')) {
+			throw new Error(JSON.parse(line.slice(2)).error);
+		}
+	};
+
+	try {
+		let buffer = '';
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			buffer += decoder.decode(value, { stream: true });
+			const lines = buffer.split('\n');
+			buffer = lines.pop() || '';
+			for (const line of lines) processLine(line);
+		}
+		buffer += decoder.decode();
+		if (buffer) processLine(buffer);
+	} finally {
+		reader.releaseLock();
+	}
+
+	return fullContent;
+}
+
+/**
+ * Send a user message and run the full companion turn. Handles both transports
+ * (direct provider call on desktop/local, server route on web/cloud), post-turn
+ * state, keepsakes, TTS, and the talking animation. Errors surface via
+ * chatStore.setError; the returned promise always resolves.
+ */
+export async function sendCompanionMessage(
+	content: string,
+	images: PreparedImage[],
+	hooks: CompanionChatHooks
+): Promise<void> {
+	if ((!content.trim() && images.length === 0) || chatStore.isLoading) return;
+
+	if (!modulesStore.isModuleEnabled('consciousness')) {
+		chatStore.setError('Chat is disabled. Enable it in Settings > Character > AI Services.');
+		return;
+	}
+
+	const shown = images.map((img) => ({ id: img.id, url: URL.createObjectURL(img.blob) }));
+	chatStore.addMessage('user', content, shown.length ? shown : undefined);
+	hooks.onShownImages?.(shown);
+	chatStore.setLoading(true);
+	chatStore.setError(null);
+	hooks.setTyping(true);
+	hooks.setLatestResponse('');
+	hooks.beforeStream?.();
+
+	// Only touch relationship-time state once the character has loaded, or an
+	// early message would mutate the default state that load then discards.
+	if (characterStore.isReady) {
+		characterStore.updateStreak();
+		characterStore.updateDaysKnown();
+	}
+
+	try {
+		const consciousnessSettings = modulesStore.getModuleSettings('consciousness');
+		const provider = consciousnessSettings.activeProvider as string;
+		const model = consciousnessSettings.activeModel as string;
+		if (!provider) {
+			throw new Error('Please configure a provider in Settings > Modules > Consciousness');
+		}
+
+		const systemPrompt = await buildCompanionPrompt(content, images.length > 0);
+		const providerConfig = settingsStore.getProviderConfig(provider);
+		const apiKey = providerConfig.apiKey;
+		const providerMeta = getLLMProvider(provider);
+		if (providerMeta?.requiresApiKey && !apiKey) {
+			throw new Error(`Please configure API key for ${providerMeta.name} in Settings > Providers`);
+		}
+
+		chatStore.addMessage('assistant', '');
+		const selectedModel = model || providerMeta?.models?.[0]?.id || '';
+		const baseURL = providerConfig.baseUrl || providerMeta?.defaultBaseUrl;
+		const messages = buildMessages(images);
+		const onDelta = (full: string) => chatStore.updateLastMessage(full);
+
+		let fullContent = '';
+		if (isTauri() || providerMeta?.isLocal) {
+			// Desktop and local providers call the provider API directly.
+			await new Promise<void>((resolve, reject) => {
+				streamChatDirect(
+					{
+						messages,
+						provider: provider as LLMProvider,
+						model: selectedModel,
+						apiKey: apiKey || undefined,
+						baseURL,
+						systemPrompt
+					},
+					(text) => {
+						fullContent += text;
+						onDelta(fullContent);
+					},
+					(error) => reject(new Error(error)),
+					() => resolve()
+				);
+			});
+		} else {
+			// Cloud providers on web go through the SvelteKit server route.
+			fullContent = await streamServerRoute(
+				{
+					messages: messages.map((m) => ({ role: m.role, content: toOpenAIContent(m.content) })),
+					provider,
+					model: selectedModel,
+					apiKey: apiKey || 'not-needed',
+					baseURL,
+					systemPrompt
+				},
+				onDelta
+			);
+		}
+
+		hooks.setTyping(false);
+
+		const turn = await processCompanionTurn({
+			userMessage: content,
+			companionResponse: fullContent,
+			llm: {
+				provider,
+				model: selectedModel,
+				apiKey: apiKey || undefined,
+				baseURL,
+				hasImages: images.length > 0
+			},
+			debug: import.meta.env.DEV
+		});
+
+		hooks.onNewMemory?.(turn.newMemory);
+		if (turn.triggeredEvent) hooks.setActiveEvent(turn.triggeredEvent);
+
+		// She's seen the images and responded; keep them as local keepsakes.
+		if (images.length > 0) {
+			await Promise.all(
+				images.map((img) =>
+					keepImage(img.id, img.blob, { mimeType: img.mimeType, note: turn.newMemory })
+				)
+			);
+		}
+
+		chatStore.updateLastMessage(turn.dialogue);
+		hooks.setLatestResponse(turn.dialogue);
+
+		if (turn.dialogue) {
+			vrmStore.startTalking(turn.dialogue);
+
+			const speechState = modulesStore.getModuleState('speech');
+			const speechSettings = modulesStore.getModuleSettings('speech');
+			if (speechState?.enabled) {
+				const ttsProvider = speechSettings.activeProvider as TTSProvider;
+				const ttsConfig = settingsStore.getProviderConfig(ttsProvider);
+				const ttsMeta = getTTSProvider(ttsProvider);
+				ttsStore.speak(turn.dialogue, {
+					provider: ttsProvider,
+					apiKey: ttsConfig.apiKey,
+					voiceId: (speechSettings.activeVoiceId as string) || ttsConfig.voiceId,
+					model: (speechSettings.activeModel as string) || ttsConfig.modelId,
+					baseUrl: ttsConfig.baseUrl || ttsMeta?.defaultBaseUrl,
+					speed: (speechSettings.speed as number) ?? 1
+				});
+			}
+		}
+	} catch (err) {
+		chatStore.setError(err instanceof Error ? err.message : 'Unknown error');
+		hooks.setTyping(false);
+	} finally {
+		chatStore.setLoading(false);
+	}
+}

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -11,30 +11,23 @@
 	import MemoryGraphModal from '$lib/components/memory/MemoryGraphModal.svelte';
 	import { vrmStore } from '$lib/stores/vrm.svelte';
 	import { chatStore } from '$lib/stores/chat.svelte';
-	import { settingsStore } from '$lib/stores/settings.svelte';
 	import { modulesStore } from '$lib/stores/modules.svelte';
-	import { ttsStore } from '$lib/stores/tts.svelte';
 	import { characterStore } from '$lib/stores/character.svelte';
 	import { personaStore } from '$lib/stores/persona.svelte';
 	import { debugEventsStore } from '$lib/stores/debugEvents.svelte';
-	import { getLLMProvider, getTTSProvider, providerSupportsVision } from '$lib/services/providers/registry';
+	import { getLLMProvider, providerSupportsVision } from '$lib/services/providers/registry';
 	import { isLocalLLMProvider } from '$lib/services/providers/local-endpoints';
 	import { canShowImages } from '$lib/services/providers/vision';
-	import { streamChatDirect } from '$lib/services/chat/client-chat';
-	import { processCompanionTurn } from '$lib/services/chat/companion-turn';
-	import { keepImage, type PreparedImage } from '$lib/services/storage/keepsakes';
-	import { type ContentPart, toOpenAIContent } from '$lib/services/chat/content';
+	import { sendCompanionMessage } from '$lib/services/chat/companion-chat';
+	import { type PreparedImage } from '$lib/services/storage/keepsakes';
 	import { isTauri } from '$lib/services/platform';
 	import { browser } from '$app/environment';
-	import type { TTSProvider } from '$lib/types';
 	import type { StateUpdates } from '$lib/types/character';
 	import type { EventDefinition } from '$lib/types/events';
 	import { pop, fadeFast } from '$lib/utils/motion';
 
 	// V2 companion system imports
-	import { buildSystemPrompt, type PromptContext } from '$lib/ai/prompt-builder';
 	import {
-		retrieveRelevantContext,
 		hydrateWorkingMemory,
 		backfillEmbeddings,
 		getEmbeddingBackfillStatus
@@ -129,220 +122,15 @@
 	});
 
 
-	// Build system prompt
-	async function buildCompanionSystemPrompt(userMessage: string, hasImages = false): Promise<string> {
-		const state = characterStore.state;
-		const persona = personaStore.activeCard;
-
-		const memories = await retrieveRelevantContext(userMessage);
-
-		if (import.meta.env.DEV) {
-			console.log('%c[memory hydration]', 'color:#a855f7;font-weight:bold', {
-				relevantFacts: memories.relevantFacts.map((f) => f.content),
-				triggered: memories.triggeredMemories.map((m) => m.content),
-				recentTurns: memories.recentTurns.length
-			});
-		}
-
-		const context: PromptContext = {
-			persona,
-			state,
-			memories,
-			userMessage,
-			systemTime: new Date(),
-			hasImages
-		};
-
-		return buildSystemPrompt(context);
-	}
-
-	// Handle send message
+	// Send a message through the shared companion pipeline.
 	async function handleSend(content: string, images: PreparedImage[] = []) {
-		if ((!content.trim() && images.length === 0) || chatStore.isLoading) return;
-
-		// Check if chat is enabled
-		if (!modulesStore.isModuleEnabled('consciousness')) {
-			chatStore.setError('Chat is disabled. Enable it in Settings > Character > AI Services.');
-			return;
-		}
-
-		const shown = images.map((img) => ({ id: img.id, url: URL.createObjectURL(img.blob) }));
-		chatStore.addMessage('user', content, shown);
-		thinkingImages = shown;
-		chatStore.setLoading(true);
-		chatStore.setError(null);
-		isTyping = true;
-		latestResponse = '';
-
-		characterStore.updateStreak();
-		characterStore.updateDaysKnown();
-
-		try {
-			const consciousnessSettings = modulesStore.getModuleSettings('consciousness');
-			const provider = consciousnessSettings.activeProvider as string;
-			const model = consciousnessSettings.activeModel as string;
-
-			if (!provider) {
-				throw new Error('Please configure a provider in Settings > Modules > Consciousness');
-			}
-
-			const systemPrompt = await buildCompanionSystemPrompt(content, images.length > 0);
-			const providerConfig = settingsStore.getProviderConfig(provider);
-			const apiKey = providerConfig.apiKey;
-			const providerMeta = getLLMProvider(provider);
-
-			if (providerMeta?.requiresApiKey && !apiKey) {
-				throw new Error(`Please configure API key for ${providerMeta.name} in Settings > Providers`);
-			}
-
-			chatStore.addMessage('assistant', '');
-			let fullContent = '';
-			const selectedModel = model || providerMeta?.models?.[0]?.id || '';
-
-			const shouldUseDirectChat = isTauri() || !!providerMeta?.isLocal;
-
-			// The current turn carries the image bytes; prior turns stay text.
-			const history = chatStore.messages.slice(0, -1).filter((m) => m.content || m.images?.length);
-			const directMessages = history.map((m, idx) => {
-				const isCurrentTurn = idx === history.length - 1 && images.length > 0;
-				if (!isCurrentTurn) {
-					return { role: m.role as 'user' | 'assistant', content: m.content };
-				}
-				const parts: ContentPart[] = [];
-				if (m.content) parts.push({ type: 'text', text: m.content });
-				for (const img of images) {
-					parts.push({ type: 'image', mimeType: img.mimeType, data: img.base64 });
-				}
-				return { role: m.role as 'user' | 'assistant', content: parts };
-			});
-
-			if (shouldUseDirectChat) {
-				await new Promise<void>((resolve, reject) => {
-					streamChatDirect(
-						{
-							messages: directMessages,
-							provider: provider as import('$lib/types').LLMProvider,
-							model: selectedModel,
-							apiKey: apiKey || undefined,
-							baseURL: providerConfig.baseUrl || providerMeta?.defaultBaseUrl,
-							systemPrompt
-						},
-						(text) => { fullContent += text; chatStore.updateLastMessage(fullContent); },
-						(error) => reject(new Error(error)),
-						() => resolve()
-					);
-				});
-			} else {
-				const response = await fetch('/api/chat', {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({
-						messages: directMessages.map((m) => ({
-							role: m.role,
-							content: toOpenAIContent(m.content)
-						})),
-						provider,
-						model: selectedModel,
-						apiKey: apiKey || 'not-needed',
-						baseURL: providerConfig.baseUrl || providerMeta?.defaultBaseUrl,
-						systemPrompt
-					})
-				});
-
-				if (!response.ok) {
-					const errBody = await response.json().catch(() => null);
-					throw new Error(errBody?.error || 'Failed to get response');
-				}
-
-				const reader = response.body?.getReader();
-				const decoder = new TextDecoder();
-				if (!reader) throw new Error('No response body');
-
-				const processLine = (line: string) => {
-					if (line.startsWith('0:')) {
-						const text = JSON.parse(line.slice(2));
-						fullContent += text;
-						chatStore.updateLastMessage(fullContent);
-					} else if (line.startsWith('e:')) {
-						const { error } = JSON.parse(line.slice(2));
-						throw new Error(error);
-					}
-				};
-
-				// Buffer partial lines so a delta split across network chunks doesn't break JSON.parse
-				let streamBuffer = '';
-				while (true) {
-					const { done, value } = await reader.read();
-					if (done) break;
-
-					streamBuffer += decoder.decode(value, { stream: true });
-					const lines = streamBuffer.split('\n');
-					streamBuffer = lines.pop() || '';
-					for (const line of lines) {
-						processLine(line);
-					}
-				}
-				streamBuffer += decoder.decode();
-				if (streamBuffer) processLine(streamBuffer);
-			}
-
-			isTyping = false;
-			const turn = await processCompanionTurn({
-				userMessage: content,
-				companionResponse: fullContent,
-				llm: {
-					provider,
-					model: selectedModel,
-					apiKey: apiKey || undefined,
-					baseURL: providerConfig.baseUrl || providerMeta?.defaultBaseUrl,
-					hasImages: images.length > 0
-				},
-				debug: import.meta.env.DEV
-			});
-			const cleanedResponse = turn.dialogue;
-			lastNewMemory = turn.newMemory;
-			if (turn.triggeredEvent) activeEvent = turn.triggeredEvent;
-
-			// She's seen it and responded; keep the shown images as local keepsakes
-			if (images.length > 0) {
-				await Promise.all(
-					images.map((img) =>
-						keepImage(img.id, img.blob, { mimeType: img.mimeType, note: lastNewMemory })
-					)
-				);
-			}
-
-			chatStore.updateLastMessage(cleanedResponse);
-			latestResponse = cleanedResponse;
-
-			// Trigger talking animation based on response length
-			if (cleanedResponse) {
-				vrmStore.startTalking(cleanedResponse);
-			}
-
-			// TTS - speak if module is enabled
-			const speechState = modulesStore.getModuleState('speech');
-			const speechSettings = modulesStore.getModuleSettings('speech');
-			if (speechState?.enabled && cleanedResponse) {
-				const ttsProvider = speechSettings.activeProvider as TTSProvider;
-				const ttsConfig = settingsStore.getProviderConfig(ttsProvider);
-				const ttsMeta = getTTSProvider(ttsProvider);
-
-				ttsStore.speak(cleanedResponse, {
-					provider: ttsProvider,
-					apiKey: ttsConfig.apiKey,
-					voiceId: speechSettings.activeVoiceId as string || ttsConfig.voiceId,
-					model: speechSettings.activeModel as string || ttsConfig.modelId,
-					baseUrl: ttsConfig.baseUrl || ttsMeta?.defaultBaseUrl,
-					speed: speechSettings.speed as number ?? 1
-				});
-			}
-		} catch (err) {
-			chatStore.setError(err instanceof Error ? err.message : 'Unknown error');
-			isTyping = false;
-		} finally {
-			chatStore.setLoading(false);
-		}
+		await sendCompanionMessage(content, images, {
+			setTyping: (v) => (isTyping = v),
+			setLatestResponse: (v) => (latestResponse = v),
+			setActiveEvent: (e) => (activeEvent = e),
+			onShownImages: (shown) => (thinkingImages = shown),
+			onNewMemory: (m) => (lastNewMemory = m)
+		});
 	}
 
 	// Handle speech bubble hide

--- a/src/routes/overlay/+page.svelte
+++ b/src/routes/overlay/+page.svelte
@@ -21,18 +21,13 @@
 	import { personaStore } from '$lib/stores/persona.svelte';
 	import { overlayStore } from '$lib/stores/overlay.svelte';
 	import { isTauri, startDragging } from '$lib/services/platform';
-	import { getLLMProvider, getTTSProvider } from '$lib/services/providers/registry';
-	import { streamChatDirect } from '$lib/services/chat/client-chat';
-	import { processCompanionTurn } from '$lib/services/chat/companion-turn';
+	import { sendCompanionMessage } from '$lib/services/chat/companion-chat';
 	import { eventsApi } from '$lib/engine/events';
 	import { completionMarkers } from '$lib/engine/event-completion';
-	import type { TTSProvider } from '$lib/types';
 	import type { EventDefinition } from '$lib/types/events';
 	import type { StateUpdates } from '$lib/types/character';
 
-	import { buildSystemPrompt, type PromptContext } from '$lib/ai/prompt-builder';
 	import {
-		retrieveRelevantContext,
 		hydrateWorkingMemory,
 		backfillEmbeddings,
 		getEmbeddingBackfillStatus
@@ -207,180 +202,15 @@
 	}
 
 
-	async function buildCompanionSystemPrompt(userMessage: string): Promise<string> {
-		const state = characterStore.state;
-		const persona = personaStore.activeCard;
-		const memories = await retrieveRelevantContext(userMessage);
-
-		const context: PromptContext = {
-			persona,
-			state,
-			memories,
-			userMessage,
-			systemTime: new Date()
-		};
-
-		return buildSystemPrompt(context);
-	}
-
+	// Send a message through the shared companion pipeline. The overlay collapses
+	// its chat on send and has no image path.
 	async function handleSend(content: string) {
-		if (!content.trim() || chatStore.isLoading) return;
-
-		if (!modulesStore.isModuleEnabled('consciousness')) {
-			chatStore.setError('Chat is disabled. Enable it in Settings > Character > AI Services.');
-			return;
-		}
-
-		chatStore.addMessage('user', content);
-		chatStore.setLoading(true);
-		chatStore.setError(null);
-		isTyping = true;
-		latestResponse = '';
-
-		// Collapse chat after sending
-		overlayStore.setChatExpanded(false);
-
-		characterStore.updateStreak();
-		characterStore.updateDaysKnown();
-
-		try {
-			const consciousnessSettings = modulesStore.getModuleSettings('consciousness');
-			const provider = consciousnessSettings.activeProvider as string;
-			const model = consciousnessSettings.activeModel as string;
-
-			if (!provider) {
-				throw new Error('Please configure a provider in Settings > Modules > Consciousness');
-			}
-
-			const systemPrompt = await buildCompanionSystemPrompt(content);
-			const providerConfig = settingsStore.getProviderConfig(provider);
-			const apiKey = providerConfig.apiKey;
-			const providerMeta = getLLMProvider(provider);
-
-			if (providerMeta?.requiresApiKey && !apiKey) {
-				throw new Error(`Please configure API key for ${providerMeta.name} in Settings > Providers`);
-			}
-
-			chatStore.addMessage('assistant', '');
-			let fullContent = '';
-			const selectedModel = model || providerMeta?.models?.[0]?.id || '';
-
-			const shouldUseDirectChat = isTauri() || !!providerMeta?.isLocal;
-
-			if (shouldUseDirectChat) {
-				// Tauri and local providers call provider APIs directly.
-				await new Promise<void>((resolve, reject) => {
-					streamChatDirect(
-						{
-							messages: chatStore.messages.slice(0, -1).map((m) => ({ role: m.role as 'user' | 'assistant', content: m.content })),
-							provider: provider as import('$lib/types').LLMProvider,
-							model: selectedModel,
-							apiKey: apiKey || undefined,
-							baseURL: providerConfig.baseUrl || providerMeta?.defaultBaseUrl,
-							systemPrompt
-						},
-						(text) => { fullContent += text; chatStore.updateLastMessage(fullContent); },
-						(error) => reject(new Error(error)),
-						() => resolve()
-					);
-				});
-			} else {
-				// Cloud providers in web builds use the SvelteKit server route.
-				const response = await fetch('/api/chat', {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({
-						messages: chatStore.messages.slice(0, -1).filter((m) => m.content).map((m) => ({ role: m.role, content: m.content })),
-						provider,
-						model: selectedModel,
-						apiKey: apiKey || 'not-needed',
-						baseURL: providerConfig.baseUrl || providerMeta?.defaultBaseUrl,
-						systemPrompt
-					})
-				});
-
-				if (!response.ok) {
-					const errBody = await response.json().catch(() => null);
-					throw new Error(errBody?.error || 'Failed to get response');
-				}
-
-				const reader = response.body?.getReader();
-				const decoder = new TextDecoder();
-				if (!reader) throw new Error('No response body');
-
-				const processLine = (line: string) => {
-					if (line.startsWith('0:')) {
-						const text = JSON.parse(line.slice(2));
-						fullContent += text;
-						chatStore.updateLastMessage(fullContent);
-					} else if (line.startsWith('e:')) {
-						const { error } = JSON.parse(line.slice(2));
-						throw new Error(error);
-					}
-				};
-
-				// Buffer partial lines so a delta split across network chunks doesn't break JSON.parse
-				let streamBuffer = '';
-				while (true) {
-					const { done, value } = await reader.read();
-					if (done) break;
-
-					streamBuffer += decoder.decode(value, { stream: true });
-					const lines = streamBuffer.split('\n');
-					streamBuffer = lines.pop() || '';
-					for (const line of lines) {
-						processLine(line);
-					}
-				}
-				streamBuffer += decoder.decode();
-				if (streamBuffer) processLine(streamBuffer);
-			}
-
-			isTyping = false;
-			const turn = await processCompanionTurn({
-				userMessage: content,
-				companionResponse: fullContent,
-				llm: {
-					provider,
-					model: selectedModel,
-					apiKey: apiKey || undefined,
-					baseURL: providerConfig.baseUrl || providerMeta?.defaultBaseUrl,
-					hasImages: false
-				},
-				debug: import.meta.env.DEV
-			});
-			const cleanedResponse = turn.dialogue;
-			if (turn.triggeredEvent) activeEvent = turn.triggeredEvent;
-			chatStore.updateLastMessage(cleanedResponse);
-			latestResponse = cleanedResponse;
-
-			if (cleanedResponse) {
-				vrmStore.startTalking(cleanedResponse);
-			}
-
-			// TTS
-			const speechState = modulesStore.getModuleState('speech');
-			const speechSettings = modulesStore.getModuleSettings('speech');
-			if (speechState?.enabled && cleanedResponse) {
-				const ttsProvider = speechSettings.activeProvider as TTSProvider;
-				const ttsConfig = settingsStore.getProviderConfig(ttsProvider);
-				const ttsMeta = getTTSProvider(ttsProvider);
-
-				ttsStore.speak(cleanedResponse, {
-					provider: ttsProvider,
-					apiKey: ttsConfig.apiKey,
-					voiceId: speechSettings.activeVoiceId as string || ttsConfig.voiceId,
-					model: speechSettings.activeModel as string || ttsConfig.modelId,
-					baseUrl: ttsConfig.baseUrl || ttsMeta?.defaultBaseUrl,
-					speed: speechSettings.speed as number ?? 1
-				});
-			}
-		} catch (err) {
-			chatStore.setError(err instanceof Error ? err.message : 'Unknown error');
-			isTyping = false;
-		} finally {
-			chatStore.setLoading(false);
-		}
+		await sendCompanionMessage(content, [], {
+			setTyping: (v) => (isTyping = v),
+			setLatestResponse: (v) => (latestResponse = v),
+			setActiveEvent: (e) => (activeEvent = e),
+			beforeStream: () => overlayStore.setChatExpanded(false)
+		});
 	}
 
 	function handleBubbleHide() {


### PR DESCRIPTION
## What

ARCH-1 from the audit: the app and overlay pages each carried ~180 near-identical lines of the chat pipeline (`buildCompanionSystemPrompt` + `handleSend`), and they had **already drifted** — the overlay omitted the app's empty-message filter.

All of it now lives in one `sendCompanionMessage()` module: prompt building, both transports (direct provider call on desktop/local, server route on web/cloud), post-turn processing, keepsakes, TTS, and the talking animation. Each page's `handleSend` is a thin call passing hooks for its own reactive state (`setTyping`, `setLatestResponse`, `setActiveEvent`, plus `onShownImages`/`onNewMemory` for the app and `beforeStream` for the overlay's chat-collapse).

## Fixes folded into the consolidation

- **Empty-message filter** now applied consistently (the overlay used to send an empty assistant placeholder to the provider).
- **SSE reader leak**: the server-route reader lock is released in `finally`, even when an `e:` error line throws (previously abandoned).
- **isReady race**: relationship-time state (streak/daysKnown) only updates once the character has loaded, so an early message can't mutate the default state that load then discards.

Net ~330 lines of duplication removed; dead imports pruned from both pages.

## Testing

- 129/129 unit tests pass; lint clean.
- Live: **app chat via OpenAI** (server-route transport) and **overlay chat via local Ollama** (direct transport) both complete correctly — covering both pages and both branches through the shared module. Overlay reply rendered in the docked speech bubble.