### PR TITLE
docs: codify contribution standards in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Utsuwa
 
-Thank you for your interest in contributing to Utsuwa! This document provides guidelines and information for contributors.
+Thank you for your interest in contributing to Utsuwa! Community PRs are welcome and reviewed with care. This document tells you what to expect and what gets a PR merged quickly.
 
 ## Getting Started
 
@@ -29,6 +29,55 @@ Thank you for your interest in contributing to Utsuwa! This document provides gu
 5. Open [http://localhost:5173](http://localhost:5173) in your browser
 6. For desktop development, run `pnpm tauri dev` instead (requires Rust)
 
+## What Lands Quickly
+
+A short list, learned from real PRs. Following it is the difference between one review round and three.
+
+**One thing per PR.** A PR that bundles a feature, a refactor, and a settings change will be asked to split. Small focused PRs get reviewed fast; each piece moves at its own speed.
+
+**Tests for pure logic.** The engine and helper modules are deliberately pure and testable, and CI runs the full suite on every PR. If you add or change a pure function (anything in `src/lib/engine/`, prompt building, parsing, budgets, truncation, dedup), add tests in the same PR. Pattern: `*.test.ts` next to the module, `node:test` runner, and relative imports need the `.ts` extension to run under `node --test`. Edge cases are first-class here: empty inputs, boundary values, and clock weirdness are exactly what the existing suites cover.
+
+**Gating lives in the pipeline, not the UI.** Hiding a control for some providers does not scope the feature. If a setting should only apply to certain providers or platforms, enforce that where the value is consumed (the chat pipeline, the server route), not just where the checkbox renders. A hidden toggle that still fires is a bug.
+
+**Don't change defaults out from under existing users.** If your change alters what happens for people who never touch your new setting (prompt composition, request parameters, truncation), call it out explicitly in the PR description, or better, make the old behavior the default.
+
+**No fork-local configuration upstream.** Personal ignore rules, editor and tool files, and fork housekeeping belong in your fork (or `.git/info/exclude`), not in upstream `.gitignore`.
+
+**Both provider surfaces, or neither.** Provider configuration currently renders in two places: onboarding (`ServicesStep`) and settings (`AiServicesSection`). Until they share components, a provider UI change should keep the two consistent. Say so in the PR if you deliberately did only one.
+
+**Match the code around you.** TypeScript everywhere, Svelte 5 runes (`$state`, `$derived`, `$effect`), design tokens instead of hardcoded colors (`var(--accent)`, not hex), and minimal comments that explain why, not what.
+
+Before pushing:
+
+```bash
+pnpm check   # svelte-check, must be 0 errors 0 warnings
+pnpm test    # full unit suite, must be green
+```
+
+CI runs both plus a Rust `cargo check` on every PR. A red check means no review until it's green.
+
+## Adding a Provider Integration
+
+LLM, TTS, and STT providers follow an established pattern. If you're adding or extending one:
+
+- Default base URLs live in one place: `src/lib/services/providers/provider-defaults.ts`. Never duplicate a URL into a component or route.
+- Local and self-hosted servers need base-URL normalization and origin handling like the existing Ollama and local-TTS integrations. Read one of those first and mirror it.
+- Web builds route cloud calls through the SvelteKit server routes; desktop and local providers call directly. Your change usually needs both paths, and they must behave identically (including auth headers when there is no API key).
+- Fixed cloud providers always use their official endpoint. User-supplied base URLs are for local and custom providers only.
+
+## Scope and Content Decisions
+
+Some changes are product decisions, not code decisions: anything that changes what Utsuwa ships in its prompts, how the project positions itself, or what the hosted deployment transmits. Open an issue to discuss before writing code, it saves everyone time.
+
+One standing decision, so nobody has to rediscover it: **Utsuwa core does not ship content preambles or filter-override text.** The persona system prompt is fully user-editable, on the user's machine, in the user's words, and that is where tone and content boundaries belong. PRs that bundle preamble text into the app will be asked to convert to documentation instead.
+
+## Review Expectations
+
+- Reviews check correctness first (including edge cases and cross-file effects), then scoping, duplication, and consistency. Expect specific, actionable comments; expect to be asked for tests.
+- `main` is production and moves fast, including maintainer refactors. If a refactor is about to touch an area your open PR changes, you'll get a heads-up in your PR thread; a rebase may still be needed. Rebasing promptly keeps your PR reviewable.
+- Significant features should update docs in the same PR: `README.md` and, for anything touching the companion engine or memory, `src/content/docs/technology/companion-system.md`.
+- Security issues: please report privately per [SECURITY.md](SECURITY.md), not in a public issue.
+
 ## How to Contribute
 
 ### Reporting Bugs
@@ -51,67 +100,53 @@ Feature requests are welcome! Please create an issue with:
 
 ### Pull Requests
 
-1. Create a new branch for your feature or fix:
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
-2. Make your changes
-3. Ensure your code follows the project's style:
-   ```bash
-   pnpm lint
-   ```
-4. Test your changes thoroughly
-5. Commit your changes with a clear message
-6. Push to your fork and submit a pull request
-
-## Code Style
-
-- Use TypeScript for all new code
-- Follow the existing code patterns in the project
-- Use Svelte 5 runes (`$state`, `$derived`, `$effect`) for reactivity
-- Keep components focused and single-purpose
-- Write self-documenting code with clear variable and function names
+1. Create a new branch: `feature/your-feature-name`, `fix/description`, or `docs/description`
+2. Make your changes, following the sections above
+3. Run `pnpm check` and `pnpm test`
+4. Use conventional commit style for the PR title (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`); PRs are squash-merged, so the title becomes the commit
+5. Push to your fork and open the PR with a description of what changed and how you tested it
 
 ## Project Structure
+
+The repo contains both the product and its website. Product code is what most contributions touch:
 
 ```
 src/
 ├── lib/
-│   ├── ai/            # LLM response parsing and prompt building
-│   ├── assets/        # Static assets (images, etc.)
-│   ├── components/    # Reusable Svelte components
+│   ├── ai/            # LLM response parsing and prompt building        [product]
+│   ├── components/    # Reusable Svelte components                      [product, except marketing/]
 │   ├── config/        # App and docs configuration
-│   ├── data/          # Event definitions and static data
-│   ├── db/            # IndexedDB database (Dexie)
-│   ├── engine/        # Companion engine (state, memory, events, heuristics)
-│   ├── services/      # LLM, TTS, STT, and storage services
-│   ├── stores/        # Svelte 5 stores for state management
-│   ├── styles/        # Shared CSS (prose, etc.)
+│   ├── data/          # Event definitions and static data               [product]
+│   ├── db/            # IndexedDB database (Dexie)                      [product]
+│   ├── engine/        # Companion engine: state, memory, events         [product, pure + tested]
+│   ├── services/      # LLM, TTS, STT, and storage services             [product]
+│   ├── stores/        # Svelte 5 rune stores                            [product]
+│   ├── styles/        # Shared CSS
 │   ├── types/         # TypeScript type definitions
 │   └── utils/         # Utility functions
 ├── content/
-│   ├── blog/          # Blog post markdown content
-│   └── docs/          # Documentation site markdown content
+│   ├── blog/          # Blog posts                                      [website]
+│   └── docs/          # Documentation site content                      [website]
 ├── routes/
-│   ├── app/           # Main application routes
-│   ├── api/           # API routes
-│   ├── blog/          # Blog routes
-│   ├── docs/          # Documentation site routes
-│   └── overlay/       # Desktop overlay route
-└── app.css            # Global styles
-src-tauri/              # Tauri desktop app (Rust)
+│   ├── app/           # Main application                                [product]
+│   ├── api/           # Server routes (chat proxy, model discovery)     [product]
+│   ├── blog/, docs/   # Website routes                                  [website]
+│   ├── overlay/       # Desktop overlay window                          [product]
+│   └── +page.svelte   # Landing page                                    [website]
+└── app.css            # Global styles and design tokens
+src-tauri/              # Tauri desktop shell (Rust)
 ```
 
 ## Releases
 
-Desktop builds are produced automatically by CI — there's no need to build installers on your own machine for a release.
+Desktop builds are produced automatically by CI. There's no need to build installers on your own machine for a release.
 
 Maintainers cut a release by pushing a version tag:
 
 ```bash
 # Bump the version in package.json, src-tauri/Cargo.toml, and src-tauri/tauri.conf.json first
-git tag v0.3.0
-git push origin v0.3.0
+git tag v0.9.0
+git push origin v0.9.0
 ```
 
 The [`Release` workflow](.github/workflows/release.yml) then builds the app on macOS, Windows, and Linux runners in parallel and attaches the installers to a **draft** GitHub Release:


### PR DESCRIPTION
## Summary
Now that community PRs are arriving, the review bar should be written down instead of discovered by being reviewed. This refresh adds:

- A "What Lands Quickly" section codifying the standards applied in recent reviews: one thing per PR, tests for pure logic (with the node --test pattern spelled out), gating in the pipeline rather than the UI, no silent default changes for existing users, no fork-local config upstream, and keeping both provider-config surfaces consistent
- A provider-integration pattern section (single source of truth for base URLs, web/desktop path parity, official endpoints for fixed cloud providers)
- A scope-and-content section documenting the standing decision that core does not ship content preambles or filter-override text; the persona prompt is the user's space
- Review expectations, including honest framing that main is production and moves fast, plus the heads-up etiquette for maintainer refactors that touch open PRs
- Product vs website annotations on the project structure so newcomers know which half is which

No changes to setup, release, or license sections beyond a version-number refresh in the tag example.