### PR TITLE
fix: stop relationship mechanics from flatlining on non-Latin input

### DIFF
--- a/src/lib/engine/heuristics.test.ts
+++ b/src/lib/engine/heuristics.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { analyzeMessage, calculateBaselineUpdates } from './heuristics.ts';
+import { analyzeMessage, calculateBaselineUpdates, isNonLatinDominant } from './heuristics.ts';
 import type { CharacterState } from '$lib/types/character';
 
 function makeState(overrides: Partial<CharacterState> = {}): CharacterState {
@@ -98,4 +98,34 @@ test('strong sentiment sets a mood change', () => {
 test('extracted facts surface as a new memory', () => {
 	const updates = calculateBaselineUpdates("I'm Alex, nice to meet you", makeState());
 	assert.ok(updates.newMemory?.includes("I'm Alex"));
+});
+
+// --- non-Latin input (I18N) ---
+
+test('isNonLatinDominant classifies scripts correctly', () => {
+	assert.equal(isNonLatinDominant('今日は仕事で大変なことがあったんだ'), true);
+	assert.equal(isNonLatinDominant('오늘 정말 좋은 하루였어'), true);
+	assert.equal(isNonLatinDominant('Сегодня был хороший день'), true);
+	assert.equal(isNonLatinDominant('I had a really good day today'), false);
+	assert.equal(isNonLatinDominant('Watched 攻殻機動隊 again, still my favorite movie ever made'), false);
+	assert.equal(isNonLatinDominant('!!!???'), false);
+	assert.equal(isNonLatinDominant(''), false);
+});
+
+test('non-Latin input skips keyword sentiment instead of reading as flat negative', () => {
+	// "悲しい" (sad) would never match English keywords; sentiment must be
+	// neutral-zero with the nonLatinDominant flag set so the caller can lean on
+	// the LLM's own deltas instead.
+	const analysis = analyzeMessage('今日はちょっと悲しいことがあったんだ。でもあなたと話せてよかった。');
+	assert.equal(analysis.nonLatinDominant, true);
+	assert.equal(analysis.sentiment, 0);
+});
+
+test('a full-width question mark still reads as a question', () => {
+	assert.equal(analyzeMessage('明日は何をしますか？').isQuestion, true);
+});
+
+test('apologizing is not negative sentiment', () => {
+	const analysis = analyzeMessage("Sorry I was away yesterday, I missed talking to you");
+	assert.ok(analysis.sentiment >= 0, `sentiment was ${analysis.sentiment}`);
 });

--- a/src/lib/engine/heuristics.ts
+++ b/src/lib/engine/heuristics.ts
@@ -38,9 +38,10 @@ const POSITIVE_KEYWORDS = [
 	'💕'
 ];
 
+// "sorry" is deliberately absent: apologizing is repair, not negativity, and
+// counting it dinged comfort every time the user said sorry for being away.
 const NEGATIVE_KEYWORDS = [
 	'sad',
-	'sorry',
 	'hate',
 	'bad',
 	'awful',
@@ -127,26 +128,46 @@ const EMOTIONAL_MARKERS = [
 	'worried'
 ];
 
+// All keyword lists above are English. When a message is written mostly in a
+// non-Latin script (Japanese being the obvious audience), none of them can
+// match, so sentiment would read as a meaningless flat zero-negative and the
+// caller should lean on the LLM's own deltas instead. Letters are counted via
+// Unicode script classes; symbols, digits, and emoji don't vote.
+export function isNonLatinDominant(content: string): boolean {
+	let letters = 0;
+	let latin = 0;
+	for (const ch of content) {
+		if (!/\p{L}/u.test(ch)) continue;
+		letters++;
+		if (/\p{Script=Latin}/u.test(ch)) latin++;
+	}
+	if (letters < 4) return false;
+	return latin / letters < 0.5;
+}
+
 // Analyze a message for sentiment, depth, and other characteristics
 export function analyzeMessage(content: string): MessageAnalysis {
 	const lowerContent = content.toLowerCase();
 	const words = lowerContent.split(/\s+/);
+	const nonLatinDominant = isNonLatinDominant(content);
 
-	// Calculate sentiment
+	// Calculate sentiment (English keywords; skipped for non-Latin input)
 	let positiveCount = 0;
 	let negativeCount = 0;
 
-	for (const word of words) {
-		if (POSITIVE_KEYWORDS.some((kw) => word.includes(kw))) positiveCount++;
-		if (NEGATIVE_KEYWORDS.some((kw) => word.includes(kw))) negativeCount++;
-	}
+	if (!nonLatinDominant) {
+		for (const word of words) {
+			if (POSITIVE_KEYWORDS.some((kw) => word.includes(kw))) positiveCount++;
+			if (NEGATIVE_KEYWORDS.some((kw) => word.includes(kw))) negativeCount++;
+		}
 
-	// Also check for emoticons/emoji in full content
-	for (const kw of POSITIVE_KEYWORDS) {
-		if (lowerContent.includes(kw)) positiveCount++;
-	}
-	for (const kw of NEGATIVE_KEYWORDS) {
-		if (lowerContent.includes(kw)) negativeCount++;
+		// Also check for emoticons/emoji in full content
+		for (const kw of POSITIVE_KEYWORDS) {
+			if (lowerContent.includes(kw)) positiveCount++;
+		}
+		for (const kw of NEGATIVE_KEYWORDS) {
+			if (lowerContent.includes(kw)) negativeCount++;
+		}
 	}
 
 	const totalSentiment = positiveCount + negativeCount;
@@ -174,8 +195,8 @@ export function analyzeMessage(content: string): MessageAnalysis {
 		}
 	}
 
-	// Check if it's a question
-	const isQuestion = content.includes('?') || /^(what|who|where|when|why|how|do|does|did|is|are|was|were|can|could|would|will|should)\b/i.test(content);
+	// Check if it's a question (both ASCII and full-width question marks)
+	const isQuestion = content.includes('?') || content.includes('？') || /^(what|who|where|when|why|how|do|does|did|is|are|was|were|can|could|would|will|should)\b/i.test(content);
 
 	// Extract potential facts (very basic)
 	const extractedFacts: string[] = [];
@@ -208,7 +229,8 @@ export function analyzeMessage(content: string): MessageAnalysis {
 		detectedEmotion,
 		extractedFacts,
 		isQuestion,
-		hasEmotionalContent
+		hasEmotionalContent,
+		nonLatinDominant
 	};
 }
 

--- a/src/lib/engine/state-updates.test.ts
+++ b/src/lib/engine/state-updates.test.ts
@@ -311,3 +311,26 @@ test('promotions are not flagged as strained', () => {
 	assert.equal(result.transitioned, true);
 	assert.equal(result.strained, false);
 });
+
+// --- mergeUpdates: full-weight LLM deltas for non-Latin input ---
+
+test('trustLLMDeltas passes sanitized LLM deltas through instead of clamping to baseline', () => {
+	const baseline: StateUpdates = { affectionDelta: 1, trustDelta: 0 };
+	// Default mode: relative clamp caps affection at max(|1|*2, 5) = 5
+	const clamped = mergeUpdates(baseline, { affectionDelta: 15, trustDelta: 8 });
+	assert.equal(clamped.affectionDelta, 5);
+	assert.equal(clamped.trustDelta, 3);
+
+	// Full-weight mode: the parser already sanitized these, take them as-is
+	const trusted = mergeUpdates(baseline, { affectionDelta: 15, trustDelta: 8 }, { trustLLMDeltas: true });
+	assert.equal(trusted.affectionDelta, 15);
+	assert.equal(trusted.trustDelta, 8);
+});
+
+test('trustLLMDeltas keeps baseline values for fields the LLM omitted', () => {
+	const baseline: StateUpdates = { affectionDelta: 2, energyDelta: -3 };
+	const merged = mergeUpdates(baseline, { trustDelta: 4 }, { trustLLMDeltas: true });
+	assert.equal(merged.affectionDelta, 2);
+	assert.equal(merged.energyDelta, -3);
+	assert.equal(merged.trustDelta, 4);
+});

--- a/src/lib/engine/state-updates.ts
+++ b/src/lib/engine/state-updates.ts
@@ -252,9 +252,17 @@ export function calculateMessageImpact(
 	};
 }
 
-// Merge baseline heuristics with LLM suggestions
-export function mergeUpdates(baseline: StateUpdates, llmSuggestion: Partial<StateUpdates>): StateUpdates {
+// Merge baseline heuristics with LLM suggestions. By default the baseline
+// bounds the LLM's deltas; with trustLLMDeltas (non-Latin input, where the
+// keyword baseline is meaningless) the LLM's values are taken as-is — the
+// response parser has already sanitized them to absolute ranges.
+export function mergeUpdates(
+	baseline: StateUpdates,
+	llmSuggestion: Partial<StateUpdates>,
+	options: { trustLLMDeltas?: boolean } = {}
+): StateUpdates {
 	const merged: StateUpdates = { ...baseline };
+	const trustLLM = options.trustLLMDeltas === true;
 
 	// LLM can override mood entirely
 	if (llmSuggestion.moodChange) {
@@ -263,28 +271,42 @@ export function mergeUpdates(baseline: StateUpdates, llmSuggestion: Partial<Stat
 
 	// LLM can adjust deltas, but baseline provides bounds
 	if (llmSuggestion.affectionDelta !== undefined) {
-		// Take LLM suggestion but cap it relative to baseline
-		const baseAffection = baseline.affectionDelta ?? 0;
-		const maxDelta = Math.max(Math.abs(baseAffection) * 2, 5);
-		merged.affectionDelta = clamp(llmSuggestion.affectionDelta, -maxDelta, maxDelta);
+		if (trustLLM) {
+			merged.affectionDelta = llmSuggestion.affectionDelta;
+		} else {
+			// Take LLM suggestion but cap it relative to baseline
+			const baseAffection = baseline.affectionDelta ?? 0;
+			const maxDelta = Math.max(Math.abs(baseAffection) * 2, 5);
+			merged.affectionDelta = clamp(llmSuggestion.affectionDelta, -maxDelta, maxDelta);
+		}
 	}
 
 	if (llmSuggestion.trustDelta !== undefined) {
-		const baseTrust = baseline.trustDelta ?? 0;
-		const maxDelta = Math.max(Math.abs(baseTrust) * 2, 3);
-		merged.trustDelta = clamp(llmSuggestion.trustDelta, -maxDelta, maxDelta);
+		if (trustLLM) {
+			merged.trustDelta = llmSuggestion.trustDelta;
+		} else {
+			const baseTrust = baseline.trustDelta ?? 0;
+			const maxDelta = Math.max(Math.abs(baseTrust) * 2, 3);
+			merged.trustDelta = clamp(llmSuggestion.trustDelta, -maxDelta, maxDelta);
+		}
 	}
 
 	if (llmSuggestion.intimacyDelta !== undefined) {
-		merged.intimacyDelta = clamp(llmSuggestion.intimacyDelta, -3, 5);
+		merged.intimacyDelta = trustLLM
+			? llmSuggestion.intimacyDelta
+			: clamp(llmSuggestion.intimacyDelta, -3, 5);
 	}
 
 	if (llmSuggestion.comfortDelta !== undefined) {
-		merged.comfortDelta = clamp(llmSuggestion.comfortDelta, -3, 5);
+		merged.comfortDelta = trustLLM
+			? llmSuggestion.comfortDelta
+			: clamp(llmSuggestion.comfortDelta, -3, 5);
 	}
 
 	if (llmSuggestion.respectDelta !== undefined) {
-		merged.respectDelta = clamp(llmSuggestion.respectDelta, -3, 5);
+		merged.respectDelta = trustLLM
+			? llmSuggestion.respectDelta
+			: clamp(llmSuggestion.respectDelta, -3, 5);
 	}
 
 	// Energy delta stays from baseline (app controls energy)

--- a/src/lib/services/chat/companion-turn.ts
+++ b/src/lib/services/chat/companion-turn.ts
@@ -49,6 +49,7 @@ export async function processCompanionTurn(input: CompanionTurnInput): Promise<C
 	const { userMessage, companionResponse, llm, debug = false } = input;
 
 	const state = characterStore.state;
+	const userAnalysis = analyzeMessage(userMessage);
 	const baselineUpdates = calculateBaselineUpdates(userMessage, state);
 
 	const parsed = parseResponse(companionResponse, state.name);
@@ -90,7 +91,13 @@ export async function processCompanionTurn(input: CompanionTurnInput): Promise<C
 		validatedLLMUpdates = validateStateUpdates(llmUpdates).sanitized;
 	}
 
-	const finalUpdates = mergeUpdates(baselineUpdates, validatedLLMUpdates || {});
+	// For non-Latin input the keyword baseline is meaningless (English lists),
+	// so the LLM's sanitized deltas carry full weight instead of being clamped
+	// relative to it. Otherwise the game layer silently flatlines for users
+	// chatting in Japanese and other non-Latin languages.
+	const finalUpdates = mergeUpdates(baselineUpdates, validatedLLMUpdates || {}, {
+		trustLLMDeltas: userAnalysis.nonLatinDominant
+	});
 	characterStore.applyUpdates(finalUpdates);
 
 	// Save the model's memory observation
@@ -129,7 +136,6 @@ export async function processCompanionTurn(input: CompanionTurnInput): Promise<C
 	const maxHeuristicFacts = finalUpdates.newMemory ? 1 : 2;
 	for (const factContent of potentialFacts.slice(0, maxHeuristicFacts)) {
 		try {
-			const userAnalysis = analyzeMessage(userMessage);
 			await memoryApi.createFact({
 				content: factContent,
 				category: determineFactCategory(factContent),

--- a/src/lib/types/memory.ts
+++ b/src/lib/types/memory.ts
@@ -91,6 +91,9 @@ export interface MessageAnalysis {
 	extractedFacts: string[];
 	isQuestion: boolean;
 	hasEmotionalContent: boolean;
+	// Mostly non-Latin script: the English keyword heuristics didn't run, so
+	// downstream should weight the LLM's own deltas fully.
+	nonLatinDominant: boolean;
 }
 
 // Constants


### PR DESCRIPTION
## Summary
I18N-1 stage 1 from the 2026-07-04 audit. Every sentiment/depth heuristic is English keyword based, so a fully Japanese (or Korean, Russian, etc.) conversation silently degraded to flat baseline deltas: the game layer turned off with no indication to the user.

- `isNonLatinDominant` counts letters by Unicode script class (digits, punctuation, and emoji don't vote); at 50%+ non-Latin letters the message is flagged on MessageAnalysis
- Flagged messages skip keyword sentiment entirely instead of producing a fake neutral-negative count
- `mergeUpdates` gains a `trustLLMDeltas` option: the LLM's own JSON deltas (already sanitized to absolute ranges by validateStateUpdates: affection +-20, trust +-10, others +-10) pass through at full weight instead of being clamped relative to the meaningless keyword baseline
- companion-turn analyzes the user message once and enables the mode for non-Latin turns
- Full-width question marks count as questions
- "sorry" removed from NEGATIVE_KEYWORDS (apologizing was dinging comfort)

Stage 2 (multilingual embedding model + versioned backfill) comes separately.

## Testing
- 8 new unit tests: script classification across JP/KR/RU/EN/mixed, sentiment-skip for Japanese, full-width question mark, apology sentiment, full-weight vs relative clamping in both merge modes
- 192/192 tests pass, svelte-check clean
- Live e2e on localhost:5173 with Ollama gemma3:4b: a fully Japanese message produced real stat movement (affection +7, intimacy +8, comfort +9, mood happy), all beyond what the old baseline-relative clamps permitted for a keyword-silent message