### PR TITLE
fix: stop main and overlay windows from clobbering each other's character state

### DIFF
--- a/src/lib/services/storage/character-merge.test.ts
+++ b/src/lib/services/storage/character-merge.test.ts
@@ -1,0 +1,128 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { mergeCharacterStates } from './character-merge.ts';
+import type { CharacterState } from '$lib/types/character';
+
+// A day of progress in the main window: markers earned, streak kept alive
+const persisted = {
+	affection: 250,
+	trust: 60,
+	energy: 40,
+	completedEvents: ['first_deep_conversation', 'confession_event', 'confession_accepted'],
+	totalInteractions: 120,
+	daysKnown: 30,
+	currentStreak: 7,
+	longestStreak: 7,
+	streakLastDate: '2026-07-03',
+	firstMet: new Date('2026-06-01T10:00:00Z'),
+	createdAt: new Date('2026-06-01T10:00:00Z'),
+	lastInteraction: new Date('2026-07-03T18:00:00Z'),
+	lastDecayAt: new Date('2026-07-02T09:00:00Z'),
+	updatedAt: new Date('2026-07-03T18:00:00Z')
+} as unknown as CharacterState;
+
+// What the overlay window still holds: its snapshot from this morning's boot
+const staleSnapshot = {
+	affection: 12,
+	trust: 5,
+	energy: 95,
+	completedEvents: ['first_deep_conversation'],
+	totalInteractions: 20,
+	daysKnown: 29,
+	currentStreak: 6,
+	longestStreak: 6,
+	streakLastDate: '2026-07-02',
+	firstMet: new Date('2026-06-01T10:00:00Z'),
+	createdAt: new Date('2026-06-01T10:00:00Z'),
+	lastInteraction: new Date('2026-07-03T08:00:00Z'),
+	lastDecayAt: null,
+	updatedAt: new Date('2026-07-03T19:00:00Z')
+} as unknown as CharacterState;
+
+test('a stale snapshot cannot erase completed-event markers it never saw', () => {
+	const merged = mergeCharacterStates(persisted, staleSnapshot);
+	assert.ok(merged.completedEvents.includes('confession_event'));
+	assert.ok(
+		merged.completedEvents.includes('confession_accepted'),
+		'the dating-gate marker must survive a save from a window that booted before it was earned'
+	);
+	assert.ok(merged.completedEvents.includes('first_deep_conversation'));
+});
+
+test('new markers from the incoming snapshot are appended without duplicates', () => {
+	const incoming = {
+		...staleSnapshot,
+		completedEvents: ['first_deep_conversation', 'shared_vulnerability']
+	} as CharacterState;
+	const merged = mergeCharacterStates(persisted, incoming);
+	assert.deepEqual(merged.completedEvents, [
+		'first_deep_conversation',
+		'confession_event',
+		'confession_accepted',
+		'shared_vulnerability'
+	]);
+});
+
+test('monotonic counters never regress', () => {
+	const merged = mergeCharacterStates(persisted, staleSnapshot);
+	assert.equal(merged.totalInteractions, 120);
+	assert.equal(merged.daysKnown, 30);
+	assert.equal(merged.longestStreak, 7);
+});
+
+test('the streak pair with the later check-in date wins', () => {
+	const merged = mergeCharacterStates(persisted, staleSnapshot);
+	assert.equal(merged.currentStreak, 7);
+	assert.equal(merged.streakLastDate, '2026-07-03');
+});
+
+test('a legitimately broken streak (newer date) does overwrite the old one', () => {
+	const incoming = {
+		...staleSnapshot,
+		currentStreak: 1,
+		streakLastDate: '2026-07-10'
+	} as CharacterState;
+	const merged = mergeCharacterStates(persisted, incoming);
+	assert.equal(merged.currentStreak, 1);
+	assert.equal(merged.streakLastDate, '2026-07-10');
+	// ...but the longest streak it once reached is kept
+	assert.equal(merged.longestStreak, 7);
+});
+
+test('same-day writes keep the higher streak', () => {
+	const incoming = {
+		...staleSnapshot,
+		currentStreak: 6,
+		streakLastDate: '2026-07-03'
+	} as CharacterState;
+	const merged = mergeCharacterStates(persisted, incoming);
+	assert.equal(merged.currentStreak, 7);
+});
+
+test('a fresh record with no streak date cannot clear an established streak', () => {
+	const incoming = { ...staleSnapshot, currentStreak: 0, streakLastDate: null } as CharacterState;
+	const merged = mergeCharacterStates(persisted, incoming);
+	assert.equal(merged.currentStreak, 7);
+	assert.equal(merged.streakLastDate, '2026-07-03');
+});
+
+test('scalar stats are last-writer-wins (live sync keeps writers fresh)', () => {
+	const merged = mergeCharacterStates(persisted, staleSnapshot);
+	assert.equal(merged.affection, 12);
+	assert.equal(merged.trust, 5);
+	assert.equal(merged.energy, 95);
+});
+
+test('temporal anchors keep the earliest origin and the latest activity', () => {
+	const incoming = {
+		...staleSnapshot,
+		firstMet: new Date('2026-06-15T10:00:00Z'),
+		createdAt: new Date('2026-06-15T10:00:00Z')
+	} as CharacterState;
+	const merged = mergeCharacterStates(persisted, incoming);
+	assert.equal(merged.firstMet.getTime(), new Date('2026-06-01T10:00:00Z').getTime());
+	assert.equal(merged.createdAt.getTime(), new Date('2026-06-01T10:00:00Z').getTime());
+	assert.equal(merged.lastInteraction?.getTime(), new Date('2026-07-03T18:00:00Z').getTime());
+	assert.equal(merged.lastDecayAt?.getTime(), new Date('2026-07-02T09:00:00Z').getTime());
+});

