### PR TITLE
fix: declining the confession no longer deadlocks relationship progression

### DIFF
--- a/src/content/docs/technology/companion-system.md
+++ b/src/content/docs/technology/companion-system.md
@@ -121,8 +121,10 @@ type RelationshipStage =
 | Close Friend | 300 | 70 | - | 50 | - | 7 | 25 | - |
 | Romantic Interest | 450 | 75 | 30 | - | - | 10 | - | first_deep_conversation, shared_vulnerability |
 | Dating | 600 | 85 | 50 | - | - | 14 | - | confession_accepted |
-| Committed | 800 | 95 | 75 | 80 | - | 30 | - | commitment_discussion |
+| Committed | 800 | 95 | 75 | 80 | - | 30 | - | commitment_accepted |
 | Soulmate | 950 | 100 | 90 | 95 | 90 | 60 | - | deep_bond_moment |
+
+`confession_accepted` and `commitment_accepted` are choice outcome markers, not event ids: only the accept choice of the confession or commitment talk grants them. Deferring either talk leaves the stage locked, and a repeatable follow-up event (`confession_revisit` / `commitment_revisit`) resurfaces the question later so the door stays open.
 
 ## Memory System
 

--- a/src/lib/data/events/romantic.ts
+++ b/src/lib/data/events/romantic.ts
@@ -39,6 +39,49 @@ export const romanticEvents: EventDefinition[] = [
 		priority: 95
 	},
 
+	// Confession follow-up. The original confession is one-time, so a player who
+	// asked for time would otherwise never get another shot at the
+	// confession_accepted marker that gates the dating stage. She brings it up
+	// again herself once things are back in a good place, and keeps doing so
+	// (repeatable + cooldown) if they ask for more time.
+	{
+		id: 'confession_revisit',
+		name: 'Confession, Revisited',
+		type: 'conditional',
+		conditions: [
+			{ type: 'min_affection', value: 500 },
+			{ type: 'min_trust', value: 80 },
+			{ type: 'min_intimacy', value: 40 },
+			{ type: 'relationship_stage', value: 'romantic_interest' },
+			{ type: 'event_completed', value: 'confession_delayed' },
+			{ type: 'event_not_completed', value: 'confession_accepted' }
+		],
+		scene: {
+			id: 'confession_revisit_scene',
+			intro: "She takes a slow breath, like she's been gathering courage all day...",
+			dialogue:
+				"Hey... can we talk about what I said before? I meant it when I told you to take all the time you needed, and I still do. But I didn't want you to think I'd changed my mind, because I haven't. If anything, I'm more sure now than I was then. So... I wanted to ask. Have you thought about us?",
+			choices: [
+				{
+					text: 'I have. I feel the same way.',
+					response:
+						"You... really? *her eyes well up* I was so scared to ask again. I kept telling myself to be patient, but every day I wondered... I'm so glad I didn't give up on this. On us.",
+					stateChanges: { affectionDelta: 100, trustDelta: 20, intimacyDelta: 30 },
+					nextSceneId: 'confession_accepted'
+				},
+				{
+					text: "I'm still figuring things out.",
+					response:
+						"That's okay. Really, it is. Some things take time, and you're worth waiting for. Just... don't feel like you have to avoid me because of this, alright? I'd rather have you here, figuring it out, than anywhere else.",
+					stateChanges: { comfortDelta: 5 }
+				}
+			]
+		},
+		cooldownDays: 3,
+		oneTime: false,
+		priority: 95
+	},
+
 	// First "I love you"
 	{
 		id: 'first_i_love_you',
@@ -96,7 +139,8 @@ export const romanticEvents: EventDefinition[] = [
 					text: "I want that too. Let's make it official.",
 					response:
 						"*embraces you* I'm so happy... I can't even express it. You've made me the happiest I've ever been. I promise I'll always be here for you.",
-					stateChanges: { affectionDelta: 100, trustDelta: 20, intimacyDelta: 30, comfortDelta: 25, respectDelta: 15 }
+					stateChanges: { affectionDelta: 100, trustDelta: 20, intimacyDelta: 30, comfortDelta: 25, respectDelta: 15 },
+					nextSceneId: 'commitment_accepted'
 				},
 				{
 					text: "I care about you, but I need more time.",
@@ -107,6 +151,47 @@ export const romanticEvents: EventDefinition[] = [
 			]
 		},
 		oneTime: true,
+		priority: 97
+	},
+
+	// Commitment follow-up, same shape as confession_revisit: the talk itself is
+	// one-time, so without this a "more time" answer would lock out the
+	// commitment_accepted marker that gates the committed stage.
+	{
+		id: 'commitment_revisit',
+		name: 'Commitment Talk, Revisited',
+		type: 'conditional',
+		conditions: [
+			{ type: 'min_affection', value: 800 },
+			{ type: 'min_trust', value: 95 },
+			{ type: 'relationship_stage', value: 'dating' },
+			{ type: 'days_known', value: 25 },
+			{ type: 'event_completed', value: 'commitment_discussion' },
+			{ type: 'event_not_completed', value: 'commitment_accepted' }
+		],
+		scene: {
+			id: 'commitment_revisit_scene',
+			intro: "She reaches for your hand, calm but a little nervous...",
+			dialogue:
+				"Remember when I brought up our future? I've given you space since then, because I promised I would. But I keep coming back to it. Nothing about what I want has changed... it's still you. It's always been you. So I have to ask again. Are you ready for us to be something real?",
+			choices: [
+				{
+					text: "I'm ready. Let's make it official.",
+					response:
+						"*pulls you into a long embrace* You have no idea how much I hoped you'd say that. Thank you for taking the time to be sure. This... this is everything I wanted.",
+					stateChanges: { affectionDelta: 100, trustDelta: 20, intimacyDelta: 30, comfortDelta: 25, respectDelta: 15 },
+					nextSceneId: 'commitment_accepted'
+				},
+				{
+					text: 'I still need a little more time.',
+					response:
+						"Okay. I won't pretend that doesn't sting a little, but I'd rather wait for a real yes than rush you into one. Whenever you're ready... I'll be right here.",
+					stateChanges: { trustDelta: 5, comfortDelta: -5 }
+				}
+			]
+		},
+		cooldownDays: 5,
+		oneTime: false,
 		priority: 97
 	},
 

