### PR TITLE
fix: normalize custom-endpoint chat URLs and drop the keyless bearer

### DIFF
--- a/src/lib/services/chat/client-chat.ts
+++ b/src/lib/services/chat/client-chat.ts
@@ -1,5 +1,6 @@
 import type { LLMProvider } from '$lib/types';
 import {
+	ensureOpenAIPath,
 	getChatBaseUrl,
 	getLocalProviderConnectionHint,
 	isLocalLLMProvider
@@ -54,9 +55,13 @@ export async function streamChatDirect(
 		return;
 	}
 
+	// Custom endpoints get the same /v1 normalization as model discovery, so a
+	// base URL that populates the dropdown can't then 404 on chat.
 	const providerBaseURL = isLocal
 		? getChatBaseUrl(provider, baseURL)
-		: baseURL || DEFAULT_CHAT_BASE_URLS[provider];
+		: provider === 'openai-compatible' && baseURL
+			? ensureOpenAIPath(baseURL)
+			: baseURL || DEFAULT_CHAT_BASE_URLS[provider];
 	if (!providerBaseURL) {
 		onError(`Unknown provider: ${provider}`);
 		return;
@@ -215,7 +220,11 @@ export async function extractStateUpdates(options: ExtractOptions): Promise<stri
 	const isLocal = isLocalLLMProvider(provider);
 	if (!apiKey && !isLocal && provider !== 'openai-compatible') return null;
 
-	const base = isLocal ? getChatBaseUrl(provider, baseURL) : baseURL || DEFAULT_CHAT_BASE_URLS[provider];
+	const base = isLocal
+		? getChatBaseUrl(provider, baseURL)
+		: provider === 'openai-compatible' && baseURL
+			? ensureOpenAIPath(baseURL)
+			: baseURL || DEFAULT_CHAT_BASE_URLS[provider];
 	if (!base) return null;
 
 	const trimmedBase = base.replace(/\/+$/, '');

--- a/src/lib/services/chat/companion-chat.ts
+++ b/src/lib/services/chat/companion-chat.ts
@@ -214,7 +214,7 @@ export async function sendCompanionMessage(
 					messages: messages.map((m) => ({ role: m.role, content: toOpenAIContent(m.content) })),
 					provider,
 					model: selectedModel,
-					apiKey: apiKey || 'not-needed',
+					apiKey: apiKey || (providerMeta?.custom ? undefined : 'not-needed'),
 					baseURL,
 					systemPrompt,
 					...advancedParams

--- a/src/lib/services/providers/client-models.ts
+++ b/src/lib/services/providers/client-models.ts
@@ -3,7 +3,8 @@ import {
 	ensureOpenAIPath,
 	getLocalProviderConnectionHint,
 	getModelsBaseUrl,
-	isLocalLLMProvider
+	isLocalLLMProvider,
+	looksLikeOllama
 } from './local-endpoints';
 import { DEFAULT_MODELS_BASE_URLS } from './provider-defaults.ts';
 
@@ -40,18 +41,6 @@ function normalizeModelName(id: string, providerId: string): string {
 		.replace(/O1/g, 'o1')
 		.replace(/O3/g, 'o3');
 	return name;
-}
-
-function looksLikeOllama(baseUrl: string): boolean {
-	try {
-		const url = new URL(baseUrl);
-		return (
-			(url.hostname === 'localhost' || url.hostname === '127.0.0.1') &&
-			url.port === '11434'
-		);
-	} catch {
-		return false;
-	}
 }
 
 /**

--- a/src/lib/services/providers/local-endpoints.test.ts
+++ b/src/lib/services/providers/local-endpoints.test.ts
@@ -11,7 +11,8 @@ import {
 	getLocalTTSConnectionHint,
 	isLocalSTTProvider,
 	getSTTBaseUrl,
-	getLocalSTTConnectionHint
+	getLocalSTTConnectionHint,
+	ensureOpenAIPath, looksLikeOllama
 } from './local-endpoints.ts';
 
 test('identifies local STT providers', () => {
@@ -103,4 +104,27 @@ test('provides local TTS troubleshooting hint with CORS guidance', () => {
 		getLocalTTSConnectionHint('http://localhost:8880', 'https://utsuwa.app'),
 		/https:\/\/utsuwa\.app/
 	);
+});
+
+// --- ensureOpenAIPath (shared by model discovery and custom-endpoint chat) ---
+
+test('ensureOpenAIPath appends /v1 to bare base URLs', () => {
+	assert.equal(ensureOpenAIPath('https://api.together.xyz'), 'https://api.together.xyz/v1');
+	assert.equal(ensureOpenAIPath('https://api.together.xyz/'), 'https://api.together.xyz/v1');
+});
+
+test('ensureOpenAIPath leaves /v1 URLs unchanged', () => {
+	assert.equal(ensureOpenAIPath('https://api.openai.com/v1'), 'https://api.openai.com/v1');
+	assert.equal(ensureOpenAIPath('https://api.openai.com/v1/'), 'https://api.openai.com/v1');
+});
+
+// --- looksLikeOllama ---
+
+test('looksLikeOllama matches default local Ollama only', () => {
+	assert.equal(looksLikeOllama('http://localhost:11434'), true);
+	assert.equal(looksLikeOllama('http://127.0.0.1:11434'), true);
+	assert.equal(looksLikeOllama('http://localhost:11434/v1'), true);
+	assert.equal(looksLikeOllama('http://localhost:1234'), false);
+	assert.equal(looksLikeOllama('https://api.openai.com/v1'), false);
+	assert.equal(looksLikeOllama('not a url'), false);
 });

--- a/src/lib/services/providers/local-endpoints.ts
+++ b/src/lib/services/providers/local-endpoints.ts
@@ -20,6 +20,21 @@ export function ensureOpenAIPath(url: string): string {
 	return cleanUrl.endsWith('/v1') ? cleanUrl : `${cleanUrl}/v1`;
 }
 
+// A default local Ollama reached through the OpenAI-compatible provider: its
+// model list lives at /api/tags instead of /v1/models. Shared so the web and
+// desktop discovery paths can't drift.
+export function looksLikeOllama(baseUrl: string): boolean {
+	try {
+		const url = new URL(baseUrl);
+		return (
+			(url.hostname === 'localhost' || url.hostname === '127.0.0.1') &&
+			url.port === '11434'
+		);
+	} catch {
+		return false;
+	}
+}
+
 export function isLocalLLMProvider(providerId: string): boolean {
 	return LOCAL_LLM_PROVIDERS.has(providerId);
 }

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -2,7 +2,7 @@ import { streamText } from '@xsai/stream-text';
 import { env } from '$env/dynamic/private';
 import type { RequestHandler } from './$types';
 import type { LLMProvider } from '$lib/types';
-import { getChatBaseUrl } from '$lib/services/providers/local-endpoints';
+import { ensureOpenAIPath, getChatBaseUrl } from '$lib/services/providers/local-endpoints';
 import { assertSafeProviderUrl } from '$lib/services/providers/url-guard';
 import { sanitizeProviderError } from '$lib/services/providers/provider-errors';
 import { DEFAULT_CHAT_BASE_URLS } from '$lib/services/providers/provider-defaults';
@@ -51,6 +51,10 @@ export const POST: RequestHandler = async ({ request }) => {
 			headers['anthropic-dangerous-direct-browser-access'] = 'true';
 		} else if (isLocalProvider) {
 			providerBaseURL = getChatBaseUrl(typedProvider, providerBaseURL);
+		} else if (typedProvider === 'openai-compatible') {
+			// Same /v1 normalization as model discovery, so a base URL that
+			// populates the dropdown can't then 404 on chat.
+			providerBaseURL = providerBaseURL ? ensureOpenAIPath(providerBaseURL) : providerBaseURL;
 		} else {
 			// Use default base URL for provider
 			providerBaseURL = providerBaseURL || DEFAULT_CHAT_BASE_URLS[typedProvider];
@@ -80,7 +84,10 @@ export const POST: RequestHandler = async ({ request }) => {
 		let result;
 		try {
 			result = streamText({
-				apiKey: apiKey || 'not-needed',
+				// Keyless custom endpoints must not receive a fabricated bearer;
+				// strict gateways reject 'Bearer not-needed'. xsai omits the
+				// Authorization header entirely when apiKey is undefined.
+				apiKey: apiKey || (typedProvider === 'openai-compatible' ? undefined : 'not-needed'),
 				baseURL: providerBaseURL,
 				model,
 				messages: messagesWithSystem,

--- a/src/routes/api/providers/models/+server.ts
+++ b/src/routes/api/providers/models/+server.ts
@@ -4,7 +4,8 @@ import type { LLMProvider } from '$lib/types';
 import {
 	ensureOpenAIPath,
 	getModelsBaseUrl,
-	isLocalLLMProvider
+	isLocalLLMProvider,
+	looksLikeOllama
 } from '$lib/services/providers/local-endpoints';
 import { assertSafeProviderUrl } from '$lib/services/providers/url-guard';
 import { DEFAULT_MODELS_BASE_URLS } from '$lib/services/providers/provider-defaults';
@@ -60,18 +61,6 @@ function normalizeModelName(id: string, providerId: string): string {
 		.replace(/O3/g, 'o3');
 
 	return name;
-}
-
-function looksLikeOllama(baseUrl: string): boolean {
-	try {
-		const url = new URL(baseUrl);
-		return (
-			(url.hostname === 'localhost' || url.hostname === '127.0.0.1') &&
-			url.port === '11434'
-		);
-	} catch {
-		return false;
-	}
 }
 
 async function fetchOpenAIModels(apiKey: string | undefined, baseUrl: string): Promise<ModelInfo[]> {


### PR DESCRIPTION
## Summary
The two follow-ups promised on #99, plus the helper dedup:

- The models fetch normalizes a bare base URL to /v1 but the chat paths did not, so entering `https://api.together.xyz` gave a working model dropdown and a 404 on every chat message. Both chat paths (client-direct and the server route) now run the same `ensureOpenAIPath` normalization for `openai-compatible`
- Keyless custom endpoints on the web path no longer receive `Authorization: Bearer not-needed` (the xsai client omits the header entirely when apiKey is undefined); strict gateways rejected the fabricated value. The models routes already behaved correctly after #99, this aligns chat
- `looksLikeOllama` was duplicated across the web and desktop discovery paths; it now lives in `local-endpoints` with tests, alongside new tests for `ensureOpenAIPath`

## Testing
- 200/200 tests (3 new), svelte-check clean
- Live against the dev server with a real OpenAI key: the exact request that 404'd before (chat with a base URL missing /v1) now streams correctly, and `provider=openai` regression is byte-identical
- No behavior change for any provider except `openai-compatible`

Thanks @dezihh for the underlying feature and the report trail that surfaced these.