### PR TITLE
feat: multilingual embeddings with versioned backfill

### DIFF
--- a/src/lib/engine/embedding-version.test.ts
+++ b/src/lib/engine/embedding-version.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+	EMBEDDING_MODEL_ID,
+	hasCurrentEmbedding,
+	needsReembedding
+} from './embedding-version.ts';
+
+test('the embedding model id is the multilingual MiniLM', () => {
+	assert.match(EMBEDDING_MODEL_ID, /multilingual/i);
+});
+
+test('a fact embedded by the current model is current', () => {
+	const fact = { embedding: [0.1, 0.2], embeddingModel: EMBEDDING_MODEL_ID };
+	assert.equal(hasCurrentEmbedding(fact), true);
+	assert.equal(needsReembedding(fact), false);
+});
+
+test('legacy facts with untagged embeddings need re-embedding and are excluded from search', () => {
+	// Everything embedded before the model swap has no embeddingModel field.
+	// Cosine similarity across two different embedding spaces is meaningless,
+	// so these must not participate in retrieval or dedup until re-embedded.
+	const legacy = { embedding: [0.1, 0.2] };
+	assert.equal(hasCurrentEmbedding(legacy), false);
+	assert.equal(needsReembedding(legacy), true);
+});
+
+test('facts tagged by a different model need re-embedding', () => {
+	const other = { embedding: [0.1], embeddingModel: 'Xenova/all-MiniLM-L6-v2' };
+	assert.equal(hasCurrentEmbedding(other), false);
+	assert.equal(needsReembedding(other), true);
+});
+
+test('facts without any embedding need embedding but are never search-current', () => {
+	assert.equal(hasCurrentEmbedding({}), false);
+	assert.equal(needsReembedding({}), true);
+	assert.equal(hasCurrentEmbedding({ embedding: [] }), false);
+	assert.equal(needsReembedding({ embedding: [], embeddingModel: EMBEDDING_MODEL_ID }), true);
+});

--- a/src/lib/engine/embedding-version.ts
+++ b/src/lib/engine/embedding-version.ts
@@ -1,0 +1,22 @@
+// Which embedding model produced a fact's vector. Vectors from different
+// models live in different spaces, so cosine similarity across them is
+// meaningless: retrieval, dedup, and the memory graph must only compare
+// same-model embeddings, and anything else gets re-embedded by the backfill.
+
+// Multilingual so Japanese (and other non-Latin) memories retrieve properly;
+// same 384-dim output and on-device size class as the English-only model it
+// replaced.
+export const EMBEDDING_MODEL_ID = 'Xenova/paraphrase-multilingual-MiniLM-L12-v2';
+
+interface EmbeddedLike {
+	embedding?: number[];
+	embeddingModel?: string;
+}
+
+export function hasCurrentEmbedding(fact: EmbeddedLike, model: string = EMBEDDING_MODEL_ID): boolean {
+	return !!fact.embedding && fact.embedding.length > 0 && fact.embeddingModel === model;
+}
+
+export function needsReembedding(fact: EmbeddedLike, model: string = EMBEDDING_MODEL_ID): boolean {
+	return !hasCurrentEmbedding(fact, model);
+}

