### PR TITLE
docs: note the 0.5.x-0.6.x changelog gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidated provider default base URLs and the companion-turn pipeline into single shared sources to reduce drift.
 - Refreshed the README and documentation (STT options, provider list, roadmap, and acknowledgments) to match the current app.
 
+> Versions 0.5.x and 0.6.x shipped without changelog entries during a rapid iteration stretch; everything from that window is summarized in the 0.7.0 notes above.
+
 ## [0.4.0] - 2026-06-29
 
 ### Added


### PR DESCRIPTION
## Summary
PROC-2 (partial) from the 2026-07-04 audit: the changelog jumped from 0.4.0 to 0.7.0 with no entries for the 0.5.x/0.6.x window. Adds a one-line annotation so readers know the gap is deliberate and where those changes are summarized.

The other half of PROC-2 (ESLint + Prettier with a CI format check) is deliberately not included: about half the source files fail Prettier today, so enforcing it means a repo-wide mechanical reformat commit, and lint rule selection is style policy. Both feel like maintainer calls rather than overnight agent changes; happy to run that rollout on request.