### PR TITLE
perf: tidy 3D render-loop allocations and resource lifecycles

### DIFF
--- a/src/lib/components/vrm/Scene.svelte
+++ b/src/lib/components/vrm/Scene.svelte
@@ -100,19 +100,26 @@
 		isDarkMode ? SCENE_COLORS.dark.background : SCENE_COLORS.light.background
 	);
 
-	const floorMaterial = $derived.by(() => {
-		const theme = isDarkMode ? SCENE_COLORS.dark : SCENE_COLORS.light;
-		return new ShaderMaterial({
-			uniforms: {
-				uColor: { value: new Color(theme.floor) },
-				uOpacity: { value: 0.06 }
-			},
-			vertexShader: floorVertexShader,
-			fragmentShader: floorFragmentShader,
-			transparent: true,
-			depthWrite: false
-		});
+	// One material for the life of the scene; only its color uniform changes on
+	// theme toggle. Rebuilding it per toggle (the old $derived.by) orphaned a GPU
+	// shader program each time.
+	const floorMaterial = new ShaderMaterial({
+		uniforms: {
+			uColor: { value: new Color(SCENE_COLORS.light.floor) },
+			uOpacity: { value: 0.06 }
+		},
+		vertexShader: floorVertexShader,
+		fragmentShader: floorFragmentShader,
+		transparent: true,
+		depthWrite: false
 	});
+
+	$effect(() => {
+		const theme = isDarkMode ? SCENE_COLORS.dark : SCENE_COLORS.light;
+		(floorMaterial.uniforms.uColor.value as Color).set(theme.floor);
+	});
+
+	onMount(() => () => floorMaterial.dispose());
 
 	// --- Camera auto-fit ---
 	// Frames each model by its actual proportions: bottom of frame around the

--- a/src/lib/components/vrm/VrmModel.svelte
+++ b/src/lib/components/vrm/VrmModel.svelte
@@ -89,7 +89,7 @@
 	const { renderer, camera } = useThrelte();
 
 	// Generate thumbnail from the current 3D render
-	function generateThumbnail() {
+	function generateThumbnail(modelId: string | null) {
 		if (!renderer) return;
 
 		const canvas = renderer.domElement;
@@ -109,7 +109,7 @@
 			ctx.drawImage(canvas, srcX, srcY, srcSize, srcSize, 0, 0, size, size);
 
 			const thumbnailDataUrl = thumbCanvas.toDataURL('image/png');
-			vrmStore.setModelPreview(vrmStore.activeModelId, thumbnailDataUrl);
+			vrmStore.setModelPreview(modelId, thumbnailDataUrl);
 		}
 	}
 
@@ -460,6 +460,10 @@
 	$effect(() => {
 		if (!url) return;
 
+		// Capture the model this load belongs to, so a fast switch can't save this
+		// render under a different model's id.
+		const loadModelId = vrmStore.activeModelId;
+
 		// Invalidate this load if the URL changes or the component unmounts
 		// before the loader finishes, so a slow load can't clobber a newer one
 		let cancelled = false;
@@ -552,15 +556,15 @@
 						if (ctx) {
 							ctx.drawImage(thumbnailImage as CanvasImageSource, 0, 0);
 							const thumbnailDataUrl = canvas.toDataURL('image/png');
-							vrmStore.setModelPreview(vrmStore.activeModelId, thumbnailDataUrl);
+							vrmStore.setModelPreview(loadModelId, thumbnailDataUrl);
 						}
 					} catch (e) {
 						console.error('Failed to extract thumbnail:', e);
-						setTimeout(() => generateThumbnail(), 500);
+						setTimeout(() => generateThumbnail(loadModelId), 500);
 					}
 				} else {
 					// No embedded thumbnail - generate one from the 3D render
-					setTimeout(() => generateThumbnail(), 500);
+					setTimeout(() => generateThumbnail(loadModelId), 500);
 				}
 
 			},
@@ -587,6 +591,14 @@
 				talkingClip = null;
 				emoteAction = null;
 			}
+			// If an emote was mid-play, its 'finished' handler (bound to the old
+			// mixer) never runs, so reset the flags it would have cleared —
+			// otherwise currentAnimation stays stale and the next model can
+			// immediately replay the leftover emote.
+			if (isEmotePlaying) {
+				isEmotePlaying = false;
+				vrmStore.setCurrentAnimation(null);
+			}
 			if (vrm) {
 				// Frees geometries, materials, and textures (manual traverse missed textures)
 				VRMUtils.deepDispose(vrm.scene);
@@ -596,6 +608,11 @@
 			}
 		};
 	});