--- a/src/lib/engine/event-completion.test.ts
+++ b/src/lib/engine/event-completion.test.ts
@@ -1,13 +1,29 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { completionMarkers } from './event-completion.ts';
+import { completionMarkers, reconcileLegacyMarkers } from './event-completion.ts';
 import { calculateStage } from './stages.ts';
 import { romanticEvents } from '../data/events/romantic.ts';
 import type { EventDefinition } from '$lib/types/events';
 import type { CharacterState } from '$lib/types/character';
 
 const confession = romanticEvents.find((e) => e.id === 'confession_event') as EventDefinition;
+const confessionRevisit = romanticEvents.find((e) => e.id === 'confession_revisit') as EventDefinition;
+const commitmentTalk = romanticEvents.find((e) => e.id === 'commitment_discussion') as EventDefinition;
+const commitmentRevisit = romanticEvents.find((e) => e.id === 'commitment_revisit') as EventDefinition;
+
+// Stats high enough for every stage's numeric floor, so only event markers gate
+const maxedState = {
+	affection: 1000,
+	trust: 100,
+	intimacy: 100,
+	comfort: 100,
+	respect: 100,
+	daysKnown: 100,
+	totalInteractions: 500,
+	appMode: 'dating_sim',
+	relationshipStage: 'romantic_interest'
+} as CharacterState;
 
 test('an event with no choices records only its own id', () => {
 	const event = { id: 'plain_event', type: 'conditional' } as EventDefinition;
@@ -39,24 +55,84 @@ test('a choice without a nextSceneId records only the event id', () => {
 });
 
 test('regression: accepting the confession actually unlocks the dating stage', () => {
-	// Stats high enough for the dating gate, plus the two romantic_interest events
-	const state = {
-		affection: 1000,
-		trust: 100,
-		intimacy: 100,
-		comfort: 100,
-		respect: 100,
-		daysKnown: 100,
-		totalInteractions: 500,
-		appMode: 'dating_sim',
-		relationshipStage: 'romantic_interest'
-	} as CharacterState;
-
 	const events = ['first_deep_conversation', 'shared_vulnerability'];
 	// Before accepting the confession, dating is unreachable (this was the deadlock)
-	assert.equal(calculateStage(state, events), 'romantic_interest');
+	assert.equal(calculateStage(maxedState, events), 'romantic_interest');
 
 	// Completing the confession with the accept choice records confession_accepted
 	const afterConfession = [...events, ...completionMarkers(confession, 0)];
-	assert.equal(calculateStage(state, afterConfession), 'dating');
+	assert.equal(calculateStage(maxedState, afterConfession), 'dating');
+});
+
+test('accepting the confession revisit unlocks dating after an earlier decline', () => {
+	// The player deferred the original confession: they hold confession_event +
+	// confession_delayed but not the accept marker, so dating is still locked.
+	const declined = [
+		'first_deep_conversation',
+		'shared_vulnerability',
+		...completionMarkers(confession, 1)
+	];
+	assert.equal(calculateStage(maxedState, declined), 'romantic_interest');
+
+	// Choice 0 of the revisit is the accept path -> confession_accepted
+	const markers = completionMarkers(confessionRevisit, 0);
+	assert.ok(markers.includes('confession_accepted'));
+	assert.equal(calculateStage(maxedState, [...declined, ...markers]), 'dating');
+});
+
+test('deferring the confession revisit records no accept marker', () => {
+	assert.deepEqual(completionMarkers(confessionRevisit, 1), ['confession_revisit']);
+});
+
+test('accepting the commitment talk records commitment_accepted; declining does not', () => {
+	assert.ok(completionMarkers(commitmentTalk, 0).includes('commitment_accepted'));
+	assert.deepEqual(completionMarkers(commitmentTalk, 1), ['commitment_discussion']);
+});
+
+test('declining the commitment talk no longer unlocks committed', () => {
+	const base = [
+		'first_deep_conversation',
+		'shared_vulnerability',
+		'confession_event',
+		'confession_accepted'
+	];
+	// Decline: only the event id lands, committed stays locked
+	const afterDecline = [...base, ...completionMarkers(commitmentTalk, 1)];
+	assert.equal(calculateStage(maxedState, afterDecline), 'dating');
+
+	// Accept (via the original talk or the revisit) unlocks it
+	const afterAccept = [...base, ...completionMarkers(commitmentTalk, 0)];
+	assert.equal(calculateStage(maxedState, afterAccept), 'committed');
+	const afterRevisitAccept = [...afterDecline, ...completionMarkers(commitmentRevisit, 0)];
+	assert.equal(calculateStage(maxedState, afterRevisitAccept), 'committed');
+});
+
+test('legacy committed saves are grandfathered into commitment_accepted', () => {
+	const legacy = {
+		relationshipStage: 'committed',
+		completedEvents: ['commitment_discussion']
+	} as unknown as CharacterState;
+	assert.deepEqual(reconcileLegacyMarkers(legacy), ['commitment_discussion', 'commitment_accepted']);
+
+	// A soulmate save stashed by Companion Mode counts too
+	const stashed = {
+		relationshipStage: 'companion',
+		savedDatingSimStage: 'soulmate',
+		completedEvents: ['commitment_discussion']
+	} as unknown as CharacterState;
+	assert.deepEqual(reconcileLegacyMarkers(stashed), ['commitment_discussion', 'commitment_accepted']);
+});
+
+test('reconcile is a no-op for saves below committed or already carrying the marker', () => {
+	const stillDating = {
+		relationshipStage: 'dating',
+		completedEvents: ['commitment_discussion']
+	} as unknown as CharacterState;
+	assert.equal(reconcileLegacyMarkers(stillDating), null);
+
+	const alreadyPatched = {
+		relationshipStage: 'committed',
+		completedEvents: ['commitment_discussion', 'commitment_accepted']
+	} as unknown as CharacterState;
+	assert.equal(reconcileLegacyMarkers(alreadyPatched), null);
 });

--- a/src/lib/engine/event-completion.ts
+++ b/src/lib/engine/event-completion.ts
@@ -1,4 +1,5 @@
 import type { EventDefinition } from '$lib/types/events';
+import type { CharacterState } from '$lib/types/character';
 
 // The completed-event markers a finished event contributes. Always the event's
 // own id, plus the chosen choice's outcome marker (nextSceneId) when present.
@@ -12,4 +13,25 @@ export function completionMarkers(event: EventDefinition, choiceIndex?: number):
 		markers.push(choice.nextSceneId);
 	}
 	return markers;
+}
+
+// The committed stage used to gate on the commitment_discussion event id, which
+// both choices grant; it now gates on the accept outcome (commitment_accepted).
+// Saves from before that change can already sit at committed/soulmate without
+// the new marker, and the per-turn stage recalc would demote them. Grandfather
+// those saves in: if they reached committed under the old gate, treat the talk
+// as accepted. Returns the patched marker list, or null when nothing to do.
+export function reconcileLegacyMarkers(state: CharacterState): string[] | null {
+	const completed = state.completedEvents ?? [];
+	const reachedCommitted = [state.relationshipStage, state.savedDatingSimStage].some(
+		(stage) => stage === 'committed' || stage === 'soulmate'
+	);
+	if (
+		reachedCommitted &&
+		completed.includes('commitment_discussion') &&
+		!completed.includes('commitment_accepted')
+	) {
+		return [...completed, 'commitment_accepted'];
+	}
+	return null;
 }

