### PR TITLE
fix: reset TTS voice on provider switch and surface playback errors

### DIFF
--- a/src/lib/components/chat/BottomChatBar.svelte
+++ b/src/lib/components/chat/BottomChatBar.svelte
@@ -5,6 +5,7 @@
 	import { browser } from '$app/environment';
 	import { isTauri } from '$lib/services/platform/platform';
 	import { sttStore } from '$lib/stores/stt.svelte';
+	import { ttsStore } from '$lib/stores/tts.svelte';
 	import { prepareImage, UnsupportedImageError, type PreparedImage } from '$lib/services/storage/keepsakes';
 	import AudioVisualizer from './AudioVisualizer.svelte';
 	import { pop, fadeFast } from '$lib/utils/motion';
@@ -63,6 +64,13 @@
 		return () => {
 			if (hintTimer) clearTimeout(hintTimer);
 		};
+	});
+
+	// Surface voice playback failures; without this a TTS misconfiguration
+	// (like a stale voice id after switching providers) looks like she simply
+	// chose not to speak.
+	$effect(() => {
+		if (ttsStore.lastError) showHint(ttsStore.lastError);
 	});
 
 	function promptVision() {

--- a/src/lib/components/onboarding/steps/ServicesStep.svelte
+++ b/src/lib/components/onboarding/steps/ServicesStep.svelte
@@ -3,6 +3,7 @@
 	import { modulesStore } from '$lib/stores/modules.svelte';
 	import { settingsStore } from '$lib/stores/settings.svelte';
 	import { getLLMProvider, getTTSProvider } from '$lib/services/providers/registry';
+	import { defaultVoiceForProvider } from '$lib/services/tts/provider-utils';
 	import {
 		fetchModels,
 		getCachedModelsForProvider,
@@ -263,10 +264,11 @@
 		if (provider?.models?.length) {
 			modulesStore.setModuleSetting('speech', 'activeModel', provider.models[0].id);
 		}
-		// Local providers ship a default voice so requests work before the user picks one
-		if (provider?.isLocal && provider.voices?.length) {
-			modulesStore.setModuleSetting('speech', 'activeVoiceId', provider.voices[0].id);
-		}
+		// Voice ids are provider-specific (a Kokoro voice id means nothing to
+		// ElevenLabs), so switching providers always resets the voice: the new
+		// provider's first declared voice, or empty so its own default applies.
+		// Carrying the old value over made the next provider 404 silently.
+		modulesStore.setModuleSetting('speech', 'activeVoiceId', defaultVoiceForProvider(provider));
 		// Mark local providers as added immediately (they don't need API keys)
 		if (provider?.isLocal || !provider?.requiresApiKey) {
 			settingsStore.markProviderAdded(providerId);

--- a/src/lib/services/tts/elevenlabs.ts
+++ b/src/lib/services/tts/elevenlabs.ts
@@ -1,4 +1,5 @@
 import { getSharedAudioContext, type ITTSProvider, type TTSOptions, type TTSSpeakResult } from './index';
+import { providerErrorMessage } from './provider-utils';
 
 function ensureTrailingSlash(url: string): string {
 	return url.endsWith('/') ? url : url + '/';
@@ -44,7 +45,15 @@ export class ElevenLabsTTS implements ITTSProvider {
 		);
 
 		if (!response.ok) {
-			throw new Error(`ElevenLabs API error: ${response.status}`);
+			// Keep the API's own explanation (voice_not_found, quota_exceeded, ...)
+			// so the failure is self-diagnosing instead of a bare status code.
+			let body: unknown;
+			try {
+				body = await response.json();
+			} catch {
+				// non-JSON error body
+			}
+			throw new Error(providerErrorMessage('ElevenLabs', response.status, body));
 		}
 
 		const arrayBuffer = await response.arrayBuffer();

--- a/src/lib/services/tts/openai-tts.ts
+++ b/src/lib/services/tts/openai-tts.ts
@@ -4,6 +4,7 @@ import {
 	getLocalTTSConnectionHint,
 	isLocalTTSProvider
 } from '$lib/services/providers/local-endpoints';
+import { providerErrorMessage } from './provider-utils';
 
 function ensureTrailingSlash(url: string): string {
 	return url.endsWith('/') ? url : url + '/';
@@ -74,7 +75,13 @@ export class OpenAITTS implements ITTSProvider {
 					`Local TTS server returned ${response.status} at ${this.baseUrl}. Check the model and voice are valid for this server.`
 				);
 			}
-			throw new Error(`OpenAI TTS API error: ${response.status}`);
+			let body: unknown;
+			try {
+				body = await response.json();
+			} catch {
+				// non-JSON error body
+			}
+			throw new Error(providerErrorMessage('OpenAI TTS', response.status, body));
 		}
 
 		const arrayBuffer = await response.arrayBuffer();

--- a/src/lib/services/tts/provider-utils.test.ts
+++ b/src/lib/services/tts/provider-utils.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { defaultVoiceForProvider, providerErrorMessage } from './provider-utils.ts';
+
+// --- defaultVoiceForProvider ---
+
+test('returns the first declared voice for a provider', () => {
+	const provider = { voices: [{ id: '21m00Tcm4TlvDq8ikWAM' }, { id: 'EXAVITQu4vr4xnSDxMaL' }] };
+	assert.equal(defaultVoiceForProvider(provider), '21m00Tcm4TlvDq8ikWAM');
+});
+
+test('returns empty for providers without declared voices, so the provider default applies', () => {
+	assert.equal(defaultVoiceForProvider({}), '');
+	assert.equal(defaultVoiceForProvider({ voices: [] }), '');
+	assert.equal(defaultVoiceForProvider(undefined), '');
+	assert.equal(defaultVoiceForProvider(null), '');
+});
+
+// --- providerErrorMessage ---
+
+test('extracts the ElevenLabs detail shape', () => {
+	const body = {
+		detail: { type: 'not_found', code: 'voice_not_found', message: "A voice with voice_id 'af_bella' was not found.", status: 'voice_not_found' }
+	};
+	assert.equal(
+		providerErrorMessage('ElevenLabs', 404, body),
+		"ElevenLabs error 404: A voice with voice_id 'af_bella' was not found."
+	);
+});
+
+test('extracts the OpenAI error shape', () => {
+	const body = { error: { message: 'Invalid voice: bella-af', type: 'invalid_request_error' } };
+	assert.equal(providerErrorMessage('OpenAI TTS', 400, body), 'OpenAI TTS error 400: Invalid voice: bella-af');
+});
+
+test('falls back to a generic message field, a string body, or status only', () => {
+	assert.equal(providerErrorMessage('TTS', 500, { message: 'boom' }), 'TTS error 500: boom');
+	assert.equal(providerErrorMessage('TTS', 502, 'Bad gateway'), 'TTS error 502: Bad gateway');
+	assert.equal(providerErrorMessage('TTS', 429), 'TTS error 429');
+	assert.equal(providerErrorMessage('TTS', 401, {}), 'TTS error 401');
+});
+
+test('long details are truncated so toasts stay readable', () => {
+	const message = providerErrorMessage('TTS', 400, { message: 'x'.repeat(500) });
+	assert.ok(message.length <= 'TTS error 400: '.length + 160);
+});

--- a/src/lib/services/tts/provider-utils.ts
+++ b/src/lib/services/tts/provider-utils.ts
@@ -1,0 +1,49 @@
+// Pure TTS provider helpers, dependency-free so they run under node --test.
+
+// Voice ids are provider-specific (a Kokoro voice id means nothing to
+// ElevenLabs), so provider switches reset the voice to the new provider's
+// first declared voice. Empty means "let the provider use its own default".
+export function defaultVoiceForProvider(
+	provider?: { voices?: Array<{ id: string }> } | null
+): string {
+	return provider?.voices?.[0]?.id ?? '';
+}
+
+const MAX_DETAIL_LENGTH = 160;
+
+// Builds a human-readable error out of a TTS API failure, keeping the API's
+// own explanation (e.g. ElevenLabs' "voice_not_found") instead of just the
+// status code, so the failure is self-diagnosing in the UI and the console.
+export function providerErrorMessage(provider: string, status: number, body?: unknown): string {
+	const detail = extractDetail(body);
+	return detail ? `${provider} error ${status}: ${detail}` : `${provider} error ${status}`;
+}
+
+function extractDetail(body: unknown): string {
+	if (!body) return '';
+	if (typeof body === 'string') return body.slice(0, MAX_DETAIL_LENGTH);
+	if (typeof body !== 'object') return '';
+
+	const record = body as Record<string, unknown>;
+
+	// ElevenLabs: { detail: { message, status, ... } }
+	const detail = record.detail;
+	if (detail && typeof detail === 'object') {
+		const message = (detail as Record<string, unknown>).message;
+		if (typeof message === 'string') return message.slice(0, MAX_DETAIL_LENGTH);
+		const statusText = (detail as Record<string, unknown>).status;
+		if (typeof statusText === 'string') return statusText.slice(0, MAX_DETAIL_LENGTH);
+	}
+
+	// OpenAI-style: { error: { message } }
+	const error = record.error;
+	if (error && typeof error === 'object') {
+		const message = (error as Record<string, unknown>).message;
+		if (typeof message === 'string') return message.slice(0, MAX_DETAIL_LENGTH);
+	}
+
+	// Generic: { message }
+	if (typeof record.message === 'string') return record.message.slice(0, MAX_DETAIL_LENGTH);
+
+	return '';
+}

--- a/src/lib/stores/tts.svelte.ts
+++ b/src/lib/stores/tts.svelte.ts
@@ -6,6 +6,17 @@ function createTTSStore() {
 	let currentAnalyser = $state<AnalyserNode | null>(null);
 	let currentSource = $state<AudioBufferSourceNode | null>(null);
 	let queue = $state<string[]>([]);
+	// Last playback failure, surfaced by the UI as a toast. Silent failures made
+	// misconfigurations (like a stale voice id from another provider) look like
+	// the companion just chose not to speak.
+	let lastError = $state<string | null>(null);
+	let errorTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function reportError(error: unknown) {
+		lastError = error instanceof Error ? error.message : 'Voice playback failed';
+		if (errorTimer) clearTimeout(errorTimer);
+		errorTimer = setTimeout(() => (lastError = null), 8000);
+	}
 
 	async function speak(text: string, options: TTSOptions) {
 		// Cloud providers need a key; local servers (e.g. Kokoro) don't.
@@ -47,6 +58,7 @@ function createTTSStore() {
 			});
 		} catch (error) {
 			console.error('TTS error:', error);
+			reportError(error);
 		}
 
 		// Process next in queue
@@ -73,6 +85,9 @@ function createTTSStore() {
 		},
 		get currentAnalyser() {
 			return currentAnalyser;
+		},
+		get lastError() {
+			return lastError;
 		},
 		speak,
 		stop

--- a/src/routes/app/settings/persona/persona-page.svelte.ts
+++ b/src/routes/app/settings/persona/persona-page.svelte.ts
@@ -4,6 +4,7 @@ import { vrmStore } from '$lib/stores/vrm.svelte';
 import { modulesStore } from '$lib/stores/modules.svelte';
 import { settingsStore } from '$lib/stores/settings.svelte';
 import { getLLMProvider, getTTSProvider } from '$lib/services/providers/registry';
+import { defaultVoiceForProvider } from '$lib/services/tts/provider-utils';
 import { allEvents } from '$lib/data/events';
 import type { CompletedEventRecord, EventType } from '$lib/types/events';
 import {
@@ -294,10 +295,11 @@ export function createPersonaPageState() {
 		if (provider?.models?.length) {
 			modulesStore.setModuleSetting('speech', 'activeModel', provider.models[0].id);
 		}
-		// Local providers ship a default voice so requests work before the user picks one
-		if (provider?.isLocal && provider.voices?.length) {
-			modulesStore.setModuleSetting('speech', 'activeVoiceId', provider.voices[0].id);
-		}
+		// Voice ids are provider-specific (a Kokoro voice id means nothing to
+		// ElevenLabs), so switching providers always resets the voice: the new
+		// provider's first declared voice, or empty so its own default applies.
+		// Carrying the old value over made the next provider 404 silently.
+		modulesStore.setModuleSetting('speech', 'activeVoiceId', defaultVoiceForProvider(provider));
 		// Mark local providers as added immediately (they don't need API keys)
 		if (provider?.isLocal || !provider?.requiresApiKey) {
 			settingsStore.markProviderAdded(providerId);


### PR DESCRIPTION
## Summary
Found while investigating the ElevenLabs report on #95, and reproduced live on production: the speech module keeps one shared activeVoiceId across all TTS providers, and switching providers only reset it for local ones. Anyone who used a local TTS (Kokoro voice ids like af_bella) or OpenAI TTS and then switched to ElevenLabs had the stale voice id sent along, which ElevenLabs rejects with 404 voice_not_found. The app swallowed the error, so the companion just silently stopped speaking.

- Provider switches now always reset the voice to the new provider's first declared registry voice, or empty so the provider's own default applies (applied in both the settings page and onboarding, per the both-surfaces rule)
- New pure `services/tts/provider-utils` helper with tests: default-voice resolution plus error formatting that keeps the API's own detail (ElevenLabs detail.message, OpenAI error.message, generic message, string bodies, truncated for toasts)
- ElevenLabs and OpenAI TTS now throw with that detail instead of a bare status code
- The TTS store exposes lastError and the chat bar surfaces it as a toast (auto-dismisses), so playback failures are self-diagnosing instead of silent

## Repro evidence (production, before the fix)
- App request: POST /v1/text-to-speech/af_bella/stream -> 404
- API body: voice_not_found, "A voice with voice_id 'af_bella' was not found."
- Console: "TTS error: Error: ElevenLabs API error: 404" and nothing visible to the user
- After correcting the voice id, the same pipeline synthesized and played normally

## Testing
- 6 new unit tests for the pure helpers (203/203 total, svelte-check clean)
- Full browser e2e on the deployed app confirmed the failure mechanism and the healthy path; a post-merge e2e of the switch flow itself will be run when this lands

## Notes
- Deliberately not merging yet; queued for 0.9.1 so open community work can settle first
- Existing users already in the stale state get unstuck by the toast (which now names the bad voice id) or by re-picking any voice