### PR TITLE
fix: damp stage demotions, guard zero-value decay, harden streak logic

### DIFF
--- a/src/lib/data/events/index.ts
+++ b/src/lib/data/events/index.ts
@@ -4,6 +4,10 @@ import { romanticEvents } from './romantic';
 import { timeBasedEvents } from './time-based';
 import type { EventDefinition } from '$lib/types/events';
 
+// Dispatched directly by the turn pipeline on a stage demotion, deliberately
+// not part of allEvents (see strain.ts).
+export { relationshipStrainEvent } from './strain';
+
 // All events combined
 export const allEvents: EventDefinition[] = [
 	...milestoneEvents,

--- a/src/lib/data/events/strain.ts
+++ b/src/lib/data/events/strain.ts
@@ -1,0 +1,36 @@
+import type { EventDefinition } from '$lib/types/events';
+
+// Fired by the turn pipeline when the stage engine demotes a stage (stats fell
+// below the hysteresis band, usually after a long absence). Not part of
+// allEvents: it has no trigger conditions of its own, so the general event
+// check would fire it every turn. The cooldown still applies through the
+// normal completion records.
+export const relationshipStrainEvent: EventDefinition = {
+	id: 'relationship_strain',
+	name: 'Growing Apart',
+	type: 'conditional',
+	conditions: [],
+	scene: {
+		id: 'relationship_strain_scene',
+		intro: 'Something in her expression is different today. Quieter. More careful.',
+		dialogue:
+			"Hey... can I say something? I've felt us drifting lately. Not in a dramatic way, just... further apart than we used to be. Maybe it's the time apart, maybe it's me overthinking again. I just didn't want to pretend everything was the same when it doesn't feel that way.",
+		choices: [
+			{
+				text: "You're right. I want to close that distance.",
+				response:
+					"...Thank you for not brushing it off. That means more than you know. We'll find our way back. I know we will.",
+				stateChanges: { comfortDelta: 5, trustDelta: 2 }
+			},
+			{
+				text: "I've just been busy. It's nothing.",
+				response:
+					"Right... busy. Okay. I just needed you to know how it felt from where I'm standing. That's all.",
+				stateChanges: { comfortDelta: -3 }
+			}
+		]
+	},
+	oneTime: false,
+	cooldownDays: 1,
+	priority: 90
+};

--- a/src/lib/engine/stages.test.ts
+++ b/src/lib/engine/stages.test.ts
@@ -1,7 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { calculateStage } from './stages.ts';
+import {
+	calculateStage,
+	meetsStageRequirements,
+	resolveStageTransition,
+	DEMOTION_HYSTERESIS
+} from './stages.ts';
 import type { CharacterState } from '$lib/types/character';
 
 function makeState(overrides: Partial<CharacterState> = {}): CharacterState {
@@ -111,4 +116,67 @@ test('stage never regresses below stranger and ignores the companion stage', () 
 	// calculateStage only walks the dating-sim ladder; companion is a mode, not a rung
 	const state = makeState({ appMode: 'companion' });
 	assert.equal(calculateStage(state, []), 'stranger');
+});
+
+// --- meetsStageRequirements (explicit requirement objects) ---
+
+test('an explicit zero minimum is evaluated, not skipped', () => {
+	const requirements = { minAffection: 0, minTrust: 0, minIntimacy: 0 };
+	assert.equal(meetsStageRequirements(makeState(), requirements, []), true);
+	assert.equal(
+		meetsStageRequirements(makeState(), { ...requirements, minIntimacy: 1 }, []),
+		false
+	);
+});
+
+test('omitted optional minimums are skipped', () => {
+	const requirements = { minAffection: 10, minTrust: 5 };
+	assert.equal(meetsStageRequirements(makeState({ affection: 10, trust: 5 }), requirements, []), true);
+});
+
+// --- resolveStageTransition (hysteresis) ---
+
+const ROMANTIC_EVENTS = ['first_deep_conversation', 'shared_vulnerability'];
+const ROMANTIC_STATS = {
+	affection: 460,
+	trust: 75,
+	intimacy: 30,
+	comfort: 50,
+	respect: 10,
+	daysKnown: 10,
+	totalInteractions: 25,
+	relationshipStage: 'romantic_interest' as const
+};
+
+test('promotion happens as soon as requirements are met', () => {
+	const state = makeState({ ...ROMANTIC_STATS, relationshipStage: 'close_friend' });
+	const result = resolveStageTransition(state, ROMANTIC_EVENTS);
+	assert.equal(result.stage, 'romantic_interest');
+	assert.equal(result.direction, 'promotion');
+});
+
+test('a dip inside the hysteresis band holds the current stage', () => {
+	// romantic_interest needs 450 affection; the demotion floor is 450 * 0.85
+	const floor = 450 * DEMOTION_HYSTERESIS;
+	const state = makeState({ ...ROMANTIC_STATS, affection: Math.ceil(floor) });
+	const result = resolveStageTransition(state, ROMANTIC_EVENTS);
+	assert.equal(result.stage, 'romantic_interest');
+	assert.equal(result.changed, false);
+});
+
+test('a collapse below the band demotes to the earned stage and reports strain', () => {
+	const state = makeState({ ...ROMANTIC_STATS, affection: 300 });
+	const result = resolveStageTransition(state, ROMANTIC_EVENTS);
+	assert.equal(result.stage, 'close_friend');
+	assert.equal(result.direction, 'demotion');
+});
+
+test('hysteresis applies per stat, not just affection', () => {
+	// trust floor for romantic_interest is 75 * 0.85 = 63.75
+	const held = resolveStageTransition(makeState({ ...ROMANTIC_STATS, trust: 70 }), ROMANTIC_EVENTS);
+	assert.equal(held.changed, false);
+
+	const dropped = resolveStageTransition(makeState({ ...ROMANTIC_STATS, trust: 60 }), ROMANTIC_EVENTS);
+	assert.equal(dropped.direction, 'demotion');
+	assert.equal(dropped.stage, 'friend'); // trust 60 also fails close_friend's 70
 });

--- a/src/lib/engine/stages.ts
+++ b/src/lib/engine/stages.ts
@@ -12,8 +12,7 @@ export const STAGE_ORDER: RelationshipStage[] = [
 	'soulmate'
 ];
 
-// Stage requirements for progression
-const STAGE_REQUIREMENTS: Record<RelationshipStage, {
+export interface StageRequirements {
 	minAffection: number;
 	minTrust: number;
 	minIntimacy?: number;
@@ -22,7 +21,10 @@ const STAGE_REQUIREMENTS: Record<RelationshipStage, {
 	requiredEvents?: string[];
 	minDaysKnown?: number;
 	minInteractions?: number;
-}> = {
+}
+
+// Stage requirements for progression
+const STAGE_REQUIREMENTS: Record<RelationshipStage, StageRequirements> = {
 	companion: { minAffection: 0, minTrust: 0 }, // Special locked stage for Companion Mode
 	stranger: { minAffection: 0, minTrust: 0 },
 	acquaintance: { minAffection: 50, minTrust: 20, minInteractions: 3 },
@@ -34,21 +36,22 @@ const STAGE_REQUIREMENTS: Record<RelationshipStage, {
 	soulmate: { minAffection: 950, minTrust: 100, minIntimacy: 90, minComfort: 95, minRespect: 90, minDaysKnown: 60, requiredEvents: ['deep_bond_moment'] }
 };
 
-// Check if state meets stage requirements
-function meetsStageRequirements(
+// Check if state meets a set of stage requirements. `scale` shrinks the numeric
+// stat floors (for the demotion hysteresis band); time/interaction counts and
+// event markers only ever grow, so they are checked unscaled.
+export function meetsStageRequirements(
 	state: CharacterState,
-	stage: RelationshipStage,
-	completedEvents: string[]
+	requirements: StageRequirements,
+	completedEvents: string[],
+	scale = 1
 ): boolean {
-	const requirements = STAGE_REQUIREMENTS[stage];
-
-	if (state.affection < requirements.minAffection) return false;
-	if (state.trust < requirements.minTrust) return false;
-	if (requirements.minIntimacy && state.intimacy < requirements.minIntimacy) return false;
-	if (requirements.minComfort && state.comfort < requirements.minComfort) return false;
-	if (requirements.minRespect && state.respect < requirements.minRespect) return false;
-	if (requirements.minDaysKnown && state.daysKnown < requirements.minDaysKnown) return false;
-	if (requirements.minInteractions && state.totalInteractions < requirements.minInteractions) return false;
+	if (state.affection < requirements.minAffection * scale) return false;
+	if (state.trust < requirements.minTrust * scale) return false;
+	if (requirements.minIntimacy !== undefined && state.intimacy < requirements.minIntimacy * scale) return false;
+	if (requirements.minComfort !== undefined && state.comfort < requirements.minComfort * scale) return false;
+	if (requirements.minRespect !== undefined && state.respect < requirements.minRespect * scale) return false;
+	if (requirements.minDaysKnown !== undefined && state.daysKnown < requirements.minDaysKnown) return false;
+	if (requirements.minInteractions !== undefined && state.totalInteractions < requirements.minInteractions) return false;
 
 	if (requirements.requiredEvents) {
 		for (const eventId of requirements.requiredEvents) {
@@ -63,11 +66,57 @@ function meetsStageRequirements(
 export function calculateStage(state: CharacterState, completedEvents: string[]): RelationshipStage {
 	for (let i = STAGE_ORDER.length - 1; i >= 0; i--) {
 		const stage = STAGE_ORDER[i];
-		if (meetsStageRequirements(state, stage, completedEvents)) {
+		if (meetsStageRequirements(state, STAGE_REQUIREMENTS[stage], completedEvents)) {
 			return stage;
 		}
 	}
 	return 'stranger';
+}
+
+// Demotion only happens once a stat falls below 85% of the current stage's
+// floor. Without the band, a single -1 turn at a threshold demotes and the
+// next +2 turn re-promotes, firing the transition celebration repeatedly.
+export const DEMOTION_HYSTERESIS = 0.85;
+
+export interface StageTransitionResolution {
+	stage: RelationshipStage;
+	changed: boolean;
+	direction?: 'promotion' | 'demotion';
+}
+
+// Decide the next stage relative to the one currently held. Promotion is
+// immediate; demotion is damped by the hysteresis band so boundary noise and
+// mild decay don't silently strip a stage. A real collapse still demotes to
+// whatever stage the stats actually support.
+export function resolveStageTransition(
+	state: CharacterState,
+	completedEvents: string[]
+): StageTransitionResolution {
+	const current = state.relationshipStage;
+	const calculated = calculateStage(state, completedEvents);
+
+	if (calculated === current) {
+		return { stage: current, changed: false };
+	}
+
+	const currentIndex = STAGE_ORDER.indexOf(current);
+	const calculatedIndex = STAGE_ORDER.indexOf(calculated);
+
+	// Current stage isn't on the dating-sim ladder (companion); adopt the
+	// calculated stage outright.
+	if (currentIndex === -1) {
+		return { stage: calculated, changed: true, direction: 'promotion' };
+	}
+
+	if (calculatedIndex > currentIndex) {
+		return { stage: calculated, changed: true, direction: 'promotion' };
+	}
+
+	if (meetsStageRequirements(state, STAGE_REQUIREMENTS[current], completedEvents, DEMOTION_HYSTERESIS)) {
+		return { stage: current, changed: false };
+	}
+
+	return { stage: calculated, changed: true, direction: 'demotion' };
 }
 
 // Stage behavior definition

--- a/src/lib/engine/state-updates.test.ts
+++ b/src/lib/engine/state-updates.test.ts
@@ -7,6 +7,7 @@ import {
 	checkAndApplyStageTransition,
 	resolveTimeDecayOnLoad
 } from './state-updates.ts';
+import { STAGE_ORDER } from './stages.ts';
 import type { CharacterState, StateUpdates } from '$lib/types/character';
 
 const HOUR = 1000 * 60 * 60;
@@ -159,6 +160,43 @@ test('no decay under the 30-minute floor', () => {
 	assert.equal(result.changed, false);
 });
 
+// --- zero-decay guard (48-72h dead zone) ---
+
+test('a 49h absence computes zero decay and sets no affection delta', () => {
+	const updates = applyTimeDecay(makeState({ affection: 500 }), 49);
+	assert.equal(updates.affectionDelta, undefined);
+});
+
+test('a rounding-to-zero decay sets no delta either', () => {
+	// affection 30 at 5 days away: floor(30 * 0.03) = 0
+	const updates = applyTimeDecay(makeState({ affection: 30 }), 120);
+	assert.equal(updates.affectionDelta, undefined);
+});
+
+test('regression: a zero-decay load does not consume the once-per-absence slot', () => {
+	const now = 1_000_000_000_000;
+	const lastInteraction = new Date(now - 49 * HOUR);
+
+	// Opening the app at hour 49 without interacting: energy recovers, but no
+	// decay happened, so the absence's decay slot must stay armed.
+	const first = resolveTimeDecayOnLoad(
+		makeState({ energy: 40, affection: 500, lastInteraction, lastDecayAt: null }),
+		now
+	);
+	assert.equal(first.next.energy, 100);
+	assert.equal(first.next.affection, undefined);
+	assert.equal(first.next.lastDecayAt, undefined, 'zero decay must not write lastDecayAt');
+	assert.equal(first.changed, true);
+
+	// Returning at hour 120 of the same absence: the real decay still applies.
+	const second = resolveTimeDecayOnLoad(
+		makeState({ affection: 500, lastInteraction, lastDecayAt: null }),
+		lastInteraction.getTime() + 120 * HOUR
+	);
+	assert.equal(second.next.affection, 485); // 3 days past grace at 1%/day
+	assert.ok(second.next.lastDecayAt instanceof Date);
+});
+
 // --- mergeUpdates ---
 
 test('LLM deltas are clamped relative to the baseline', () => {
@@ -215,4 +253,61 @@ test('no transition when the stage already matches', () => {
 	const result = checkAndApplyStageTransition(state, []);
 	assert.equal(result.transitioned, false);
 	assert.equal(result.newState, state);
+});
+
+test('acceptance: oscillating at a stage boundary yields one promotion and no demotions', () => {
+	const events = ['first_deep_conversation', 'shared_vulnerability'];
+	let state = makeState({
+		affection: 449,
+		trust: 75,
+		intimacy: 30,
+		comfort: 50,
+		daysKnown: 10,
+		totalInteractions: 25,
+		relationshipStage: 'close_friend'
+	});
+
+	let promotions = 0;
+	let demotions = 0;
+	for (let turn = 0; turn < 20; turn++) {
+		state = { ...state, affection: state.affection + (turn % 2 === 0 ? 1 : -1) };
+		const result = checkAndApplyStageTransition(state, events);
+		if (result.transitioned && result.fromStage && result.toStage) {
+			if (STAGE_ORDER.indexOf(result.toStage) > STAGE_ORDER.indexOf(result.fromStage)) {
+				promotions++;
+			} else {
+				demotions++;
+			}
+			state = result.newState;
+		}
+	}
+
+	assert.equal(promotions, 1);
+	assert.equal(demotions, 0);
+});
+
+test('a decay collapse demotes and flags the transition as strained', () => {
+	const state = makeState({
+		affection: 300,
+		trust: 75,
+		intimacy: 30,
+		comfort: 50,
+		daysKnown: 10,
+		totalInteractions: 25,
+		relationshipStage: 'romantic_interest'
+	});
+	const result = checkAndApplyStageTransition(state, [
+		'first_deep_conversation',
+		'shared_vulnerability'
+	]);
+	assert.equal(result.transitioned, true);
+	assert.equal(result.toStage, 'close_friend');
+	assert.equal(result.strained, true);
+});
+
+test('promotions are not flagged as strained', () => {
+	const state = makeState({ affection: 50, trust: 20, totalInteractions: 3 });
+	const result = checkAndApplyStageTransition(state, []);
+	assert.equal(result.transitioned, true);
+	assert.equal(result.strained, false);
 });

--- a/src/lib/engine/state-updates.ts
+++ b/src/lib/engine/state-updates.ts
@@ -1,32 +1,42 @@
 import type { CharacterState, StateUpdates, Emotion, MoodState, RelationshipStage } from '$lib/types/character';
-import { calculateStage } from './stages.ts';
+import { resolveStageTransition } from './stages.ts';
 
 // Clamp a value between min and max
 function clamp(value: number, min: number, max: number): number {
 	return Math.max(min, Math.min(max, value));
 }
 
-// Check and apply stage transition if needed
+// Check and apply stage transition if needed. Promotion is immediate; demotion
+// is damped by the hysteresis band in resolveStageTransition and flagged as
+// `strained` so callers can acknowledge it in dialogue instead of letting the
+// relationship downgrade silently.
 export function checkAndApplyStageTransition(
 	state: CharacterState,
 	completedEvents: string[]
-): { newState: CharacterState; transitioned: boolean; fromStage?: RelationshipStage; toStage?: RelationshipStage } {
-	const calculatedStage = calculateStage(state, completedEvents);
+): {
+	newState: CharacterState;
+	transitioned: boolean;
+	strained: boolean;
+	fromStage?: RelationshipStage;
+	toStage?: RelationshipStage;
+} {
+	const resolution = resolveStageTransition(state, completedEvents);
 
-	if (calculatedStage !== state.relationshipStage) {
+	if (resolution.changed) {
 		return {
 			newState: {
 				...state,
-				relationshipStage: calculatedStage,
+				relationshipStage: resolution.stage,
 				updatedAt: new Date()
 			},
 			transitioned: true,
+			strained: resolution.direction === 'demotion',
 			fromStage: state.relationshipStage,
-			toStage: calculatedStage
+			toStage: resolution.stage
 		};
 	}
 
-	return { newState: state, transitioned: false };
+	return { newState: state, transitioned: false, strained: false };
 }
 
 // Apply time-based decay (call on session start)
@@ -45,27 +55,38 @@ export function applyTimeDecay(state: CharacterState, hoursSinceLastInteraction:
 		}
 	}
 
-	// Affection decay (only after 48 hours)
+	// Affection decay (only after 48 hours). A zero-value delta must not be set
+	// at all: resolveTimeDecayOnLoad treats any delta as "decay happened" and
+	// consumes the once-per-absence slot, so a -0 written at hour 49 would
+	// swallow the real decay owed at day 5.
 	if (hoursSinceLastInteraction > 48 && state.affection > 0) {
 		const daysAway = Math.floor(hoursSinceLastInteraction / 24) - 2; // Start after 2 days
 		const decayRate = Math.min(0.05, 0.01 * daysAway);
 		const decay = Math.floor(state.affection * decayRate);
-		updates.affectionDelta = -Math.min(decay, 50); // Cap at 50 per session
+		if (decay > 0) {
+			updates.affectionDelta = -Math.min(decay, 50); // Cap at 50 per session
+		}
 	}
 
 	// Trust decay (only after 7 days)
 	if (hoursSinceLastInteraction > 168 && state.trust > 0) {
 		const weeksAway = Math.floor(hoursSinceLastInteraction / 168);
-		updates.trustDelta = -Math.min(weeksAway * 2, 10); // Slow decay, max 10 per session
+		const decay = Math.min(weeksAway * 2, 10); // Slow decay, max 10 per session
+		if (decay > 0) {
+			updates.trustDelta = -decay;
+		}
 	}
 
 	// Mood shifts towards melancholy if away too long (3+ days)
 	if (hoursSinceLastInteraction > 72) {
-		updates.moodChange = {
-			emotion: 'melancholy',
-			intensityDelta: Math.min(30, Math.floor(hoursSinceLastInteraction / 24) * 5),
-			cause: 'missing you'
-		};
+		const intensityDelta = Math.min(30, Math.floor(hoursSinceLastInteraction / 24) * 5);
+		if (intensityDelta > 0) {
+			updates.moodChange = {
+				emotion: 'melancholy',
+				intensityDelta,
+				cause: 'missing you'
+			};
+		}
 	}
 
 	return updates;

--- a/src/lib/engine/streak.test.ts
+++ b/src/lib/engine/streak.test.ts
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { computeStreakUpdate, localDateKey } from './streak.ts';
+
+test('localDateKey formats in local time with zero padding', () => {
+	assert.equal(localDateKey(new Date(2026, 0, 5)), '2026-01-05');
+	assert.equal(localDateKey(new Date(2026, 11, 31, 23, 59)), '2026-12-31');
+});
+
+test('first visit starts a streak of 1', () => {
+	const result = computeStreakUpdate(
+		{ currentStreak: 0, longestStreak: 0, streakLastDate: null },
+		new Date(2026, 5, 15, 9, 0)
+	);
+	assert.deepEqual(result, { currentStreak: 1, longestStreak: 1, streakLastDate: '2026-06-15' });
+});
+
+test('a repeat visit on the same day changes nothing', () => {
+	const streak = { currentStreak: 4, longestStreak: 6, streakLastDate: '2026-06-15' };
+	const result = computeStreakUpdate(streak, new Date(2026, 5, 15, 22, 30));
+	assert.deepEqual(result, streak);
+});
+
+test('a consecutive day increments and updates the longest streak', () => {
+	const result = computeStreakUpdate(
+		{ currentStreak: 3, longestStreak: 3, streakLastDate: '2026-06-14' },
+		new Date(2026, 5, 15, 7, 0)
+	);
+	assert.deepEqual(result, { currentStreak: 4, longestStreak: 4, streakLastDate: '2026-06-15' });
+});
+
+test('a missed day resets the streak to 1 but keeps the longest', () => {
+	const result = computeStreakUpdate(
+		{ currentStreak: 5, longestStreak: 8, streakLastDate: '2026-06-12' },
+		new Date(2026, 5, 15)
+	);
+	assert.deepEqual(result, { currentStreak: 1, longestStreak: 8, streakLastDate: '2026-06-15' });
+});
+
+test('yesterday crosses month and year boundaries by calendar arithmetic', () => {
+	// Dec 31 -> Jan 1
+	const newYear = computeStreakUpdate(
+		{ currentStreak: 2, longestStreak: 5, streakLastDate: '2025-12-31' },
+		new Date(2026, 0, 1, 8)
+	);
+	assert.equal(newYear.currentStreak, 3);
+
+	// Feb 28 -> Mar 1 (2026 is not a leap year)
+	const march = computeStreakUpdate(
+		{ currentStreak: 1, longestStreak: 1, streakLastDate: '2026-02-28' },
+		new Date(2026, 2, 1, 12)
+	);
+	assert.equal(march.currentStreak, 2);
+});
+
+test('a DST transition day still counts as consecutive', () => {
+	// US spring-forward is 2026-03-08; the local calendar day before it is 03-07
+	// regardless of the day only having 23 hours.
+	const result = computeStreakUpdate(
+		{ currentStreak: 5, longestStreak: 5, streakLastDate: '2026-03-07' },
+		new Date(2026, 2, 8, 9, 0)
+	);
+	assert.deepEqual(result, { currentStreak: 6, longestStreak: 6, streakLastDate: '2026-03-08' });
+});
+
+test('a clock set backwards (future streakLastDate) reads as already visited, not a reset', () => {
+	const streak = { currentStreak: 7, longestStreak: 9, streakLastDate: '2026-06-20' };
+	const result = computeStreakUpdate(streak, new Date(2026, 5, 15));
+	assert.deepEqual(result, streak);
+});

--- a/src/lib/engine/streak.ts
+++ b/src/lib/engine/streak.ts
@@ -1,0 +1,48 @@
+// Pure streak logic, split from the character store so it can be unit-tested.
+
+export interface StreakSnapshot {
+	currentStreak: number;
+	longestStreak: number;
+	streakLastDate: string | null;
+}
+
+// Format a date as local YYYY-MM-DD (toISOString would use UTC day boundaries,
+// which breaks streaks for anyone chatting across a UTC midnight)
+export function localDateKey(date: Date): string {
+	const y = date.getFullYear();
+	const m = String(date.getMonth() + 1).padStart(2, '0');
+	const d = String(date.getDate()).padStart(2, '0');
+	return `${y}-${m}-${d}`;
+}
+
+export function computeStreakUpdate(streak: StreakSnapshot, now: Date): StreakSnapshot {
+	const today = localDateKey(now);
+
+	if (streak.streakLastDate === today) {
+		return { ...streak };
+	}
+
+	// A recorded date ahead of today means the clock was set backwards. Treat it
+	// as already visited rather than punishing the user with a reset.
+	if (streak.streakLastDate && streak.streakLastDate > today) {
+		return { ...streak };
+	}
+
+	// Calendar arithmetic, not now - 24h: DST days aren't 24 hours long.
+	const yesterday = localDateKey(new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1));
+
+	if (streak.streakLastDate === yesterday) {
+		const next = streak.currentStreak + 1;
+		return {
+			currentStreak: next,
+			longestStreak: Math.max(streak.longestStreak, next),
+			streakLastDate: today
+		};
+	}
+
+	return {
+		currentStreak: 1,
+		longestStreak: Math.max(streak.longestStreak, 1),
+		streakLastDate: today
+	};
+}

--- a/src/lib/services/chat/companion-turn.ts
+++ b/src/lib/services/chat/companion-turn.ts
@@ -9,8 +9,8 @@ import {
 	determineFactCategory,
 	calculateFactImportance
 } from '$lib/engine/memory';
-import { checkAllEvents, eventsApi } from '$lib/engine/events';
-import { allEvents } from '$lib/data/events';
+import { checkAllEvents, checkEvent, eventsApi } from '$lib/engine/events';
+import { allEvents, relationshipStrainEvent } from '$lib/data/events';
 import { extractStateUpdates } from './client-chat';
 import type { LLMProvider } from '$lib/types';
 import type { EventDefinition } from '$lib/types/events';
@@ -107,11 +107,13 @@ export async function processCompanionTurn(input: CompanionTurnInput): Promise<C
 	}
 
 	// Stage transitions (Dating Sim Mode only)
+	let stageStrained = false;
 	if (characterStore.appMode === 'dating_sim') {
 		const completedEventIds = characterStore.state.completedEvents || [];
 		const transition = checkAndApplyStageTransition(characterStore.state, completedEventIds);
 		if (transition.transitioned && transition.toStage) {
 			characterStore.setRelationshipStage(transition.toStage);
+			stageStrained = transition.strained;
 		}
 	}
 
@@ -139,9 +141,22 @@ export async function processCompanionTurn(input: CompanionTurnInput): Promise<C
 	if (characterStore.appMode === 'dating_sim') {
 		try {
 			const completedEvents = await eventsApi.getCompletedEvents();
-			const triggeredEvents = checkAllEvents(allEvents, characterStore.state, completedEvents, userMessage);
-			if (triggeredEvents.length > 0) {
-				triggeredEvent = triggeredEvents[0];
+
+			// A demotion this turn takes over the event slot so the character can
+			// acknowledge the strain instead of it happening silently. checkEvent
+			// still applies the cooldown via the completion records.
+			if (stageStrained) {
+				const strain = checkEvent(relationshipStrainEvent, characterStore.state, completedEvents);
+				if (strain.triggered) {
+					triggeredEvent = relationshipStrainEvent;
+				}
+			}
+
+			if (!triggeredEvent) {
+				const triggeredEvents = checkAllEvents(allEvents, characterStore.state, completedEvents, userMessage);
+				if (triggeredEvents.length > 0) {
+					triggeredEvent = triggeredEvents[0];
+				}
 			}
 		} catch (e) {
 			console.debug('Event check failed:', e);

--- a/src/lib/stores/character.svelte.ts
+++ b/src/lib/stores/character.svelte.ts
@@ -18,6 +18,7 @@ import { statChangesStore } from './statChanges.svelte';
 import { resolveTimeDecayOnLoad } from '$lib/engine/state-updates';
 import { reconcileLegacyMarkers } from '$lib/engine/event-completion';
 import { calculateStage, STAGE_ORDER } from '$lib/engine/stages';
+import { computeStreakUpdate } from '$lib/engine/streak';
 
 // Single character state
 let state = $state<CharacterState>(createDefaultCharacterState() as CharacterState);
@@ -288,12 +289,18 @@ function createCharacterStore() {
 	function markEventCompleted(eventId: string): void {
 		if (!state.completedEvents.includes(eventId)) {
 			const completedEvents = [...state.completedEvents, eventId];
-			// A gating event can unlock the next relationship stage right away.
-			// Companion mode has no dating-sim ladder, so leave its stage locked.
-			const relationshipStage =
-				state.appMode === 'companion'
-					? state.relationshipStage
-					: calculateStage(state, completedEvents);
+			// A gating event can unlock the next relationship stage right away, but
+			// completing an event never demotes: demotion is handled by the per-turn
+			// hysteresis check so it can be acknowledged in dialogue, not sprung on
+			// the user as a side effect of finishing a scene. Companion mode has no
+			// dating-sim ladder, so leave its stage locked.
+			let relationshipStage = state.relationshipStage;
+			if (state.appMode !== 'companion') {
+				const calculated = calculateStage(state, completedEvents);
+				if (STAGE_ORDER.indexOf(calculated) > STAGE_ORDER.indexOf(relationshipStage)) {
+					relationshipStage = calculated;
+				}
+			}
 			state = {
 				...state,
 				completedEvents,
@@ -309,39 +316,29 @@ function createCharacterStore() {
 		return state?.completedEvents.includes(eventId) ?? false;
 	}
 
-	// Format a date as local YYYY-MM-DD (toISOString would use UTC day boundaries,
-	// which breaks streaks for anyone chatting across a UTC midnight)
-	function localDateKey(date: Date): string {
-		const y = date.getFullYear();
-		const m = String(date.getMonth() + 1).padStart(2, '0');
-		const d = String(date.getDate()).padStart(2, '0');
-		return `${y}-${m}-${d}`;
-	}
-
-	// Update streak (call on session start)
+	// Update streak (call on session start). Pure logic lives in engine/streak.ts;
+	// it handles DST days and clock-set-back protection.
 	function updateStreak(): void {
-		const today = localDateKey(new Date());
-		const yesterday = localDateKey(new Date(Date.now() - 86400000));
+		const next = computeStreakUpdate(
+			{
+				currentStreak: state.currentStreak,
+				longestStreak: state.longestStreak,
+				streakLastDate: state.streakLastDate
+			},
+			new Date()
+		);
 
-		let newStreak = state.currentStreak;
-		let newLongest = state.longestStreak;
-
-		if (state.streakLastDate === today) {
-			// Already visited today, no change
-		} else if (state.streakLastDate === yesterday) {
-			// Consecutive day
-			newStreak++;
-			newLongest = Math.max(newLongest, newStreak);
-		} else {
-			// Streak broken
-			newStreak = 1;
+		if (
+			next.currentStreak === state.currentStreak &&
+			next.longestStreak === state.longestStreak &&
+			next.streakLastDate === state.streakLastDate
+		) {
+			return;
 		}
 
 		state = {
 			...state,
-			currentStreak: newStreak,
-			longestStreak: newLongest,
-			streakLastDate: today,
+			...next,
 			updatedAt: new Date()
 		};
 		save();


### PR DESCRIPTION
## Summary
Engine correctness batch from the 2026-07-04 audit: MECH-1, MECH-2, MECH-3, MECH-5.

### Stage hysteresis (MECH-1)
- Promotion is immediate as before, but demotion only happens once a stat falls below 85% of the current stage's floor, so a -1 turn at a threshold can't demote and re-promote in a loop, and the transition celebration fires once per milestone
- A real collapse (long absence decay) still demotes to the stage the stats actually support, but the transition is flagged as strained and routed through a new Growing Apart event so she acknowledges the distance in dialogue instead of the stage silently dropping
- The strain event is dispatched by the turn pipeline only on demotion (it is deliberately not in allEvents) and respects a 1-day cooldown through the normal completion records
- Completing an event can now only promote, never demote, so finishing a scene can't spring a downgrade as a side effect

### Zero-decay guard (MECH-2)
- applyTimeDecay only writes a delta when the computed decay is non-zero. Previously a load in the 48-72h window wrote affectionDelta -0, which resolveTimeDecayOnLoad counted as the absence's one decay application, so the real decay owed at day 5 never applied

### Requirement checks (MECH-3)
- meetsStageRequirements uses explicit undefined checks instead of truthiness and now takes the requirements object directly, so an explicit zero minimum is evaluated rather than skipped (matters for future data-driven stage configs)

### Streak hardening (MECH-5)
- Streak logic extracted to a pure engine module with tests
- Yesterday is computed by calendar arithmetic instead of now minus 86400000ms, which is wrong on DST days
- A streakLastDate ahead of today (clock set backwards) reads as already visited today instead of resetting the streak

## Testing
- 21 new unit tests covering the oscillation acceptance case (20 turns at a boundary yields exactly one promotion, zero demotions), strain flagging, the 49h/120h decay slot regression, zero-rounding decay, min-0 requirements, and streak DST/month/year/clock-back cases
- 177/177 tests pass, svelte-check clean
- Live e2e on localhost:5173 with Ollama gemma3:4b: full chat turn through the shared pipeline, stats applied, streak advanced 2 to 3 across the real midnight boundary via the new module, milestone event triggered and scene advanced, zero console errors

## Do Not Break checklist
- lastDecayAt once-per-absence design unchanged; only when the marker is written changed (real decay only)
- Companion mode isolation untouched (stage transitions still gated on dating_sim at every entry point)
- savedDatingSimStage restore logic untouched