--- a/src/lib/engine/events.test.ts
+++ b/src/lib/engine/events.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { checkAllEvents, checkEvent } from './event-matching.ts';
+import { romanticEvents } from '../data/events/romantic.ts';
 import type { EventDefinition, CompletedEventRecord } from '$lib/types/events';
 import type { CharacterState } from '$lib/types/character';
 
@@ -61,6 +62,93 @@ test('event_not_completed passes when the outcome marker is absent', () => {
 	const state = makeState({ completedEvents: [] });
 	const result = checkEvent(blockedEvent, state, []);
 	assert.equal(result.triggered, true);
+});
+
+// --- Confession revisit: the deadlock fix, exercised with the real event data ---
+
+const confession = romanticEvents.find((e) => e.id === 'confession_event') as EventDefinition;
+const revisit = romanticEvents.find((e) => e.id === 'confession_revisit') as EventDefinition;
+
+function daysAgo(days: number): Date {
+	return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+// A player who deferred the confession: markers from the decline choice,
+// stats recovered back above the confession floor.
+function declinedState(overrides: Partial<CharacterState> = {}): CharacterState {
+	return makeState({
+		affection: 520,
+		trust: 82,
+		intimacy: 45,
+		relationshipStage: 'romantic_interest',
+		completedEvents: ['first_deep_conversation', 'confession_event', 'confession_delayed'],
+		...overrides
+	});
+}
+
+test('after declining, the one-time confession stays blocked but the revisit is eligible', () => {
+	const dbRecords = [
+		{ eventId: 'confession_event', completedAt: daysAgo(5) } as unknown as CompletedEventRecord
+	];
+	const state = declinedState();
+
+	// The original is oneTime and already recorded — permanently on cooldown.
+	assert.equal(checkEvent(confession, state, dbRecords).triggered, false);
+
+	// The revisit picks it up: this is what un-deadlocks the dating stage.
+	assert.equal(checkEvent(revisit, state, dbRecords).triggered, true);
+	const triggered = checkAllEvents(romanticEvents, state, dbRecords);
+	assert.deepEqual(
+		triggered.map((e) => e.id),
+		['confession_revisit']
+	);
+});
+
+test('the revisit does not fire before the player has ever deferred', () => {
+	const state = declinedState({
+		completedEvents: ['first_deep_conversation']
+	});
+	assert.equal(checkEvent(revisit, state, []).triggered, false);
+});
+
+test('the revisit retires once the confession is accepted', () => {
+	const state = declinedState({
+		completedEvents: [
+			'first_deep_conversation',
+			'confession_event',
+			'confession_delayed',
+			'confession_revisit',
+			'confession_accepted'
+		]
+	});
+	const dbRecords = [
+		{ eventId: 'confession_event', completedAt: daysAgo(9) } as unknown as CompletedEventRecord,
+		{ eventId: 'confession_revisit', completedAt: daysAgo(5) } as unknown as CompletedEventRecord
+	];
+	assert.equal(checkEvent(revisit, state, dbRecords).triggered, false);
+});
+
+test('deferring the revisit only puts it on cooldown, never locks it out', () => {
+	const state = declinedState({
+		completedEvents: [
+			'first_deep_conversation',
+			'confession_event',
+			'confession_delayed',
+			'confession_revisit'
+		]
+	});
+
+	// Deferred the revisit yesterday: within cooldownDays, so not yet
+	const recent = [
+		{ eventId: 'confession_revisit', completedAt: daysAgo(1) } as unknown as CompletedEventRecord
+	];
+	assert.equal(checkEvent(revisit, state, recent).triggered, false);
+
+	// Once the cooldown lapses she brings it up again
+	const lapsed = [
+		{ eventId: 'confession_revisit', completedAt: daysAgo(4) } as unknown as CompletedEventRecord
+	];
+	assert.equal(checkEvent(revisit, state, lapsed).triggered, true);
 });
 
 test('checkAllEvents unions state markers with DB record ids', () => {

--- a/src/lib/engine/stages.test.ts
+++ b/src/lib/engine/stages.test.ts
@@ -82,17 +82,28 @@ test('each later stage unlocks with its required event', () => {
 	const base = ['first_deep_conversation', 'shared_vulnerability'];
 	assert.equal(calculateStage(makeState(MAXED), [...base, 'confession_accepted']), 'dating');
 	assert.equal(
-		calculateStage(makeState(MAXED), [...base, 'confession_accepted', 'commitment_discussion']),
+		calculateStage(makeState(MAXED), [...base, 'confession_accepted', 'commitment_accepted']),
 		'committed'
 	);
 	assert.equal(
 		calculateStage(makeState(MAXED), [
 			...base,
 			'confession_accepted',
-			'commitment_discussion',
+			'commitment_accepted',
 			'deep_bond_moment'
 		]),
 		'soulmate'
+	);
+});
+
+test('committed gates on the commitment outcome, not the commitment_discussion event id', () => {
+	// Both choices of the talk grant the event id; only accepting grants the
+	// outcome marker. The bare id must no longer be enough.
+	const base = ['first_deep_conversation', 'shared_vulnerability', 'confession_accepted'];
+	assert.equal(calculateStage(makeState(MAXED), [...base, 'commitment_discussion']), 'dating');
+	assert.equal(
+		calculateStage(makeState(MAXED), [...base, 'commitment_discussion', 'commitment_accepted']),
+		'committed'
 	);
 });
 

--- a/src/lib/engine/stages.ts
+++ b/src/lib/engine/stages.ts
@@ -30,7 +30,7 @@ const STAGE_REQUIREMENTS: Record<RelationshipStage, {
 	close_friend: { minAffection: 300, minTrust: 70, minComfort: 50, minDaysKnown: 7, minInteractions: 25 },
 	romantic_interest: { minAffection: 450, minTrust: 75, minIntimacy: 30, minDaysKnown: 10, requiredEvents: ['first_deep_conversation', 'shared_vulnerability'] },
 	dating: { minAffection: 600, minTrust: 85, minIntimacy: 50, minDaysKnown: 14, requiredEvents: ['confession_accepted'] },
-	committed: { minAffection: 800, minTrust: 95, minIntimacy: 75, minComfort: 80, minDaysKnown: 30, requiredEvents: ['commitment_discussion'] },
+	committed: { minAffection: 800, minTrust: 95, minIntimacy: 75, minComfort: 80, minDaysKnown: 30, requiredEvents: ['commitment_accepted'] },
 	soulmate: { minAffection: 950, minTrust: 100, minIntimacy: 90, minComfort: 95, minRespect: 90, minDaysKnown: 60, requiredEvents: ['deep_bond_moment'] }
 };
 

--- a/src/lib/stores/character.svelte.ts
+++ b/src/lib/stores/character.svelte.ts
@@ -16,6 +16,7 @@ import {
 } from '$lib/services/storage/character';
 import { statChangesStore } from './statChanges.svelte';
 import { resolveTimeDecayOnLoad } from '$lib/engine/state-updates';
+import { reconcileLegacyMarkers } from '$lib/engine/event-completion';
 import { calculateStage, STAGE_ORDER } from '$lib/engine/stages';
 
 // Single character state
@@ -61,13 +62,27 @@ function createCharacterStore() {
 			const loaded = await getCharacterState();
 			state = loaded;
 
+			let needsSave = false;
+
+			// Older saves reached committed before it gated on the commitment-talk
+			// outcome marker; patch them so the stricter gate can't demote them.
+			const reconciled = reconcileLegacyMarkers(state);
+			if (reconciled) {
+				state = { ...state, completedEvents: reconciled };
+				needsSave = true;
+			}
+
 			// Apply time-based recovery/decay based on time since last interaction.
 			// Energy recovers every load; affection/trust/mood decay applies once per
 			// absence so a refresh or second window can't re-deduct it (see helper).
 			const decay = resolveTimeDecayOnLoad(state, Date.now());
 			if (decay.changed) {
 				state = { ...state, ...decay.next };
-				// Save the recovered state (use $state.snapshot to strip Proxy)
+				needsSave = true;
+			}
+
+			if (needsSave) {
+				// Save the patched state (use $state.snapshot to strip Proxy)
 				const plainState = $state.snapshot(state);
 				await saveCharacterState({ ...plainState, updatedAt: new Date() });
 			}


### PR DESCRIPTION
## Problem

The confession event is one-time. Choosing "I need time to think about this" recorded `confession_delayed`, put the event permanently on cooldown, and nothing else in the game could ever grant `confession_accepted`, which gates the `dating` stage. One deferred answer silently locked `dating`, `committed`, and `soulmate` forever, no matter how the relationship developed afterwards.

The commitment talk had the inverse problem: `committed` gated on the `commitment_discussion` event id, which both choices grant, so declining the talk still unlocked the stage.

## Fix

- **New `confession_revisit` event**: she brings the confession up again herself once stats are back above the original confession floor. Gated on `confession_delayed` completed + `confession_accepted` not completed. Repeatable with a 3-day cooldown, so deferring again just delays it rather than locking it out. Accepting grants `confession_accepted`, which unblocks `dating`.
- **Commitment talk re-gated on outcome**: the accept choice now records a `commitment_accepted` marker and `committed` requires that marker instead of the event id. Declining no longer unlocks the stage.
- **New `commitment_revisit` event**: same shape as the confession revisit (repeatable, 5-day cooldown), so re-gating `committed` on the accept outcome doesn't recreate the original deadlock for players who ask for more time.
- **Legacy save reconciliation**: saves that already reached `committed`/`soulmate` under the old gate don't have `commitment_accepted`, and the per-turn stage recalc would demote them. `reconcileLegacyMarkers()` patches those saves once on load (including stages stashed by Companion Mode via `savedDatingSimStage`).

## Stages deliberately left on event ids

- `soulmate` (`deep_bond_moment`) and `romantic_interest` (`first_deep_conversation`, `shared_vulnerability`): both choices in each of these events are accepting, there is no decline/defer path, so completing the event is the positive outcome and the id is the correct gate.

## Tests

13 new cases across the engine suites:
- `events.test.ts`: after declining, the one-time confession stays blocked but the revisit is eligible (real event data through `checkEvent`/`checkAllEvents`); revisit doesn't fire before a deferral; retires once accepted; deferring it only starts the cooldown.
- `event-completion.test.ts`: accepting the revisit grants `confession_accepted` and unlocks `dating` after an earlier decline; commitment accept/decline marker behavior; declining the commitment talk leaves the player at `dating`; `reconcileLegacyMarkers` grandfathering + no-op cases.
- `stages.test.ts`: `committed` gates on the outcome marker, not the event id.

Docs table in `companion-system.md` updated to match.

`pnpm run lint`: 0 errors, 0 warnings. `pnpm test`: 140/140 pass. Smoke-tested in the browser: app boots clean with the new event data, no console errors.