--- a/src/lib/engine/memory.ts
+++ b/src/lib/engine/memory.ts
@@ -10,6 +10,7 @@ import type {
 import { MAX_WORKING_MEMORY_TURNS, MAX_RELEVANT_FACTS, MAX_RECENT_SESSIONS, DEFAULT_FACT_IMPORTANCE, DEFAULT_FACT_CONFIDENCE } from '$lib/types/memory';
 import * as memoryStorage from '$lib/services/storage/memory';
 import { embedText, findSimilarFacts, isEmbeddingReady } from '$lib/services/embeddings';
+import { hasCurrentEmbedding } from './embedding-version';
 import { summarizeTurns } from './session-summary';
 
 // Working memory store (single instance for the session)
@@ -381,14 +382,16 @@ export async function backfillEmbeddings(
 	return { success, failed };
 }
 
-// Check if there are facts without embeddings
+// Check if there are facts without a current-model embedding. Facts embedded
+// by an older model count as "without": the boot-time backfill re-embeds them
+// so retrieval isn't comparing vectors across embedding spaces.
 export async function getEmbeddingBackfillStatus(): Promise<{
 	total: number;
 	withEmbeddings: number;
 	withoutEmbeddings: number;
 }> {
 	const allFacts = await memoryStorage.getAllFactsWithEmbeddings();
-	const withEmbeddings = allFacts.filter((f) => f.embedding && f.embedding.length > 0).length;
+	const withEmbeddings = allFacts.filter((f) => hasCurrentEmbedding(f)).length;
 	return {
 		total: allFacts.length,
 		withEmbeddings,

--- a/src/lib/services/embeddings.ts
+++ b/src/lib/services/embeddings.ts
@@ -1,8 +1,9 @@
 import { browser } from '$app/environment';
 import type { Fact } from '$lib/types/memory';
+import { EMBEDDING_MODEL_ID } from '$lib/engine/embedding-version';
 
-// Model config
-const MODEL_NAME = 'Xenova/all-MiniLM-L6-v2';
+// Model config (single source of truth in engine/embedding-version.ts)
+const MODEL_NAME = EMBEDDING_MODEL_ID;
 
 // State
 let pipeline: unknown = null;

--- a/src/lib/services/memory-graph.ts
+++ b/src/lib/services/memory-graph.ts
@@ -1,5 +1,6 @@
 import { db } from '$lib/db';
 import { cosineSimilarity } from '$lib/services/embeddings';
+import { hasCurrentEmbedding } from '$lib/engine/embedding-version';
 import type { Fact, FactCategory } from '$lib/types/memory';
 
 export interface GraphNode {
@@ -30,10 +31,11 @@ export interface GraphFilters {
 	minSimilarity: number;
 }
 
-// Get all facts with embeddings from the database
+// Get all facts with current-model embeddings from the database. Stale-model
+// vectors are excluded: their similarities against current vectors are noise.
 export async function getFactsWithEmbeddings(): Promise<Fact[]> {
 	const allFacts = await db.facts.toArray();
-	return allFacts.filter((fact) => fact.embedding && fact.embedding.length > 0) as Fact[];
+	return allFacts.filter((fact) => hasCurrentEmbedding(fact)) as Fact[];
 }
 
 // Build graph data from facts

--- a/src/lib/services/storage/memory.ts
+++ b/src/lib/services/storage/memory.ts
@@ -2,6 +2,7 @@ import { db, type DBFact, type DBSessionSummary, type DBConversationTurn } from 
 import type { Fact, SessionSummary, ConversationTurn, MemorySearchOptions, NewFact } from '$lib/types/memory';
 import { embedText, isEmbeddingReady } from '$lib/services/embeddings';
 import { findDuplicateFact } from '$lib/engine/fact-dedup';
+import { EMBEDDING_MODEL_ID, hasCurrentEmbedding, needsReembedding } from '$lib/engine/embedding-version';
 
 // Facts
 
@@ -61,8 +62,12 @@ export async function saveFact(fact: NewFact): Promise<number> {
 	// retrieval. Exact normalized matches are caught always; with embeddings
 	// available, near-paraphrases of the same memory are merged too. On a match,
 	// bump the existing fact's reference count and importance instead of adding
-	// a near-duplicate row.
-	const candidates = await db.facts.where('category').equals(fact.category).toArray();
+	// a near-duplicate row. Stale-model embeddings are hidden from the semantic
+	// comparison (different space, meaningless cosine); those facts can still
+	// match by content.
+	const candidates = (await db.facts.where('category').equals(fact.category).toArray()).map(
+		(f) => (hasCurrentEmbedding(f) ? f : { ...f, embedding: undefined })
+	);
 	const existing = findDuplicateFact({ content: fact.content, embedding }, candidates);
 	if (existing?.id !== undefined) {
 		await db.facts.update(existing.id, {
@@ -81,7 +86,8 @@ export async function saveFact(fact: NewFact): Promise<number> {
 		source: fact.source,
 		referenceCount: 0,
 		createdAt: now,
-		embedding
+		embedding,
+		embeddingModel: embedding ? EMBEDDING_MODEL_ID : undefined
 	};
 
 	const id = await db.facts.add(dbFact);
@@ -107,14 +113,14 @@ export async function deleteAllFacts(): Promise<void> {
 }
 
 export async function updateFactEmbedding(factId: number, embedding: number[]): Promise<void> {
-	await db.facts.update(factId, { embedding });
+	await db.facts.update(factId, { embedding, embeddingModel: EMBEDDING_MODEL_ID });
 }
 
+// Facts the backfill should (re-)embed: no vector at all, or a vector from an
+// older embedding model that can't be compared against current ones.
 export async function getFactsWithoutEmbeddings(): Promise<Fact[]> {
 	const facts = await db.facts.toArray();
-	return facts
-		.filter((f) => !f.embedding || f.embedding.length === 0)
-		.map(deserializeFact);
+	return facts.filter((f) => needsReembedding(f)).map(deserializeFact);
 }
 
 export async function getAllFactsWithEmbeddings(): Promise<Fact[]> {
@@ -132,7 +138,9 @@ export async function getFactsForSemanticSearch(
 	limit: number = MAX_SEMANTIC_CANDIDATES
 ): Promise<Fact[]> {
 	const facts = await db.facts.orderBy('importance').reverse().limit(limit).toArray();
-	return facts.filter((f) => f.embedding && f.embedding.length > 0).map(deserializeFact);
+	// Only current-model embeddings: stale vectors live in a different space
+	// and would score garbage similarities until the backfill re-embeds them.
+	return facts.filter((f) => hasCurrentEmbedding(f)).map(deserializeFact);
 }
 
 // Sessions

--- a/src/lib/types/memory.ts
+++ b/src/lib/types/memory.ts
@@ -13,6 +13,7 @@ export interface Fact {
 	createdAt: Date;
 	lastAccessed?: Date;
 	embedding?: number[]; // 384-dim vector for semantic search
+	embeddingModel?: string; // which model produced the vector; absent = legacy, needs re-embed
 }
 
 // Topic depth for conversation analysis


### PR DESCRIPTION
## Summary
I18N-1 stage 2 from the 2026-07-04 audit. The previous embedding model (all-MiniLM-L6-v2) is English-centric, so semantic memory was unreliable for Japanese and other non-Latin content even after stage 1 fixed the stat mechanics.

- Embedding model swapped to `Xenova/paraphrase-multilingual-MiniLM-L12-v2`: multilingual, same 384-dim output, same on-device size class, drop-in for transformers.js
- Facts now carry an `embeddingModel` tag (no Dexie schema bump needed; the field is unindexed). Vectors from different models live in different spaces, so every consumer filters to current-model vectors: semantic retrieval, creation-time dedup, the memory graph, and the backfill status
- Legacy facts (untagged) and any future stale-model facts count as needing re-embedding; the existing boot-time auto-backfill in both the app and overlay picks them up with no new UI or migration code
- `updateFactEmbedding` stamps the tag, so backfilled facts rejoin retrieval immediately

## Testing
- 5 new unit tests for the version predicates (current, legacy-untagged, other-model, missing, empty)
- 197/197 tests pass, svelte-check clean
- Live e2e on localhost:5173: on first boot after the swap, the model downloaded and the auto-backfill re-embedded all 14 existing facts within seconds; every fact in IndexedDB now carries the multilingual model tag, zero console errors

## Notes
- First app load after this update downloads the new model (~100MB, cached by the browser after that), and memories re-embed automatically in the background