### PR TITLE
OpenAI-compatible model discovery, searchable dropdown and advanced parameters   

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,19 @@ The desktop app uses the same codebase as the web version, and your save files a
 
 ## Supported Providers
 
-### LLM Providers (7)
+### LLM Providers (8)
+
+Utsuwa supports popular cloud and local LLMs. For endpoints that speak the OpenAI API (OpenRouter, Together, vLLM, LiteLLM, etc.), use the **OpenAI-Compatible** provider:
+- Set the **Base URL** to the endpoint root (e.g. `https://api.openai.com/v1/`).
+- **API Key** is optional; leave it empty for keyless local servers.
+- Enter a model manually or fetch available models after providing a base URL.
+- **Advanced Parameters** (temperature, top-p, max tokens, presence/frequency penalties) are passed to the endpoint when set.
 
 | Category | Providers |
 |----------|-----------|
 | **Cloud** | OpenAI, Anthropic, Google Gemini, DeepSeek, xAI (Grok) |
 | **Local** | Ollama, LM Studio |
+| **OpenAI-Compatible** | OpenRouter, Together, vLLM, LiteLLM, etc. |
 
 ### TTS Providers (3)
 

--- a/src/lib/components/onboarding/steps/ServicesStep.svelte
+++ b/src/lib/components/onboarding/steps/ServicesStep.svelte
@@ -375,6 +375,7 @@
 
 		<!-- Model: manual entry for custom endpoints, discovered dropdown otherwise -->
 		{#if llmProvider?.custom}
+			{@const customConfig = settingsStore.getProviderConfig(llmProvider.id)}
 			<input
 				type="text"
 				class="api-key-input"
@@ -382,6 +383,19 @@
 				value={(llmSettings.activeModel as string) ?? ''}
 				oninput={(e) => handleLLMModelChange(e.currentTarget.value.trim())}
 			/>
+			{#if customConfig.baseUrl}
+				<ModelDropdown
+					models={llmModels}
+					value={llmSettings.activeModel as string}
+					onSelect={handleLLMModelChange}
+					placeholder="Pick a fetched model..."
+					isLoading={llmIsLoading}
+					onRefresh={fetchLLMModels}
+					disabled={false}
+				/>
+			{:else}
+				<p class="provider-note">Enter a base URL to fetch available models.</p>
+			{/if}
 		{:else if llmSettings.activeProvider}
 			<ModelDropdown
 				models={llmModels}

--- a/src/lib/components/ui/ModelDropdown.svelte
+++ b/src/lib/components/ui/ModelDropdown.svelte
@@ -29,13 +29,34 @@
 		disabledMessage = 'Enter API key first'
 	}: Props = $props();
 
+	let searchQuery = $state('');
+	let open = $state(false);
+
 	const isDisabled = $derived(disabled || isLoading);
 
 	const selectedModel = $derived(models.find((m) => m.id === value));
+
+	// Always include the currently selected model, even if it doesn't match the filter
+	const filteredModels = $derived.by(() => {
+		const q = searchQuery.trim().toLowerCase();
+		if (!q) return models;
+		const filtered = models.filter(
+			(m) => m.name.toLowerCase().includes(q) || m.id.toLowerCase().includes(q)
+		);
+		if (selectedModel && !filtered.some((m) => m.id === selectedModel.id)) {
+			return [selectedModel, ...filtered];
+		}
+		return filtered;
+	});
+
+	function handleSelect(modelId: string) {
+		searchQuery = '';
+		onSelect(modelId);
+	}
 </script>
 
 <div class="model-dropdown-wrapper">
-	<DropdownMenu.Root>
+	<DropdownMenu.Root bind:open>
 		<DropdownMenu.Trigger class="model-dropdown-trigger" disabled={isDisabled}>
 			{#if isLoading}
 				<span class="trigger-loading">
@@ -56,11 +77,27 @@
 
 		<DropdownMenu.Portal>
 			<DropdownMenu.Content class="model-dropdown-content" align="start" sideOffset={4}>
+				<div class="search-row">
+					<Icon name="search" size={14} />
+					<input
+						type="text"
+						class="search-input"
+						placeholder="Search models..."
+						bind:value={searchQuery}
+						onclick={(e) => e.stopPropagation()}
+						onkeydown={(e) => e.stopPropagation()}
+					/>
+					{#if searchQuery}
+						<button class="search-clear" onclick={() => (searchQuery = '')}>
+							<Icon name="x" size={12} />
+						</button>
+					{/if}
+				</div>
 				<div class="model-dropdown-scroll">
-					{#each models as model (model.id)}
+					{#each filteredModels as model (model.id)}
 						<DropdownMenu.Item
 							class="model-item {value === model.id ? 'selected' : ''}"
-							onSelect={() => onSelect(model.id)}
+							onSelect={() => handleSelect(model.id)}
 						>
 							<span class="model-name">{model.name}</span>
 							{#if value === model.id}
@@ -70,8 +107,8 @@
 							{/if}
 						</DropdownMenu.Item>
 					{/each}
-					{#if models.length === 0 && !isLoading}
-						<div class="no-models">No models available</div>
+					{#if filteredModels.length === 0 && !isLoading}
+						<div class="no-models">No models found</div>
 					{/if}
 				</div>
 			</DropdownMenu.Content>
@@ -206,6 +243,51 @@
 			opacity: 1;
 			transform: translateY(0);
 		}
+	}
+
+	.search-row {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		padding: 0.375rem 0.5rem;
+		margin-bottom: 0.25rem;
+		background: var(--bg-secondary);
+		border-radius: var(--radius-md);
+	}
+
+	.search-row :global(svg) {
+		color: var(--text-tertiary);
+		flex-shrink: 0;
+	}
+
+	.search-input {
+		flex: 1;
+		background: transparent;
+		border: none;
+		outline: none;
+		font-family: inherit;
+		font-size: 0.8125rem;
+		color: var(--text-primary);
+	}
+
+	.search-input::placeholder {
+		color: var(--text-tertiary);
+	}
+
+	.search-clear {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.125rem;
+		background: transparent;
+		border: none;
+		color: var(--text-tertiary);
+		cursor: pointer;
+		border-radius: var(--radius-sm);
+	}
+
+	.search-clear:hover {
+		color: var(--text-primary);
 	}
 
 	:global(.model-dropdown-content[data-state='closed']) {

--- a/src/lib/components/ui/ModelDropdown.svelte
+++ b/src/lib/components/ui/ModelDropdown.svelte
@@ -53,6 +53,11 @@
 		searchQuery = '';
 		onSelect(modelId);
 	}
+
+	// Clear the search filter when the dropdown closes so reopening starts fresh.
+	$effect(() => {
+		if (!open) searchQuery = '';
+	});
 </script>
 
 <div class="model-dropdown-wrapper">

--- a/src/lib/services/chat/client-chat.ts
+++ b/src/lib/services/chat/client-chat.ts
@@ -24,6 +24,11 @@ interface ChatOptions {
 	apiKey?: string;
 	baseURL?: string;
 	systemPrompt: string;
+	temperature?: number;
+	maxTokens?: number;
+	topP?: number;
+	presencePenalty?: number;
+	frequencyPenalty?: number;
 }
 
 function getCurrentSiteOrigin(): string | undefined {
@@ -93,7 +98,12 @@ export async function streamChatDirect(
 						role: m.role,
 						content: toOpenAIContent(m.content)
 					})),
-					stream: true
+					stream: true,
+					...(options.temperature !== undefined && { temperature: options.temperature }),
+					...(options.maxTokens !== undefined && { max_tokens: options.maxTokens }),
+					...(options.topP !== undefined && { top_p: options.topP }),
+					...(options.presencePenalty !== undefined && { presence_penalty: options.presencePenalty }),
+					...(options.frequencyPenalty !== undefined && { frequency_penalty: options.frequencyPenalty })
 				});
 
 	const url = provider === 'anthropic'

--- a/src/lib/services/chat/companion-chat.ts
+++ b/src/lib/services/chat/companion-chat.ts
@@ -174,6 +174,17 @@ export async function sendCompanionMessage(
 		const messages = buildMessages(images);
 		const onDelta = (full: string) => chatStore.updateLastMessage(full);
 
+		// Advanced parameters are only supported for OpenAI-compatible endpoints.
+		const advancedParams = providerMeta?.custom
+			? {
+					temperature: (consciousnessSettings.temperature as number) ?? 0.7,
+					topP: (consciousnessSettings.topP as number) ?? 1.0,
+					maxTokens: (consciousnessSettings.maxTokens as number) || undefined,
+					presencePenalty: (consciousnessSettings.presencePenalty as number) ?? 0,
+					frequencyPenalty: (consciousnessSettings.frequencyPenalty as number) ?? 0
+				}
+			: {};
+
 		let fullContent = '';
 		if (isTauri() || providerMeta?.isLocal) {
 			// Desktop and local providers call the provider API directly.
@@ -185,7 +196,8 @@ export async function sendCompanionMessage(
 						model: selectedModel,
 						apiKey: apiKey || undefined,
 						baseURL,
-						systemPrompt
+						systemPrompt,
+						...advancedParams
 					},
 					(text) => {
 						fullContent += text;
@@ -204,7 +216,8 @@ export async function sendCompanionMessage(
 					model: selectedModel,
 					apiKey: apiKey || 'not-needed',
 					baseURL,
-					systemPrompt
+					systemPrompt,
+					...advancedParams
 				},
 				onDelta
 			);

--- a/src/lib/services/modules/essential/consciousness.ts
+++ b/src/lib/services/modules/essential/consciousness.ts
@@ -35,11 +35,31 @@ export const consciousnessModule: ModuleDefinition = {
 				defaultValue: 0.7
 			},
 			{
+				key: 'topP',
+				type: 'number',
+				label: 'Top P',
+				description: 'Nucleus sampling threshold (0.0-1.0)',
+				defaultValue: 1.0
+			},
+			{
 				key: 'maxTokens',
 				type: 'number',
 				label: 'Max Tokens',
-				description: 'Maximum tokens in response',
-				defaultValue: 2048
+				description: 'Maximum tokens in response. Leave empty to use the provider default.'
+			},
+			{
+				key: 'presencePenalty',
+				type: 'number',
+				label: 'Presence Penalty',
+				description: 'Penalizes tokens that have already appeared (-2.0 to 2.0)',
+				defaultValue: 0
+			},
+			{
+				key: 'frequencyPenalty',
+				type: 'number',
+				label: 'Frequency Penalty',
+				description: 'Penalizes tokens based on how often they appeared (-2.0 to 2.0)',
+				defaultValue: 0
 			}
 		]
 	},

--- a/src/lib/services/providers/client-models.ts
+++ b/src/lib/services/providers/client-models.ts
@@ -1,5 +1,6 @@
 import type { LLMProvider } from '$lib/types';
 import {
+	ensureOpenAIPath,
 	getLocalProviderConnectionHint,
 	getModelsBaseUrl,
 	isLocalLLMProvider
@@ -41,6 +42,18 @@ function normalizeModelName(id: string, providerId: string): string {
 	return name;
 }
 
+function looksLikeOllama(baseUrl: string): boolean {
+	try {
+		const url = new URL(baseUrl);
+		return (
+			(url.hostname === 'localhost' || url.hostname === '127.0.0.1') &&
+			url.port === '11434'
+		);
+	} catch {
+		return false;
+	}
+}
+
 /**
  * Fetch models directly from provider APIs.
  * Used in Tauri builds where SvelteKit server routes aren't available.
@@ -72,6 +85,34 @@ export async function fetchModelsDirect(
 					id: m.id,
 					name: normalizeModelName(m.id, providerId)
 				}));
+				break;
+			}
+			case 'openai-compatible': {
+				// OpenAI-compatible endpoints (OpenRouter, Together, vLLM, ...) may or
+				// may not require an API key. Keep all returned models as-is.
+				const headers: Record<string, string> = {};
+				if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+				// Ollama exposes an OpenAI-compatible chat endpoint but its model list
+				// lives at /api/tags rather than /v1/models.
+				if (looksLikeOllama(cleanBaseUrl)) {
+					const res = await fetch(`${cleanBaseUrl}/api/tags`, { headers });
+					if (!res.ok) throw new Error(`Failed to fetch models: ${res.statusText}`);
+					const data = await res.json();
+					models = (data.models || []).map((m: { name: string }) => ({
+						id: m.name,
+						name: m.name
+					}));
+				} else {
+					const normalizedUrl = ensureOpenAIPath(cleanBaseUrl);
+					const res = await fetch(`${normalizedUrl}/models`, { headers });
+					if (!res.ok) throw new Error(`Failed to fetch models: ${res.statusText}`);
+					const data = await res.json();
+					models = (data.data || []).map((m: { id: string }) => ({
+						id: m.id,
+						name: m.id
+					}));
+				}
 				break;
 			}
 			case 'anthropic': {

--- a/src/lib/services/providers/local-endpoints.ts
+++ b/src/lib/services/providers/local-endpoints.ts
@@ -15,7 +15,7 @@ function stripOpenAIPath(url: string): string {
 	return trimTrailingSlashes(url).replace(/\/v1$/, '');
 }
 
-function ensureOpenAIPath(url: string): string {
+export function ensureOpenAIPath(url: string): string {
 	const cleanUrl = trimTrailingSlashes(url);
 	return cleanUrl.endsWith('/v1') ? cleanUrl : `${cleanUrl}/v1`;
 }

--- a/src/lib/services/providers/use-model-fetch.ts
+++ b/src/lib/services/providers/use-model-fetch.ts
@@ -3,6 +3,7 @@
  */
 
 import { fetchProviderModels, type ModelInfo } from './model-fetcher';
+import { getLLMProvider, getTTSProvider } from './registry';
 import { settingsStore } from '$lib/stores/settings.svelte';
 
 export type { ModelInfo };
@@ -58,7 +59,9 @@ export async function fetchModels(options: FetchModelsOptions): Promise<void> {
 		onStale
 	} = options;
 
-	if (!providerId || (!isLocal && !apiKey)) return;
+	const provider = getLLMProvider(providerId) || getTTSProvider(providerId);
+	// Custom OpenAI-compatible endpoints may not require an API key.
+	if (!providerId || (!isLocal && !apiKey && !provider?.custom)) return;
 
 	onStart();
 

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -11,7 +11,7 @@ import { DEFAULT_CHAT_BASE_URLS } from '$lib/services/providers/provider-default
 const LOCAL_PROVIDERS: LLMProvider[] = ['ollama', 'lmstudio'];
 
 export const POST: RequestHandler = async ({ request }) => {
-	const { messages, provider, model, apiKey, baseURL, systemPrompt } = await request.json();
+	const { messages, provider, model, apiKey, baseURL, systemPrompt, temperature, maxTokens, topP, presencePenalty, frequencyPenalty } = await request.json();
 
 	if (!Array.isArray(messages)) {
 		return new Response(JSON.stringify({ error: 'messages must be an array' }), {
@@ -22,9 +22,10 @@ export const POST: RequestHandler = async ({ request }) => {
 
 	const typedProvider = provider as LLMProvider;
 
-	// Local providers don't require API keys
+	// Local providers and OpenAI-compatible endpoints don't require API keys.
 	const isLocalProvider = LOCAL_PROVIDERS.includes(typedProvider);
-	if (!apiKey && !isLocalProvider) {
+	const isKeylessProvider = isLocalProvider || typedProvider === 'openai-compatible';
+	if (!apiKey && !isKeylessProvider) {
 		return new Response(JSON.stringify({ error: 'API key required' }), {
 			status: 400,
 			headers: { 'Content-Type': 'application/json' }
@@ -83,7 +84,14 @@ export const POST: RequestHandler = async ({ request }) => {
 				baseURL: providerBaseURL,
 				model,
 				messages: messagesWithSystem,
-				headers
+				headers,
+				...(typedProvider === 'openai-compatible' && {
+					...(temperature !== undefined && { temperature }),
+					...(maxTokens !== undefined && { max_tokens: maxTokens }),
+					...(topP !== undefined && { top_p: topP }),
+					...(presencePenalty !== undefined && { presence_penalty: presencePenalty }),
+					...(frequencyPenalty !== undefined && { frequency_penalty: frequencyPenalty })
+				})
 			});
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : 'Failed to connect to provider';

--- a/src/routes/api/providers/models/+server.ts
+++ b/src/routes/api/providers/models/+server.ts
@@ -1,7 +1,11 @@
 import { env } from '$env/dynamic/private';
 import type { RequestHandler } from './$types';
 import type { LLMProvider } from '$lib/types';
-import { getModelsBaseUrl } from '$lib/services/providers/local-endpoints';
+import {
+	ensureOpenAIPath,
+	getModelsBaseUrl,
+	isLocalLLMProvider
+} from '$lib/services/providers/local-endpoints';
 import { assertSafeProviderUrl } from '$lib/services/providers/url-guard';
 import { DEFAULT_MODELS_BASE_URLS } from '$lib/services/providers/provider-defaults';
 
@@ -28,7 +32,7 @@ const MODEL_FILTERS: Record<string, RegExp> = {
 
 function filterModels(providerId: string, models: ModelInfo[]): ModelInfo[] {
 	const filter = MODEL_FILTERS[providerId];
-	if (!filter) return models; // No filter = keep all (Ollama, LM Studio)
+	if (!filter) return models; // No filter = keep all (Ollama, LM Studio, openai-compatible)
 	return models.filter((m) => filter.test(m.id));
 }
 
@@ -58,13 +62,25 @@ function normalizeModelName(id: string, providerId: string): string {
 	return name;
 }
 
-async function fetchOpenAIModels(apiKey: string, baseUrl: string): Promise<ModelInfo[]> {
-	const response = await fetch(`${baseUrl}/models`, {
-		headers: { Authorization: `Bearer ${apiKey}` }
-	});
+function looksLikeOllama(baseUrl: string): boolean {
+	try {
+		const url = new URL(baseUrl);
+		return (
+			(url.hostname === 'localhost' || url.hostname === '127.0.0.1') &&
+			url.port === '11434'
+		);
+	} catch {
+		return false;
+	}
+}
+
+async function fetchOpenAIModels(apiKey: string | undefined, baseUrl: string): Promise<ModelInfo[]> {
+	const headers: Record<string, string> = {};
+	if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+	const response = await fetch(`${baseUrl}/models`, { headers });
 	if (!response.ok) throw new Error(`Failed to fetch models: ${response.statusText}`);
 	const data = await response.json();
-	return data.data.map((m: { id: string }) => ({
+	return (data.data || []).map((m: { id: string }) => ({
 		id: m.id,
 		name: normalizeModelName(m.id, 'openai')
 	}));
@@ -212,6 +228,16 @@ export const POST: RequestHandler = async ({ request }) => {
 				if (!apiKey) throw new Error('API key required for OpenAI');
 				models = await fetchOpenAIModels(apiKey, cleanBaseUrl);
 				break;
+			case 'openai-compatible': {
+				// OpenAI-compatible endpoints may or may not require an API key.
+				if (looksLikeOllama(cleanBaseUrl)) {
+					models = await fetchOllamaModels(cleanBaseUrl);
+				} else {
+					const normalizedUrl = ensureOpenAIPath(cleanBaseUrl);
+					models = await fetchOpenAIModels(apiKey, normalizedUrl);
+				}
+				break;
+			}
 			case 'anthropic':
 				if (!apiKey) throw new Error('API key required for Anthropic');
 				models = await fetchAnthropicModels(apiKey, cleanBaseUrl);

--- a/src/routes/app/settings/persona/AiServicesSection.svelte
+++ b/src/routes/app/settings/persona/AiServicesSection.svelte
@@ -79,6 +79,7 @@
 
 						<!-- Model: manual entry for custom endpoints, discovered dropdown otherwise -->
 						{#if provider?.custom}
+							{@const customConfig = settingsStore.getProviderConfig(provider.id)}
 							<div class="api-key-row">
 								<input
 									type="text"
@@ -88,6 +89,120 @@
 									oninput={(e) => page.handleLLMModelChange(e.currentTarget.value.trim())}
 								/>
 							</div>
+							{#if customConfig.baseUrl}
+								<div class="api-key-row">
+									<ModelDropdown
+										models={page.llmModels}
+										value={page.consciousnessSettings.activeModel as string}
+										onSelect={page.handleLLMModelChange}
+										placeholder="Pick a fetched model..."
+										isLoading={page.llmIsLoading}
+										onRefresh={page.fetchLLMModels}
+										disabled={false}
+									/>
+								</div>
+							{:else}
+								<p class="provider-note">Enter a base URL to fetch available models.</p>
+							{/if}
+
+							<!-- Advanced Parameters -->
+							<details class="llm-advanced-params">
+								<summary>Advanced Parameters</summary>
+								<div class="llm-param-grid">
+									<div class="llm-param-row">
+										<label class="llm-param-label" for="llm-temperature">
+											Temperature
+											<span class="llm-param-value">{((page.consciousnessSettings.temperature as number) ?? 0.7).toFixed(2)}</span>
+										</label>
+										<input
+											id="llm-temperature"
+											type="range"
+											class="llm-param-slider"
+											min="0"
+											max="2"
+											step="0.05"
+											value={(page.consciousnessSettings.temperature as number) ?? 0.7}
+											oninput={(e) => page.handleLLMNumberSetting('temperature', Number(e.currentTarget.value))}
+										/>
+										<p class="provider-note">Controls randomness: 0 = focused, 2 = highly creative.</p>
+									</div>
+
+									<div class="llm-param-row">
+										<label class="llm-param-label" for="llm-top-p">
+											Top P
+											<span class="llm-param-value">{((page.consciousnessSettings.topP as number) ?? 1.0).toFixed(2)}</span>
+										</label>
+										<input
+											id="llm-top-p"
+											type="range"
+											class="llm-param-slider"
+											min="0"
+											max="1"
+											step="0.05"
+											value={(page.consciousnessSettings.topP as number) ?? 1.0}
+											oninput={(e) => page.handleLLMNumberSetting('topP', Number(e.currentTarget.value))}
+										/>
+										<p class="provider-note">Nucleus sampling: 1 = disabled.</p>
+									</div>
+
+									<div class="llm-param-row">
+										<label class="llm-param-label" for="llm-max-tokens">
+											Max Tokens
+											<span class="llm-param-value">{page.consciousnessSettings.maxTokens ?? '—'}</span>
+										</label>
+										<input
+											id="llm-max-tokens"
+											type="number"
+											class="api-key-input"
+											min="1"
+											step="1"
+											placeholder="Unlimited"
+											value={(page.consciousnessSettings.maxTokens as number) ?? ''}
+											oninput={(e) => {
+												const val = e.currentTarget.value;
+												page.handleLLMNumberSetting('maxTokens', val ? parseInt(val, 10) : undefined);
+											}}
+										/>
+										<p class="provider-note">Hard limit for the number of tokens in the response. Leave empty to use the provider default.</p>
+									</div>
+
+									<div class="llm-param-row">
+										<label class="llm-param-label" for="llm-presence-penalty">
+											Presence Penalty
+											<span class="llm-param-value">{((page.consciousnessSettings.presencePenalty as number) ?? 0).toFixed(1)}</span>
+										</label>
+										<input
+											id="llm-presence-penalty"
+											type="range"
+											class="llm-param-slider"
+											min="-2"
+											max="2"
+											step="0.1"
+											value={(page.consciousnessSettings.presencePenalty as number) ?? 0}
+											oninput={(e) => page.handleLLMNumberSetting('presencePenalty', Number(e.currentTarget.value))}
+										/>
+										<p class="provider-note">Reduces repetition of tokens already used.</p>
+									</div>
+
+									<div class="llm-param-row">
+										<label class="llm-param-label" for="llm-frequency-penalty">
+											Frequency Penalty
+											<span class="llm-param-value">{((page.consciousnessSettings.frequencyPenalty as number) ?? 0).toFixed(1)}</span>
+										</label>
+										<input
+											id="llm-frequency-penalty"
+											type="range"
+											class="llm-param-slider"
+											min="-2"
+											max="2"
+											step="0.1"
+											value={(page.consciousnessSettings.frequencyPenalty as number) ?? 0}
+											oninput={(e) => page.handleLLMNumberSetting('frequencyPenalty', Number(e.currentTarget.value))}
+										/>
+										<p class="provider-note">Stronger penalty for frequently repeated tokens.</p>
+									</div>
+								</div>
+							</details>
 						{:else}
 							<ModelDropdown
 								models={page.llmModels}
@@ -443,5 +558,54 @@
 		40% { transform: translateX(4px); }
 		60% { transform: translateX(-3px); }
 		80% { transform: translateX(2px); }
+	}
+
+	.llm-advanced-params {
+		margin-top: 0.75rem;
+		border: 1px solid var(--bg-tertiary);
+		border-radius: var(--radius-lg);
+		padding: 0.75rem;
+		background: var(--bg-primary);
+	}
+
+	.llm-advanced-params summary {
+		font-size: 0.85rem;
+		font-weight: 500;
+		color: var(--text-secondary);
+		cursor: pointer;
+		user-select: none;
+	}
+
+	.llm-param-grid {
+		margin-top: 0.75rem;
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		gap: 0.75rem;
+	}
+
+	.llm-param-row {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+
+	.llm-param-label {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		font-size: 0.8rem;
+		font-weight: 500;
+		color: var(--text-secondary);
+	}
+
+	.llm-param-value {
+		font-size: 0.75rem;
+		color: var(--text-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.llm-param-slider {
+		width: 100%;
+		cursor: pointer;
 	}
 </style>

--- a/src/routes/app/settings/persona/persona-page.svelte.ts
+++ b/src/routes/app/settings/persona/persona-page.svelte.ts
@@ -267,6 +267,11 @@ export function createPersonaPageState() {
 		}
 	}
 
+	function handleLLMNumberSetting(key: string, value: number | undefined) {
+		if (value !== undefined && Number.isNaN(value)) return;
+		modulesStore.setModuleSetting('consciousness', key, value);
+	}
+
 	function handleLLMModelChange(modelId: string) {
 		modulesStore.setModuleSetting('consciousness', 'activeModel', modelId);
 	}
@@ -501,6 +506,7 @@ export function createPersonaPageState() {
 		saveSystemPrompt,
 		handleLLMProviderChange,
 		handleLLMModelChange,
+		handleLLMNumberSetting,
 		handleLLMBaseUrlChange,
 		handleTTSProviderChange,
 		handleTTSModelChange,


### PR DESCRIPTION
**This is the first split-out PR from #95, covering only the OpenAI-compatible endpoint improvements requested there.**  
                                                                                                                                    
##  What's included                                                                                                          
       - **Model discovery for OpenAI-compatible endpoints** (`/api/providers/models` + `client-models.ts`)                         
         - Supports optional API keys                                                                                               
         - Normalizes bare URLs to `/v1`                                                                                            
         - Handles Ollama's `/api/tags` model list when localhost:11434 is used                                                     
       - **Searchable model dropdown** (`ModelDropdown.svelte`)                                                                     
         - Live filter by model name/id                                                                                             
         - Refresh button to re-fetch                                                                                               
         - Search query resets when dropdown closes                                                                                 
       - **Advanced parameters for custom endpoints** (`AiServicesSection.svelte`, `companion-chat.ts`, `api/chat/+server.ts`)      
         - Temperature, Top P, Max Tokens, Presence Penalty, Frequency Penalty                                                      
         - Only sent for `openai-compatible`; cloud providers keep their previous behavior                                          
         - Max Tokens left empty = provider default (no hardcoded fallback)                                                         
                                                                                                                                    
##  Deliberately not included (separate PRs)                                                                                 
       - Context window / memory budget / truncation                                                                                
       - Unfiltered Mode toggle                                                                                                     
       - `.gitignore` changes (those stay local)                                                                                    
                                                                                                                                    
 ##  Review feedback addressed                                                                                                
       - No `Authorization: Bearer` header sent when no API key is provided                                                         
       - No default `maxTokens: 2048`                                                                                               
       - Onboarding and settings custom-endpoint blocks now match                                                                   
       - `accent-color` uses `var(--accent)` (typo not present)                                                                     
                                                                                                                                    
       `pnpm check` and `pnpm test` pass.   