+
+	// Scratch vectors reused every frame — allocating three Vector3s per frame
+	// (~180/sec) was needless GC pressure in the render loop.
+	const scratchWorld = new THREE.Vector3();
+	const scratchProjected = new THREE.Vector3();
 
 	// Update VRM each frame
 	useTask((delta) => {
@@ -610,16 +627,16 @@
 		// Track head position for 3D speech bubble
 		const headBone = vrm.humanoid.getNormalizedBoneNode('head');
 		if (headBone && camera.current) {
-			const worldPos = headBone.getWorldPosition(new THREE.Vector3());
+			headBone.getWorldPosition(scratchWorld);
 			// Offset above and slightly in front of head
-			const offsetPos = new THREE.Vector3(worldPos.x, worldPos.y + 0.25, worldPos.z + 0.1);
-			vrmStore.setHeadPosition([offsetPos.x, offsetPos.y, offsetPos.z]);
+			scratchProjected.set(scratchWorld.x, scratchWorld.y + 0.25, scratchWorld.z + 0.1);
+			vrmStore.setHeadPosition([scratchProjected.x, scratchProjected.y, scratchProjected.z]);
 
-			// Project to screen coordinates
-			const screenPos = offsetPos.clone().project(camera.current);
+			// Project to screen coordinates (in place)
+			scratchProjected.project(camera.current);
 			// Convert from NDC (-1 to 1) to screen percentage (0 to 100)
-			const x = (screenPos.x + 1) * 50;
-			const y = (-screenPos.y + 1) * 50;
+			const x = (scratchProjected.x + 1) * 50;
+			const y = (-scratchProjected.y + 1) * 50;
 			vrmStore.setHeadScreenPosition({ x, y });
 		}
 

--- a/src/lib/stores/vrm.svelte.ts
+++ b/src/lib/stores/vrm.svelte.ts
@@ -270,11 +270,22 @@ function createVrmStore() {
 		}
 	}
 
+	// These run every frame from the render loop. Skip the reactive write when the
+	// value hasn't meaningfully moved, so a near-still model doesn't churn every
+	// $derived bound to head position 60×/sec.
 	function setHeadPosition(pos: [number, number, number]) {
+		const p = headPosition;
+		if (Math.abs(p[0] - pos[0]) < 0.001 && Math.abs(p[1] - pos[1]) < 0.001 && Math.abs(p[2] - pos[2]) < 0.001) {
+			return;
+		}
 		headPosition = pos;
 	}
 
 	function setHeadScreenPosition(pos: { x: number; y: number } | null) {
+		const p = headScreenPosition;
+		if (pos && p && Math.abs(p.x - pos.x) < 0.05 && Math.abs(p.y - pos.y) < 0.05) {
+			return;
+		}
 		headScreenPosition = pos;
 	}
 

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -18,6 +18,7 @@
 	import { getLLMProvider, providerSupportsVision } from '$lib/services/providers/registry';
 	import { isLocalLLMProvider } from '$lib/services/providers/local-endpoints';
 	import { canShowImages } from '$lib/services/providers/vision';
+	import { onDestroy } from 'svelte';
 	import { sendCompanionMessage } from '$lib/services/chat/companion-chat';
 	import { type PreparedImage } from '$lib/services/storage/keepsakes';
 	import { isTauri } from '$lib/services/platform';
@@ -119,6 +120,16 @@
 		if (debugEvent) {
 			activeEvent = debugEvent;
 		}
+	});
+
+	// Shown-image previews are blob: URLs (shared between the chat history and the
+	// thinking overlay). Free them all when leaving the app so a long session's
+	// images don't linger in memory.
+	onDestroy(() => {
+		for (const m of chatStore.messages) {
+			for (const img of m.images ?? []) URL.revokeObjectURL(img.url);
+		}
+		for (const img of thinkingImages) URL.revokeObjectURL(img.url);
 	});
 
 


### PR DESCRIPTION
## What

The 3D resource/perf items from the audit.

- **Render-loop allocations**: the per-frame head-tracking task allocated three `Vector3`s every frame (~180/sec). Now reuses two scratch vectors.
- **Reactive churn**: head position/screen-position writes are skipped when the value hasn't meaningfully moved, so a near-still model doesn't invalidate every bound `$derived` 60×/sec.
- **ShaderMaterial leak**: the floor material was rebuilt via `$derived.by` on every theme toggle, orphaning a GPU shader program each time. Now built once, with only its color uniform updated on toggle, and disposed on unmount.
- **Stale emote on model switch**: switching models mid-emote left the emote's `finished` handler bound to the dead mixer, so `isEmotePlaying`/`currentAnimation` never cleared and the next model could replay the leftover. Now reset in the load-effect cleanup.
- **Thumbnail race**: `generateThumbnail` read `vrmStore.activeModelId` at call time (500ms after load), so a fast switch could save one model's render under another's id. The loading model's id is now captured and threaded through.
- **Blob URL leak**: shown-image `blob:` URLs are revoked when leaving the app.

## Testing

- 129/129 unit tests pass; lint/typecheck clean.
- Live: app renders and animates; sent a chat (head-tracked bubble); toggled theme repeatedly (floor material); switched models (Victoria loaded cleanly, exercising the emote-cleanup + thumbnail-id paths). No WebGL/dispose/3D errors in console.