### PR TITLE
fix: announce toast to screen readers and dedupe model fetches

### DIFF
--- a/src/lib/components/chat/BottomChatBar.svelte
+++ b/src/lib/components/chat/BottomChatBar.svelte
@@ -309,7 +309,12 @@
 {/if}
 
 {#if hint}
-	<div class="vision-hint" out:pop={{ base: 'translateX(-50%)', y: -10, duration: 200 }}>
+	<div
+		class="vision-hint"
+		role="status"
+		aria-live="polite"
+		out:pop={{ base: 'translateX(-50%)', y: -10, duration: 200 }}
+	>
 		<Icon name="camera" size={16} />
 		<span>{hint}</span>
 	</div>
@@ -518,6 +523,12 @@
 		animation: hintDrop 0.35s cubic-bezier(0.16, 1, 0.3, 1) both;
 	}
 	.privacy-notice :global(svg) { flex-shrink: 0; opacity: 0.65; }
+	@media (prefers-reduced-motion: reduce) {
+		.vision-hint,
+		.privacy-notice {
+			animation: none;
+		}
+	}
 	.privacy-ack {
 		flex-shrink: 0;
 		border: none;

--- a/src/lib/services/providers/model-fetcher.ts
+++ b/src/lib/services/providers/model-fetcher.ts
@@ -15,7 +15,28 @@ export interface FetchModelsResult {
 
 const FETCH_TIMEOUT_MS = 10000;
 
-export async function fetchProviderModels(
+// Collapse concurrent identical requests into one. Reactive effects and repeated
+// mounts (e.g. the settings and onboarding model pickers) can fire the same
+// fetch several times in a tick; without this each one hit the provider.
+const inFlight = new Map<string, Promise<FetchModelsResult>>();
+
+export function fetchProviderModels(
+	providerId: string,
+	apiKey: string,
+	baseUrl?: string
+): Promise<FetchModelsResult> {
+	const key = `${providerId}|${baseUrl ?? ''}|${apiKey}`;
+	const existing = inFlight.get(key);
+	if (existing) return existing;
+
+	const request = fetchProviderModelsUncached(providerId, apiKey, baseUrl).finally(() =>
+		inFlight.delete(key)
+	);
+	inFlight.set(key, request);
+	return request;
+}
+
+async function fetchProviderModelsUncached(
 	providerId: string,
 	apiKey: string,
 	baseUrl?: string


### PR DESCRIPTION
## What

The clean, verifiable items from the polish list.

- **Toast a11y**: the image-issue hint rendered with no ARIA role, so screen readers never announced it. Added `role=status` + `aria-live=polite`, and a `prefers-reduced-motion` guard on its entrance animation (and the privacy notice's). Safe-area insets were already handled.
- **Model-fetch dedup**: `fetchProviderModels` did no coalescing, so reactive effects and repeated mounts of the settings/onboarding model pickers fired the same request several times per tick, each hitting the provider. Concurrent identical requests now share one in-flight promise, re-armed after it settles (including on error).

## Testing

- 129/129 unit tests pass; lint/typecheck clean.
- Live: fired 3 concurrent identical `fetchProviderModels` calls → **1 network request**, all three resolving to the same promise.

## Deliberately deferred (not silently dropped)

A few items from the audit's lower-severity list I chose not to bundle here, with reasons:
- **Message-impact floor bias** (base `affectionDelta = 1`): this is a dating-sim relationship-balance tuning decision, not a correctness bug — worth your product call rather than a unilateral retune.
- **TTS pitch/volume + response cache, ElevenLabs specifics**: these touch the audio pipeline, which I can't exercise end-to-end without a running TTS server; I'd rather not ship audio changes I can't verify.
- **Time-decay write amplification**: already handled — `resolveTimeDecayOnLoad` gates on `lastDecayAt` and returns a `changed` flag so the caller only persists when something actually changed.