--- a/src/lib/services/storage/character-merge.ts
+++ b/src/lib/services/storage/character-merge.ts
@@ -1,0 +1,67 @@
+import type { CharacterState } from '$lib/types/character';
+
+function laterOf(a: Date | null | undefined, b: Date | null | undefined): Date | null {
+	if (!a) return b ?? null;
+	if (!b) return a;
+	return new Date(a).getTime() >= new Date(b).getTime() ? a : b;
+}
+
+function earlierOf(a: Date, b: Date): Date {
+	return new Date(a).getTime() <= new Date(b).getTime() ? a : b;
+}
+
+/**
+ * Merge an incoming character snapshot into the already-persisted one.
+ *
+ * The main and overlay windows each run their own store, so a window holding a
+ * stale boot snapshot can save long after the other window made progress. A
+ * blind full-object put would erase that progress; instead, fields that only
+ * ever move one way are reconciled here so no writer can roll them back:
+ *
+ * - completedEvents: union (markers are never removed; reset deletes the record)
+ * - totalInteractions / daysKnown / longestStreak: max
+ * - currentStreak + streakLastDate: the pair with the later check-in date wins
+ *   (a broken streak legitimately resets to 1, but always with a newer date)
+ * - firstMet / createdAt: earliest, lastInteraction / lastDecayAt: latest
+ *
+ * Everything else (stats, mood, persona, stage) is last-writer-wins; the
+ * cross-window broadcast keeps live windows rehydrated so their writes are
+ * based on current values.
+ */
+export function mergeCharacterStates(
+	existing: CharacterState,
+	incoming: CharacterState
+): CharacterState {
+	const completedEvents = [...existing.completedEvents];
+	for (const marker of incoming.completedEvents) {
+		if (!completedEvents.includes(marker)) {
+			completedEvents.push(marker);
+		}
+	}
+
+	// Dates are local YYYY-MM-DD strings, so string comparison orders them
+	let currentStreak = incoming.currentStreak;
+	let streakLastDate = incoming.streakLastDate;
+	if (existing.streakLastDate) {
+		if (!incoming.streakLastDate || existing.streakLastDate > incoming.streakLastDate) {
+			currentStreak = existing.currentStreak;
+			streakLastDate = existing.streakLastDate;
+		} else if (existing.streakLastDate === incoming.streakLastDate) {
+			currentStreak = Math.max(existing.currentStreak, incoming.currentStreak);
+		}
+	}
+
+	return {
+		...incoming,
+		completedEvents,
+		currentStreak,
+		streakLastDate,
+		longestStreak: Math.max(existing.longestStreak, incoming.longestStreak, currentStreak),
+		totalInteractions: Math.max(existing.totalInteractions, incoming.totalInteractions),
+		daysKnown: Math.max(existing.daysKnown, incoming.daysKnown),
+		firstMet: earlierOf(existing.firstMet, incoming.firstMet),
+		createdAt: earlierOf(existing.createdAt, incoming.createdAt),
+		lastInteraction: laterOf(existing.lastInteraction, incoming.lastInteraction),
+		lastDecayAt: laterOf(existing.lastDecayAt, incoming.lastDecayAt)
+	};
+}

--- a/src/lib/services/storage/character.ts
+++ b/src/lib/services/storage/character.ts
@@ -1,5 +1,6 @@
 import { db, type DBCharacterState } from '$lib/db';
 import { createDefaultCharacterState, type CharacterState } from '$lib/types/character';
