### PR TITLE
fix: event modal null-deref on close and dead click zone on dialogue box

### DIFF
--- a/src/lib/components/events/EventScene.svelte
+++ b/src/lib/components/events/EventScene.svelte
@@ -3,6 +3,7 @@
 	import type { StateUpdates } from '$lib/types/character';
 	import { Icon } from '$lib/components/ui';
 	import ChoiceDialog from './ChoiceDialog.svelte';
+	import { nextPhase, type ScenePhase } from './scene-flow';
 	import { pop, fadeFast } from '$lib/utils/motion';
 
 	interface Props {
@@ -29,46 +30,38 @@
 		}
 	});
 
-	let phase = $state<'intro' | 'dialogue' | 'choices' | 'response' | 'outro'>('intro');
+	let phase = $state<ScenePhase>('intro');
 	let selectedChoice = $state<SceneChoice | null>(null);
 	let selectedChoiceIndex = $state<number | null>(null);
 
 	// Skip intro if not present
 	$effect(() => {
-		if (phase === 'intro' && !scene.intro) {
+		if (phase === 'intro' && scene && !scene.intro) {
 			phase = 'dialogue';
 		}
 	});
 
 	function advance() {
-		switch (phase) {
-			case 'intro':
-				phase = 'dialogue';
-				break;
-			case 'dialogue':
-				if (scene.choices && scene.choices.length > 0) {
-					phase = 'choices';
-				} else if (scene.outro) {
-					phase = 'outro';
-				} else {
-					completeScene();
-				}
-				break;
-			case 'response':
-				if (scene.outro) {
-					phase = 'outro';
-				} else {
-					completeScene();
-				}
-				break;
-			case 'outro':
-				completeScene();
-				break;
+		const next = nextPhase(phase, scene);
+		if (next === null) return;
+		if (next === 'complete') {
+			completeScene();
+		} else {
+			phase = next;
 		}
 	}
 
+	// Clicks on the dialogue box advance the narrative too, not just the
+	// backdrop. Buttons (close, continue, choices) handle themselves, and
+	// advance() ignores the choices phase.
+	function handleContainerClick(e: MouseEvent) {
+		e.stopPropagation();
+		if (e.target instanceof Element && e.target.closest('button')) return;
+		advance();
+	}
+
 	function handleChoice(index: number) {
-		if (!scene.choices) return;
+		if (!scene?.choices) return;
 
 		selectedChoice = scene.choices[index];
 		selectedChoiceIndex = index;
@@ -86,7 +79,7 @@
 
 <div class="scene-overlay" class:overlay transition:fadeFast={{ duration: 200 }} onclick={advance} role="button" tabindex="0" onkeypress={(e) => e.key === 'Enter' && advance()}>
 	<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-	<div class="scene-container" transition:pop={{ duration: 240, y: 18 }} onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.key === 'Escape' && onClose()} role="dialog" aria-modal="true" tabindex="-1">
+	<div class="scene-container" transition:pop={{ duration: 240, y: 18 }} onclick={handleContainerClick} onkeydown={(e) => e.key === 'Escape' && onClose()} role="dialog" aria-modal="true" tabindex="-1">
 		<!-- Header with event title -->
 		{#if eventName}
 			<div class="scene-header">

--- a/src/lib/components/events/scene-flow.test.ts
+++ b/src/lib/components/events/scene-flow.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { nextPhase, type ScenePhase } from './scene-flow.ts';
+import type { Scene } from '$lib/types/events';
+
+function makeScene(overrides: Partial<Scene> = {}): Scene {
+	return {
+		id: 'test_scene',
+		intro: 'She looks up as you approach.',
+		dialogue: 'There is something I want to say.',
+		outro: 'The moment lingers.',
+		...overrides
+	};
+}
+
+const choice = {
+	text: 'I feel the same way.',
+	response: 'Really? I was so nervous...',
+	stateChanges: { affectionDelta: 10 }
+};
+
+test('intro advances to dialogue', () => {
+	assert.equal(nextPhase('intro', makeScene()), 'dialogue');
+});
+
+test('dialogue advances to choices when the scene has them', () => {
+	assert.equal(nextPhase('dialogue', makeScene({ choices: [choice] })), 'choices');
+});
+
+test('dialogue skips to outro when there are no choices', () => {
+	assert.equal(nextPhase('dialogue', makeScene({ choices: undefined })), 'outro');
+	assert.equal(nextPhase('dialogue', makeScene({ choices: [] })), 'outro');
+});
+
+test('dialogue completes when there are no choices and no outro', () => {
+	assert.equal(nextPhase('dialogue', makeScene({ choices: undefined, outro: undefined })), 'complete');
+});
+
+test('response goes to outro, or completes without one', () => {
+	assert.equal(nextPhase('response', makeScene()), 'outro');
+	assert.equal(nextPhase('response', makeScene({ outro: undefined })), 'complete');
+});
+
+test('outro completes', () => {
+	assert.equal(nextPhase('outro', makeScene()), 'complete');
+});
+
+test('choices phase ignores click-to-advance', () => {
+	assert.equal(nextPhase('choices', makeScene({ choices: [choice] })), null);
+});
+
+test('a missing scene is a no-op in every phase', () => {
+	// The overlay keeps its click handlers during the fade-out after the parent
+	// clears the active event, so a late click must never advance or throw.
+	const phases: ScenePhase[] = ['intro', 'dialogue', 'choices', 'response', 'outro'];
+	for (const phase of phases) {
+		assert.equal(nextPhase(phase, null), null);
+		assert.equal(nextPhase(phase, undefined), null);
+	}
+});

--- a/src/lib/components/events/scene-flow.ts
+++ b/src/lib/components/events/scene-flow.ts
@@ -1,0 +1,28 @@
+import type { Scene } from '$lib/types/events';
+
+export type ScenePhase = 'intro' | 'dialogue' | 'choices' | 'response' | 'outro';
+
+// Where a click-to-advance lands from the current phase. Returns null when the
+// click should be ignored: no scene (the overlay keeps its click handlers while
+// it fades out after the parent clears the event) or the choices phase, which
+// only moves through an explicit choice pick.
+export function nextPhase(
+	phase: ScenePhase,
+	scene: Scene | null | undefined
+): ScenePhase | 'complete' | null {
+	if (!scene) return null;
+
+	switch (phase) {
+		case 'intro':
+			return 'dialogue';
+		case 'dialogue':
+			if (scene.choices && scene.choices.length > 0) return 'choices';
+			return scene.outro ? 'outro' : 'complete';
+		case 'response':
+			return scene.outro ? 'outro' : 'complete';
+		case 'outro':
+			return 'complete';
+		default:
+			return null;
+	}
+}

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -272,9 +272,9 @@
 		<!-- Event Scene Overlay -->
 		{#if activeEvent?.scene}
 			<EventScene
-				scene={activeEvent.scene}
-				eventName={activeEvent.name}
-				eventType={activeEvent.type}
+				scene={activeEvent?.scene}
+				eventName={activeEvent?.name}
+				eventType={activeEvent?.type}
 				companionName={personaStore.activeCard.name}
 				onComplete={handleEventComplete}
 				onClose={handleEventClose}

--- a/src/routes/overlay/+page.svelte
+++ b/src/routes/overlay/+page.svelte
@@ -349,9 +349,9 @@
 	<!-- Event Scene Overlay -->
 	{#if activeEvent?.scene}
 		<EventScene
-			scene={activeEvent.scene}
-			eventName={activeEvent.name}
-			eventType={activeEvent.type}
+			scene={activeEvent?.scene}
+			eventName={activeEvent?.name}
+			eventType={activeEvent?.type}
 			companionName={personaStore.activeCard.name}
 			overlay={true}
 			onComplete={handleEventComplete}


### PR DESCRIPTION
## Bugs

**1. Null-deref when advancing as an event closes**

`EventScene`'s backdrop keeps its `onclick={advance}` handler during the 200ms fade-out after the parent clears `activeEvent`, so a click landing while the scene closed (or a quick double-click) ran `advance()` against a null scene and threw `TypeError: Cannot read properties of null (reading 'scene')` through the parent's prop getter. Svelte's boundary swallowed it, but it fired repeatedly in normal play.

**2. Clicking the dialogue box did nothing**

The modal box had `onclick={stopPropagation}`, so the obvious click target was dead and only the backdrop outside the box advanced. For choice events the dialogue phase renders no Continue button either, so the only way from dialogue to choices was the backdrop, which read as the app freezing.

## Fix

- Extracted the phase-advance logic into `scene-flow.ts` (`nextPhase()`), which treats a missing scene as a no-op, and treats the choices phase as not click-advanceable.
- The box's click handler now advances narrative phases (intro / dialogue / response / outro). Clicks originating on buttons (close, Continue, choice buttons) are ignored so nothing double-fires, and propagation still stops so the backdrop handler can't fire twice.
- Made the `scene` / `eventName` / `eventType` prop expressions null-safe (`activeEvent?.`) on both `app` and `overlay` pages, which render the same component with the same wiring, so the prop getters can't throw during the out-transition.
- Guarded the intro-skip effect and choice handler the same way.

## Tests

- 8 new unit tests for `nextPhase()` covering every phase transition, the choices-phase no-op, and the null/undefined scene guard. Full suite: 157 pass. `svelte-check`: 0 errors, 0 warnings.

## e2e (local dev server + Ollama gemma3:4b, dating-sim mode)

- [x] Clicking inside the dialogue box advances a choice event from dialogue to choices ("Opening Up" event) — no backdrop hunting
- [x] Choice-less event ("First Meeting") advances via its Continue button and completes via a click on the box
- [x] Selecting a choice works; stray clicks on the backdrop or inside the box during the choices phase do nothing
- [x] Mashing the backdrop and box while the modal fades out after completion produces no console exceptions — the old null-deref path is gone (verified with console tracking active across the full event lifecycle)
