### PR TITLE
ci: run type check, tests, and cargo check on every push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  web:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm check
+
+      - name: Test
+        run: pnpm test
+
+  tauri:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: './src-tauri -> target'
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            librsvg2-dev \
+            libayatana-appindicator3-dev \
+            patchelf
+
+      # generate_context! embeds frontendDist at compile time, so the
+      # directory has to exist even though cargo check never bundles it.
+      - name: Stub frontend dist
+        run: mkdir -p build
+
+      - name: Cargo check
+        run: cargo check --manifest-path src-tauri/Cargo.toml


### PR DESCRIPTION
## Summary
- Adds a CI workflow that runs on pushes to main and on all pull requests
- Web job: pnpm install (frozen lockfile), svelte-check, and the full node test suite (157 tests)
- Tauri job: cargo check against src-tauri on ubuntu-22.04 with the same Linux deps as release.yml
- All action SHAs pinned, matching the convention already used in release.yml

## Notes
- The tauri job stubs an empty build/ dir because generate_context! embeds frontendDist at compile time even for cargo check
- Ubuntu-only for now; a platform matrix can come later if it earns its keep