+import { mergeCharacterStates } from './character-merge';
 
 /**
  * Get the single character state from IndexedDB.
@@ -17,24 +18,25 @@ export async function getCharacterState(): Promise<CharacterState> {
 }
 
 /**
- * Save the character state to IndexedDB.
- * Clears existing records and saves the new state (single record model).
+ * Save the character state to IndexedDB (single record model).
+ * Merges into the existing record rather than blindly overwriting it, so a
+ * window holding a stale snapshot can't erase progress another window already
+ * persisted. The rw transaction makes read-merge-write atomic across windows.
  */
 export async function saveCharacterState(state: CharacterState): Promise<number> {
-	const serialized = serializeCharacterState(state);
+	return db.transaction('rw', db.characterStates, async () => {
+		const existing = await db.characterStates.toCollection().first();
 
-	// Check if a record exists
-	const existing = await db.characterStates.toCollection().first();
+		if (existing && existing.id !== undefined) {
+			const merged = mergeCharacterStates(deserializeCharacterState(existing), state);
+			await db.characterStates.put({ ...serializeCharacterState(merged), id: existing.id });
+			return existing.id;
+		}
 
-	if (existing && existing.id !== undefined) {
-		// Update existing record
-		await db.characterStates.put({ ...serialized, id: existing.id });
-		return existing.id;
-	}
-
-	// Create new record
-	const id = await db.characterStates.add(serialized);
-	return id as number;
+		// Create new record
+		const id = await db.characterStates.add(serializeCharacterState(state));
+		return id as number;
+	});
 }
 
 /**

--- a/src/lib/stores/character.svelte.ts
+++ b/src/lib/stores/character.svelte.ts
@@ -30,6 +30,14 @@ let error = $state<string | null>(null);
 // Debounce save timeout
 let saveTimeout: ReturnType<typeof setTimeout> | null = null;
 
+// Cross-window sync channel (main <-> overlay). Character state lives in
+// IndexedDB, so the 'storage' event settings relies on never fires for it;
+// BroadcastChannel reaches every same-origin context, which covers browser
+// tabs and both Tauri windows alike.
+let syncChannel: BroadcastChannel | null = null;
+// Prevents a sync-triggered rehydrate from broadcasting back and ping-ponging
+let isSyncing = false;
+
 // Create the store object
 function createCharacterStore() {
 	// Derived mood info
@@ -85,6 +93,7 @@ function createCharacterStore() {
 				// Save the patched state (use $state.snapshot to strip Proxy)
 				const plainState = $state.snapshot(state);
 				await saveCharacterState({ ...plainState, updatedAt: new Date() });
+				notifyOtherWindows();
 			}
 
 			isReady = true;
@@ -114,6 +123,7 @@ function createCharacterStore() {
 					...plainState,
 					updatedAt: new Date()
 				});
+				notifyOtherWindows();
 			} catch (e) {
 				console.error('Failed to save character state:', e);
 			}
@@ -124,6 +134,27 @@ function createCharacterStore() {
 		} else {
 			// Debounce by 1 second
 			saveTimeout = setTimeout(doSave, 1000);
+		}
+	}
+
+	// Tell other windows we persisted, so they rehydrate instead of sitting on
+	// a stale snapshot that their next save would push back over ours.
+	function notifyOtherWindows(): void {
+		if (isSyncing) return;
+		syncChannel?.postMessage('character-state-saved');
+	}
+
+	// Rehydrate from IndexedDB after another window saves. Deliberately not
+	// loadState(): decay/reconcile already ran at boot, and a sync must never
+	// trigger a save of its own or two windows would echo back and forth.
+	async function syncFromStorage(): Promise<void> {
+		isSyncing = true;
+		try {
+			state = await getCharacterState();
+		} catch (e) {
+			console.error('Failed to sync character state:', e);
+		} finally {
+			isSyncing = false;
 		}
 	}
 
@@ -357,6 +388,22 @@ function createCharacterStore() {
 
 	// Initialize on browser
 	if (browser) {
+		// Listen before the initial load so a boot-time patch save in another
+		// window is never missed.
+		if (typeof BroadcastChannel !== 'undefined') {
+			syncChannel = new BroadcastChannel('utsuwa-character-state');
+			syncChannel.onmessage = async () => {
+				// Still booting: loadState is about to read fresh data anyway
+				if (isLoading) return;
+				// Flush a pending local save first so its changes go through the
+				// storage merge instead of being dropped by the rehydrate.
+				if (saveTimeout) {
+					await save(true);
+				}
+				await syncFromStorage();
+			};
+		}
+
 		loadState();
 
 		// Flush pending saves before the page unloads to prevent data loss.
@@ -366,7 +413,7 @@ function createCharacterStore() {
 				clearTimeout(saveTimeout);
 				saveTimeout = null;
 				const plainState = $state.snapshot(state);
-				saveCharacterState({ ...plainState, updatedAt: new Date() });
+				saveCharacterState({ ...plainState, updatedAt: new Date() }).then(() => notifyOtherWindows());
 			}
 		});
 	}


### PR DESCRIPTION
## Problem

The Tauri app runs two windows (main at `/app`, overlay at `/overlay`), and each runs its own `characterStore` singleton hydrated from IndexedDB once at boot. `saveCharacterState()` did a blind full-object `put`. So: chat in the main window all day (affection up, `confession_accepted` earned, streak updated), open the overlay and send one message — the overlay applies its update to a stale boot snapshot and writes the whole object back, erasing the day's progress. Switching back clobbers the other way.

## Approach: cross-window sync + merge-on-write (option A)

I considered merge-only (B), but rejected it as the primary fix for two reasons:

1. Merge-only still corrupts scalar stats. A stale window that applies `affectionDelta: +3` to a boot snapshot of 12 writes 15 — and it *did* touch affection, so no field-level merge can know 253 was the right base. The only way delta application stays correct is if the writer's in-memory base is fresh, which is exactly what live sync provides.
2. The two windows would visibly disagree (stats, mood, stage) until a reload, which is a poor experience for an app whose whole point is one persistent character.

So: **live sync keeps every window's base fresh (correctness of deltas + consistent UI), and merge-on-write remains as the backstop** for the near-simultaneous race where a write from a not-yet-synced window slips in.

### Live sync (`src/lib/stores/character.svelte.ts`)

Character state lives in IndexedDB, so the `storage`-event pattern that `settings`/`modules` use never fires for it. Instead the store opens a `BroadcastChannel('utsuwa-character-state')` — same-origin delivery covers both two browser tabs and the two Tauri windows (they share an origin, same reason the settings `storage` events already work across them). After every successful persist (debounced save, boot-time patch save, beforeunload flush) the store posts a message; the other window rehydrates from IndexedDB via a new `syncFromStorage()`.

**Echo/loop guards:**
- `syncFromStorage()` only reads and assigns state — it never saves, so a rehydrate can't re-broadcast. It deliberately skips `loadState()` so decay/reconcile (which can trigger saves) don't re-run.
- BroadcastChannel never delivers a message to its sender, and an `isSyncing` flag (same pattern as `vrm.svelte.ts`) guards the notify path as belt-and-braces.
- Broadcasts only ever originate from real persists caused by user actions, so message volume is bounded by actual mutations; a window with nothing pending just reads and stops.
- If a broadcast arrives while a local debounced save is pending, the pending save is flushed first so its changes go through the storage merge instead of being dropped by the rehydrate.

### Merge-on-write (`src/lib/services/storage/character.ts` + new `character-merge.ts`)

`saveCharacterState()` now merges the incoming snapshot into the persisted record inside a single `rw` transaction (IndexedDB serializes overlapping rw transactions across windows, so read-merge-write is atomic even cross-window):

- `completedEvents`: union — markers can never be dropped by a writer that never saw them
- `totalInteractions` / `daysKnown` / `longestStreak`: max, never regress
- `currentStreak` + `streakLastDate`: travel as a pair; later check-in date wins (a legitimately broken streak resets to 1 *with a newer date*, so that still lands)
- `firstMet` / `createdAt`: earliest; `lastInteraction` / `lastDecayAt`: latest
- everything else: last-writer-wins, kept fresh by the live sync

Reset and save-file import intentionally bypass the merge (they delete/clear first via direct table access), so legitimate full overwrites still work.

## Tests

9 new unit tests in `src/lib/services/storage/character-merge.test.ts` covering: a stale snapshot can't erase `confession_accepted`/markers, union dedupe, counters never regress, streak-pair date rules (stale loses, legit break wins, same-day takes max, null date can't clear), scalar last-writer semantics, and earliest/latest date anchors. Full suite: **149 pass** (was 140). `pnpm run lint`: 0 errors, 0 warnings.

## Two-tab e2e (dev server, `/app` + `/overlay`)

Verified in two browser tabs as the proxy for the two Tauri windows:

1. Baseline both tabs: energy 100, totalInteractions 8, `completedEvents: ['test_conditional']`
2. Tab A (`/app`): marked a test event + applied an energy delta → persisted record: energy 85, interactions 10, marker present
3. Tab B (`/overlay`) **without any reload**: store showed energy 85, interactions 10, marker present — live sync propagated
4. Tab B saved its own change → persisted record kept the marker (energy 80, interactions 11)
5. Simulated a truly stale writer (direct `saveCharacterState` with a snapshot missing the marker, interactions 3): after the write, the marker was still present and interactions stayed 11 — before this fix that write would have wiped both
6. Tab A live-synced tab B's changes back (bidirectional), with no echo loop

One honest caveat: BroadcastChannel across two *native Tauri windows* rides on both webviews sharing the same origin and web context (the same sharing that makes the existing settings `storage`-event sync work there). I verified the two-tab web path end to end; the two-native-window path needs a desktop build to confirm empirically.