### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-07-05
+
+### Added
+- **She notices the distance now**: if the relationship weakens after a long absence, the stage no longer silently drops. Small dips hold steady, and a real drift is acknowledged in a new "Growing Apart" conversation where she tells you how it feels and you choose how to respond.
+- **Memory that speaks your language**: the on-device memory model is now multilingual, so companions remember and recall properly in Japanese, Korean, Russian, and more, not just English. Existing memories re-index themselves automatically (see note below).
+- **Chatting in other languages now counts**: messages written in non-Latin scripts previously barely moved the relationship because the mechanics only understood English. The model's own read of the conversation now carries full weight for those messages.
+
+### Fixed
+- Declining the confession no longer permanently blocks relationship progression, and the main and overlay windows no longer overwrite each other's progress.
+- Opening the app during the second day of an absence no longer swallows the reunion: time-away effects now apply when you actually return, not to a moment that didn't count.
+- Streaks survive daylight-saving transitions and device clock changes, and apologizing to your companion no longer reads as negativity.
+- Repeated observations merge into one memory instead of filling the memory book with near-duplicates, so recall stays sharp over long relationships.
+- Event popups fixed: no more dead click zone on dialogue and no crash when closing at the wrong moment.
+
+### Changed
+- Smoother streaming replies and faster startup for collections with several custom avatars.
+- The character settings page was rebuilt from one 2,300-line file into focused sections, with identical behavior.
+- Every change now runs the full test suite (197 tests) and type checks in CI before it can merge.
+
+### Note for existing users
+On your first launch after this update, Utsuwa downloads the new multilingual memory model (about 100 MB, one time, cached after that) and re-indexes your saved memories in the background. Everything keeps working during the re-index; memory recall briefly leans on keyword matching until it finishes.
+
 ## [0.8.0] - 2026-07-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.8.0"
+version = "0.9.0"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "pnpm build",


### PR DESCRIPTION
## Summary
- Version 0.8.0 to 0.9.0 in package.json, tauri.conf.json, Cargo.toml, and Cargo.lock
- CHANGELOG entry for 0.9.0 covering everything merged since the 0.8.0 tag (#84-#96): the Growing Apart mechanic, multilingual memory with automatic re-indexing, non-Latin input fixes, the confession-decline and cross-window fixes, memory dedup, performance work, CI, and the persona page rebuild
- Includes the migration note for the one-time multilingual model download

Tag v0.9.0 follows after merge; the release workflow builds installers into a draft for manual publish.