### PR TITLE
feat: configurable context window with memory scaling and history truncation for all providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ Utsuwa supports popular cloud and local LLMs. For endpoints that speak the OpenA
 
 The **Context Window** setting is available for every LLM provider. When enabled, it tells Utsuwa how many tokens the selected model can process. The app then:
 
+- Retrieves the matching number of recent conversation turns from working memory.
 - Scales the amount of injected memory (recent conversation turns and relevant facts) to match the window size.
 - Truncates older chat history before sending, always keeping the system prompt and the user's newest message.
 
-If the setting is left off, Utsuwa keeps the historical defaults (6 recent turns, 5 facts) and does not truncate history. This is useful when you want the provider to handle its own context management.
+If the setting is left off, Utsuwa keeps the historical defaults (10 retrieved turns, 6 injected turns, 5 facts) and does not truncate history. This is useful when you want the provider to handle its own context management.
 
 ### TTS Providers (3)
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ Utsuwa supports popular cloud and local LLMs. For endpoints that speak the OpenA
 | **Local** | Ollama, LM Studio |
 | **OpenAI-Compatible** | OpenRouter, Together, vLLM, LiteLLM, etc. |
 
+#### Context Window and Memory Budget
+
+The **Context Window** setting is available for every LLM provider. When enabled, it tells Utsuwa how many tokens the selected model can process. The app then:
+
+- Scales the amount of injected memory (recent conversation turns and relevant facts) to match the window size.
+- Truncates older chat history before sending, always keeping the system prompt and the user's newest message.
+
+If the setting is left off, Utsuwa keeps the historical defaults (6 recent turns, 5 facts) and does not truncate history. This is useful when you want the provider to handle its own context management.
+
 ### TTS Providers (3)
 
 | Category | Providers |
@@ -208,10 +217,11 @@ pnpm tauri dev
 #### Configuration
 
 1. Click the **Settings** (gear icon) in the sidebar
-2. Navigate to **Settings > Character** to configure your chat provider:
+2. Navigate to **Settings > AI Services** to configure your chat provider:
    - Enable Chat (LLM)
    - Select a cloud provider and enter your API key
    - Or select a local server like Ollama or LM Studio and choose an installed model from the discovered model dropdown
+   - Optional: enable **Context Window** to scale memory injection and history truncation to your model's token limit
 3. Configure text-to-speech in the same settings area (optional):
    - Select a TTS provider
    - Enter your API key

--- a/src/content/docs/technology/companion-system.md
+++ b/src/content/docs/technology/companion-system.md
@@ -317,11 +317,13 @@ The system prompt is built from 5 layers:
 
 ### Context Window and Memory Budget
 
-The LLM settings expose a **Context Window** slider that tells Utsuwa how many tokens the selected model can process. This value is used in two places:
+The LLM settings expose a **Context Window** slider that tells Utsuwa how many tokens the selected model can process. This value is used in three places:
 
-1. **Memory scaling** — The number of recent conversation turns and relevant facts injected into the prompt scales with the context size. Small local models (1K–4K tokens) receive a minimal memory layer so the system prompt itself does not overflow the window. Larger models receive more turns and facts up to a reasonable ceiling.
+1. **Memory retrieval** — `retrieveRelevantContext` asks working memory for up to the budgeted number of recent turns. Without a context window configured it falls back to 10 turns; with a large window configured it retrieves up to 20, so the larger budget is actually used.
 
-2. **History truncation** — Before a request is sent, the assembled messages are trimmed so the system prompt plus conversation history plus a small reserve for the model's response fit inside the configured window. Truncation always keeps the system prompt and the user's newest message; older history is dropped first.
+2. **Memory injection** — The prompt builder injects only the budgeted number of recent conversation turns and relevant facts. Small local models (1K–4K tokens) receive a minimal memory layer so the system prompt itself does not overflow the window. Larger models receive more turns and facts up to a reasonable ceiling.
+
+3. **History truncation** — Before a request is sent, the assembled messages are trimmed so the system prompt plus conversation history plus a small reserve for the model's response fit inside the configured window. Truncation always keeps the system prompt and the user's newest message; older history is dropped first.
 
 The reserve and scaling are intentionally conservative. If the system prompt alone is larger than the window, Utsuwa still keeps the newest user message and lets the provider handle the overflow rather than silently dropping the user's current turn.
 

--- a/src/content/docs/technology/companion-system.md
+++ b/src/content/docs/technology/companion-system.md
@@ -315,6 +315,16 @@ The system prompt is built from 5 layers:
 4. **Memory** — Recent conversation turns, relevant facts, session context
 5. **Instructions** — Stage-specific behavior guidance, JSON output format
 
+### Context Window and Memory Budget
+
+The LLM settings expose a **Context Window** slider that tells Utsuwa how many tokens the selected model can process. This value is used in two places:
+
+1. **Memory scaling** — The number of recent conversation turns and relevant facts injected into the prompt scales with the context size. Small local models (1K–4K tokens) receive a minimal memory layer so the system prompt itself does not overflow the window. Larger models receive more turns and facts up to a reasonable ceiling.
+
+2. **History truncation** — Before a request is sent, the assembled messages are trimmed so the system prompt plus conversation history plus a small reserve for the model's response fit inside the configured window. Truncation always keeps the system prompt and the user's newest message; older history is dropped first.
+
+The reserve and scaling are intentionally conservative. If the system prompt alone is larger than the window, Utsuwa still keeps the newest user message and lets the provider handle the overflow rather than silently dropping the user's current turn.
+
 ### LLM Output Format
 
 The companion uses a **two-path state extraction** model, so it stays reliable across everything from GPT-4o down to a 4B local model:

--- a/src/lib/ai/prompt-builder.test.ts
+++ b/src/lib/ai/prompt-builder.test.ts
@@ -1,7 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { buildSystemPrompt, buildExtractionSystemPrompt, type PromptContext } from './prompt-builder.ts';
+import {
+	buildSystemPrompt,
+	buildExtractionSystemPrompt,
+	truncateMessagesToContext,
+	type PromptContext
+} from './prompt-builder.ts';
 import type { CharacterState } from '$lib/types/character';
 import type { RelevantContext } from '$lib/types/memory';
 
@@ -115,4 +120,127 @@ test('extraction prompt only mentions images when there are images', () => {
 	assert.ok(buildExtractionSystemPrompt(true).includes('showed the companion an image'));
 	assert.ok(!buildExtractionSystemPrompt(false).includes('showed the companion an image'));
 	assert.ok(buildExtractionSystemPrompt().includes('ONLY a JSON object'));
+});
+
+test('context size scales memory injection in dating-sim mode', () => {
+	const memories: RelevantContext = {
+		recentTurns: Array.from({ length: 12 }, (_, i) => ({
+			id: i,
+			role: i % 2 === 0 ? 'user' : 'assistant',
+			content: `turn ${i}`,
+			createdAt: new Date()
+		})) as Array<{ id: number; role: 'user' | 'assistant'; content: string; createdAt: Date }>,
+		relevantFacts: Array.from({ length: 8 }, (_, i) => ({
+			id: i,
+			content: `fact ${i}`,
+			category: 'user' as const,
+			importance: 50,
+			confidence: 0.8,
+			referenceCount: 0,
+			createdAt: new Date()
+		})),
+		triggeredMemories: [],
+		recentSessions: []
+	};
+
+	const small = buildSystemPrompt(makeContext({ contextSize: 2048, memories }));
+	const large = buildSystemPrompt(makeContext({ contextSize: 32768, memories }));
+
+	// Small context keeps fewer turns/facts than large context.
+	const smallTurns = (small.match(/turn \d+/g) || []).length;
+	const largeTurns = (large.match(/turn \d+/g) || []).length;
+	assert.ok(smallTurns < largeTurns, `expected small context to keep fewer turns (${smallTurns} vs ${largeTurns})`);
+
+	const smallFacts = (small.match(/fact \d+/g) || []).length;
+	const largeFacts = (large.match(/fact \d+/g) || []).length;
+	assert.ok(smallFacts < largeFacts, `expected small context to keep fewer facts (${smallFacts} vs ${largeFacts})`);
+});
+
+test('context size scales memory injection in companion mode', () => {
+	const memories: RelevantContext = {
+		recentTurns: Array.from({ length: 12 }, (_, i) => ({
+			id: i,
+			role: i % 2 === 0 ? 'user' : 'assistant',
+			content: `turn ${i}`,
+			createdAt: new Date()
+		})) as Array<{ id: number; role: 'user' | 'assistant'; content: string; createdAt: Date }>,
+		relevantFacts: Array.from({ length: 8 }, (_, i) => ({
+			id: i,
+			content: `fact ${i}`,
+			category: 'user' as const,
+			importance: 50,
+			confidence: 0.8,
+			referenceCount: 0,
+			createdAt: new Date()
+		})),
+		triggeredMemories: [],
+		recentSessions: []
+	};
+
+	const small = buildSystemPrompt(
+		makeContext({ state: makeState({ appMode: 'companion' }), contextSize: 2048, memories })
+	);
+	const large = buildSystemPrompt(
+		makeContext({ state: makeState({ appMode: 'companion' }), contextSize: 32768, memories })
+	);
+
+	const smallTurns = (small.match(/turn \d+/g) || []).length;
+	const largeTurns = (large.match(/turn \d+/g) || []).length;
+	assert.ok(smallTurns < largeTurns, `expected small context to keep fewer turns (${smallTurns} vs ${largeTurns})`);
+
+	const smallFacts = (small.match(/fact \d+/g) || []).length;
+	const largeFacts = (large.match(/fact \d+/g) || []).length;
+	assert.ok(smallFacts < largeFacts, `expected small context to keep fewer facts (${smallFacts} vs ${largeFacts})`);
+});
+
+test('truncateMessagesToContext keeps all messages when within budget', () => {
+	const messages = [
+		{ role: 'system', content: 'x'.repeat(400) }, // ~100 tokens
+		{ role: 'user', content: 'hello' },
+		{ role: 'assistant', content: 'hi there' },
+		{ role: 'user', content: 'how are you?' }
+	];
+	truncateMessagesToContext(messages, 2048);
+	assert.equal(messages.length, 4);
+});
+
+test('truncateMessagesToContext removes oldest history to fit budget', () => {
+	const messages = [
+		{ role: 'system', content: 'x'.repeat(400) }, // ~100 tokens
+		{ role: 'user', content: 'a'.repeat(400) }, // ~100 tokens
+		{ role: 'assistant', content: 'b'.repeat(400) }, // ~100 tokens
+		{ role: 'user', content: 'newest message' }
+	];
+	// 100 system + 500 reserve = 600 used; 700 - 600 = 100 history budget.
+	// The two oldest history messages exceed that, so at least one is dropped.
+	truncateMessagesToContext(messages, 700);
+	// System + newest user must remain.
+	assert.equal(messages[0].role, 'system');
+	assert.equal(messages[messages.length - 1].content, 'newest message');
+	// At least one older message was dropped.
+	assert.ok(messages.length < 4);
+});
+
+test('truncateMessagesToContext always keeps newest user message even with oversized system prompt', () => {
+	const messages = [
+		{ role: 'system', content: 'x'.repeat(10000) }, // ~2500 tokens, exceeds context window
+		{ role: 'user', content: 'please help me' }
+	];
+	truncateMessagesToContext(messages, 2048);
+	assert.equal(messages.length, 2);
+	assert.equal(messages[0].role, 'system');
+	assert.equal(messages[1].content, 'please help me');
+});
+
+test('truncateMessagesToContext handles empty history gracefully', () => {
+	const messages = [{ role: 'system', content: 'you are helpful' }];
+	truncateMessagesToContext(messages, 2048);
+	assert.equal(messages.length, 1);
+	assert.equal(messages[0].role, 'system');
+});
+
+test('truncateMessagesToContext is a no-op with no messages', () => {
+	const messages: Array<{ role: string; content: string }> = [];
+	truncateMessagesToContext(messages, 2048);
+	assert.equal(messages.length, 0);
 });

--- a/src/lib/ai/prompt-builder.test.ts
+++ b/src/lib/ai/prompt-builder.test.ts
@@ -5,10 +5,13 @@ import {
 	buildSystemPrompt,
 	buildExtractionSystemPrompt,
 	truncateMessagesToContext,
+	truncateChatHistory,
+	estimateTokens,
 	type PromptContext
 } from './prompt-builder.ts';
 import type { CharacterState } from '$lib/types/character';
 import type { RelevantContext } from '$lib/types/memory';
+import { getMemoryBudget } from '../types/memory.ts';
 
 function makeState(overrides: Partial<CharacterState> = {}): CharacterState {
 	return {
@@ -243,4 +246,101 @@ test('truncateMessagesToContext is a no-op with no messages', () => {
 	const messages: Array<{ role: string; content: string }> = [];
 	truncateMessagesToContext(messages, 2048);
 	assert.equal(messages.length, 0);
+});
+
+test('getMemoryBudget boundary values', () => {
+	assert.deepEqual(getMemoryBudget(4095), { workingMemoryTurns: 6, relevantFacts: 3 });
+	assert.deepEqual(getMemoryBudget(4096), { workingMemoryTurns: 6, relevantFacts: 3 });
+	assert.deepEqual(getMemoryBudget(4097), { workingMemoryTurns: 10, relevantFacts: 5 });
+	assert.deepEqual(getMemoryBudget(8192), { workingMemoryTurns: 10, relevantFacts: 5 });
+	assert.deepEqual(getMemoryBudget(8193), { workingMemoryTurns: 20, relevantFacts: 10 });
+});
+
+test('estimateTokens handles empty, latin and cjk text', () => {
+	assert.equal(estimateTokens(''), 0);
+	assert.equal(estimateTokens('hello'), 2); // 5 chars / 4 = 1.25 -> 2
+	assert.equal(estimateTokens('a'.repeat(100)), 25);
+	// CJK characters are estimated conservatively (1 token per char) so the
+	// budget is not exhausted too quickly for non-Latin scripts.
+	assert.ok(estimateTokens('日本語のテキスト') > estimateTokens('latin text'));
+});
+
+test('memory budget defaults are used when contextSize is unset', () => {
+	const memories: RelevantContext = {
+		recentTurns: Array.from({ length: 12 }, (_, i) => ({
+			id: i,
+			role: i % 2 === 0 ? 'user' : 'assistant',
+			content: `turn ${i}`,
+			createdAt: new Date()
+		})) as Array<{ id: number; role: 'user' | 'assistant'; content: string; createdAt: Date }>,
+		relevantFacts: Array.from({ length: 8 }, (_, i) => ({
+			id: i,
+			content: `fact ${i}`,
+			category: 'user' as const,
+			importance: 50,
+			confidence: 0.8,
+			referenceCount: 0,
+			createdAt: new Date()
+		})),
+		triggeredMemories: [],
+		recentSessions: []
+	};
+
+	const prompt = buildSystemPrompt(makeContext({ memories }));
+	const turns = (prompt.match(/turn \d+/g) || []).length;
+	const facts = (prompt.match(/fact \d+/g) || []).length;
+	assert.equal(turns, 6, 'default keeps 6 recent turns');
+	assert.equal(facts, 5, 'default keeps 5 facts');
+});
+
+test('truncateMessagesToContext keeps newest user message when system prompt nearly fills window', () => {
+	const messages = [
+		{ role: 'system', content: 'x'.repeat(6000) }, // ~1500 tokens
+		{ role: 'user', content: 'older question' },
+		{ role: 'assistant', content: 'y'.repeat(100) },
+		{ role: 'user', content: 'newest question' }
+	];
+	truncateMessagesToContext(messages, 2048);
+	assert.equal(messages[0].role, 'system');
+	assert.equal(messages[messages.length - 1].content, 'newest question');
+});
+
+test('truncateMessagesToContext ignores extra system messages and treats first non-system as history start', () => {
+	const messages = [
+		{ role: 'system', content: 'x'.repeat(400) },
+		{ role: 'system', content: 'extra system instruction' },
+		{ role: 'user', content: 'a'.repeat(400) },
+		{ role: 'assistant', content: 'b'.repeat(400) },
+		{ role: 'user', content: 'newest message' }
+	];
+	// System tokens counted from first message only; reserve leaves room for newest user.
+	truncateMessagesToContext(messages, 700);
+	assert.equal(messages[0].role, 'system');
+	assert.equal(messages[messages.length - 1].content, 'newest message');
+});
+
+test('truncateChatHistory combines system prompt budgeting with original message slicing', () => {
+	const messages = [
+		{ role: 'user', content: 'a'.repeat(400) },
+		{ role: 'assistant', content: 'b'.repeat(400) },
+		{ role: 'user', content: 'newest message' }
+	];
+	const systemPrompt = 'x'.repeat(400); // ~100 tokens
+	const result = truncateChatHistory(messages, systemPrompt, 700);
+	// System + reserve leaves ~100 tokens for history; newest user (~4 tokens)
+	// plus at most one older message fit.
+	assert.ok(result.length > 0);
+	assert.equal(result[result.length - 1].content, 'newest message');
+});
+
+test('truncateChatHistory handles image content placeholders', () => {
+	const messages = [
+		{ role: 'user', content: 'a'.repeat(400) },
+		{ role: 'assistant', content: { type: 'image_url', image_url: { url: 'data:image/png;base64,abc' } } },
+		{ role: 'user', content: 'newest message' }
+	];
+	const systemPrompt = 'x'.repeat(400);
+	const result = truncateChatHistory(messages, systemPrompt, 700);
+	assert.ok(result.length > 0);
+	assert.equal(result[result.length - 1].content, 'newest message');
 });

--- a/src/lib/ai/prompt-builder.ts
+++ b/src/lib/ai/prompt-builder.ts
@@ -405,10 +405,33 @@ function formatTimeSince(lastInteraction: Date | null): string {
 	return `${Math.floor(days / 7)} weeks ago`;
 }
 
-// Rough token estimate: 1 token ≈ 4 characters for Latin script.
-// Good enough for prompt budgeting; exact counts depend on the tokenizer.
+// Approximate token count for prompt budgeting.
+// - Latin script is roughly 4 characters per token.
+// - CJK and other logographic scripts are much denser; count them as ~1 token
+//   per character so the budget is not exhausted too quickly for non-Latin chats.
+// Exact counts depend on the tokenizer; this is intentionally conservative.
 export function estimateTokens(text: string): number {
-	return Math.ceil(text.length / 4);
+	if (text.length === 0) return 0;
+
+	let cjkCount = 0;
+	let otherCount = 0;
+	for (const char of text) {
+		const code = char.codePointAt(0) ?? 0;
+		if (
+			(code >= 0x4e00 && code <= 0x9fff) || // CJK Unified Ideographs
+			(code >= 0x3040 && code <= 0x309f) || // Hiragana
+			(code >= 0x30a0 && code <= 0x30ff) || // Katakana
+			(code >= 0xac00 && code <= 0xd7af) || // Hangul
+			(code >= 0x3400 && code <= 0x4dbf) || // CJK Extension A
+			(code >= 0x20000 && code <= 0x2a6df) // CJK Extension B
+		) {
+			cjkCount++;
+		} else {
+			otherCount++;
+		}
+	}
+
+	return Math.ceil(cjkCount + otherCount / 4);
 }
 
 // Minimal budget reserved for the model's response and generation overhead.
@@ -416,6 +439,8 @@ const RESPONSE_TOKEN_RESERVE = 500;
 // Floor that guarantees at least the newest user message is kept even when the
 // system prompt already consumes most of the context window.
 const MIN_HISTORY_MESSAGE_TOKENS = 50;
+
+const isDev = typeof import.meta !== 'undefined' && (import.meta as { env?: { DEV?: boolean } }).env?.DEV === true;
 
 /**
  * Truncate message history to fit inside the configured context window.
@@ -448,9 +473,38 @@ export function truncateMessagesToContext(
 			// Keep message i (it already tipped us over budget) and remove all
 			// older history before it. The loop goes newest→oldest, so i is the
 			// oldest message we can still afford.
-			messages.splice(historyStart, i - historyStart);
+			const removed = i - historyStart;
+			if (isDev && removed > 0) {
+				console.warn(
+					`[truncateMessagesToContext] removed ${removed} older messages to fit context window (${contextSize} tokens)`
+				);
+			}
+			messages.splice(historyStart, removed);
 			return;
 		}
 	}
+}
+
+/**
+ * Truncate chat history so it fits inside the configured context window after
+ * prepending the system prompt. Returns the slice of the original messages that
+ * should be sent to the LLM. Non-string content (e.g. image blocks) is replaced
+ * by a placeholder for budgeting purposes.
+ */
+export function truncateChatHistory<T extends { role: string; content: unknown }>(
+	messages: T[],
+	systemPrompt: string,
+	contextSize: number
+): T[] {
+	const messagesWithSystem = [
+		{ role: 'system' as const, content: systemPrompt },
+		...messages.map((m) => ({
+			role: m.role,
+			content: typeof m.content === 'string' ? m.content : '[image content]'
+		}))
+	];
+	truncateMessagesToContext(messagesWithSystem, contextSize);
+	const keptHistoryCount = messagesWithSystem.length - 1;
+	return messages.slice(-keptHistoryCount);
 }
 

--- a/src/lib/ai/prompt-builder.ts
+++ b/src/lib/ai/prompt-builder.ts
@@ -1,5 +1,6 @@
 import type { CharacterState } from '$lib/types/character';
-import type { Fact, SessionSummary, RelevantContext } from '$lib/types/memory';
+import type { Fact, SessionSummary, RelevantContext, MemoryBudget } from '../types/memory.ts';
+import { getMemoryBudget } from '../types/memory.ts';
 import type { PersonaCard } from '$lib/stores/persona.svelte';
 // Relative import keeps this module runnable under the node test runner
 import { STAGE_BEHAVIORS, STAGE_INSTRUCTIONS } from '../engine/stages.ts';
@@ -14,6 +15,15 @@ export interface PromptContext {
 	// True when the user has shown her an image this turn. Adds the
 	// "being shown" reception layer so she receives it like a person.
 	hasImages?: boolean;
+	// Configured context window size in tokens. Used to scale memory injection
+	// and truncate history. When unset, historical defaults (6 turns, 5 facts)
+	// are preserved.
+	contextSize?: number;
+}
+
+function getContextMemoryBudget(contextSize?: number): MemoryBudget | undefined {
+	if (!contextSize || contextSize <= 0) return undefined;
+	return getMemoryBudget(contextSize);
 }
 
 // Build the complete system prompt
@@ -69,16 +79,19 @@ Energy: ${energyDesc} (${ctx.state.energy}/100)
 </state>`);
 
 	// Memories
+	const memoryBudget = getContextMemoryBudget(ctx.contextSize);
 	const memorySections: string[] = [];
 	if (mem.recentTurns.length > 0) {
+		const turnLimit = memoryBudget?.workingMemoryTurns ?? 6;
 		const recentChat = mem.recentTurns
-			.slice(-6)
+			.slice(-turnLimit)
 			.map((t) => `${t.role === 'user' ? 'They' : 'You'}: ${t.content}`)
 			.join('\n');
 		memorySections.push(`Recent conversation:\n${recentChat}`);
 	}
 	if (mem.relevantFacts.length > 0) {
-		const factsText = mem.relevantFacts.slice(0, 5).map((f) => `- ${f.content}`).join('\n');
+		const factLimit = memoryBudget?.relevantFacts ?? 5;
+		const factsText = mem.relevantFacts.slice(0, factLimit).map((f) => `- ${f.content}`).join('\n');
 		memorySections.push(`Things you know about them:\n${factsText}`);
 	}
 
@@ -192,12 +205,14 @@ ${state.currentStreak > 1 ? `Current Streak: ${state.currentStreak} days` : ''}
 // Memory layer - what she remembers
 function buildMemoryLayer(ctx: PromptContext): string {
 	const mem = ctx.memories;
+	const memoryBudget = getContextMemoryBudget(ctx.contextSize);
 	let sections: string[] = [];
 
 	// Recent conversation
 	if (mem.recentTurns.length > 0) {
+		const turnLimit = memoryBudget?.workingMemoryTurns ?? 6;
 		const recentChat = mem.recentTurns
-			.slice(-6)
+			.slice(-turnLimit)
 			.map((t) => `${t.role === 'user' ? 'They' : 'You'}: ${t.content}`)
 			.join('\n');
 		sections.push(`Recent conversation:\n${recentChat}`);
@@ -205,7 +220,8 @@ function buildMemoryLayer(ctx: PromptContext): string {
 
 	// Relevant facts
 	if (mem.relevantFacts.length > 0) {
-		const factsText = mem.relevantFacts.slice(0, 5).map((f) => `- ${f.content}`).join('\n');
+		const factLimit = memoryBudget?.relevantFacts ?? 5;
+		const factsText = mem.relevantFacts.slice(0, factLimit).map((f) => `- ${f.content}`).join('\n');
 		sections.push(`Things you know about them:\n${factsText}`);
 	}
 
@@ -387,5 +403,54 @@ function formatTimeSince(lastInteraction: Date | null): string {
 	if (days < 7) return `${days} days ago`;
 
 	return `${Math.floor(days / 7)} weeks ago`;
+}
+
+// Rough token estimate: 1 token ≈ 4 characters for Latin script.
+// Good enough for prompt budgeting; exact counts depend on the tokenizer.
+export function estimateTokens(text: string): number {
+	return Math.ceil(text.length / 4);
+}
+
+// Minimal budget reserved for the model's response and generation overhead.
+const RESPONSE_TOKEN_RESERVE = 500;
+// Floor that guarantees at least the newest user message is kept even when the
+// system prompt already consumes most of the context window.
+const MIN_HISTORY_MESSAGE_TOKENS = 50;
+
+/**
+ * Truncate message history to fit inside the configured context window.
+ * Operates in-place. Always keeps the system message (index 0) and the most
+ * recent user message. Requires that the first message is the system prompt.
+ */
+export function truncateMessagesToContext(
+	messages: Array<{ role: string; content: string }>,
+	contextSize: number
+): void {
+	if (messages.length === 0) return;
+
+	const systemMsg = messages[0];
+	const systemTokens = estimateTokens(systemMsg.content);
+	const maxHistoryTokens = Math.max(
+		contextSize - systemTokens - RESPONSE_TOKEN_RESERVE,
+		MIN_HISTORY_MESSAGE_TOKENS
+	);
+
+	const historyStart = messages.findIndex((m, i) => i > 0 && m.role !== 'system');
+	if (historyStart === -1) return;
+
+	let totalHistoryTokens = 0;
+	// Walk backwards from the newest message so we can stop once the budget is
+	// exhausted and remove everything older in one splice.
+	for (let i = messages.length - 1; i >= historyStart; i--) {
+		const tokens = estimateTokens(messages[i].content);
+		totalHistoryTokens += tokens;
+		if (totalHistoryTokens > maxHistoryTokens) {
+			// Keep message i (it already tipped us over budget) and remove all
+			// older history before it. The loop goes newest→oldest, so i is the
+			// oldest message we can still afford.
+			messages.splice(historyStart, i - historyStart);
+			return;
+		}
+	}
 }
 

--- a/src/lib/components/onboarding/steps/ServicesStep.svelte
+++ b/src/lib/components/onboarding/steps/ServicesStep.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Icon, ProviderDropdown, ModelDropdown } from '$lib/components/ui';
+	import { Icon, ProviderDropdown, ModelDropdown, ContextSizeSlider } from '$lib/components/ui';
 	import { modulesStore } from '$lib/stores/modules.svelte';
 	import { settingsStore } from '$lib/stores/settings.svelte';
 	import { getLLMProvider, getTTSProvider } from '$lib/services/providers/registry';
@@ -9,12 +9,6 @@
 		debounce,
 		type ModelInfo
 	} from '$lib/services/providers/use-model-fetch';
-	import {
-		CONTEXT_SIZE_STEPS,
-		DEFAULT_CONTEXT_SIZE,
-		formatContextSize,
-		snapContextSize
-	} from '$lib/utils/context-window';
 
 	interface Props {
 		onNext: () => void;
@@ -23,13 +17,8 @@
 
 	let { onNext, onBack }: Props = $props();
 
-
-	function handleContextSizeChange(value: number) {
+	function handleContextSizeChange(value: number | undefined) {
 		modulesStore.setModuleSetting('consciousness', 'contextSize', value);
-	}
-
-	function handleContextSizeToggle(enabled: boolean) {
-		modulesStore.setModuleSetting('consciousness', 'contextSize', enabled ? DEFAULT_CONTEXT_SIZE : undefined);
 	}
 
 	// LLM State
@@ -37,7 +26,6 @@
 	const llmProvider = $derived(getLLMProvider(llmSettings.activeProvider as string));
 	const staticLLMModels = $derived(llmProvider?.models ?? []);
 	const llmContextSize = $derived(llmSettings.contextSize as number | undefined);
-	const llmContextEnabled = $derived(llmContextSize !== undefined && llmContextSize > 0);
 
 	// Dynamic model fetching state for LLM
 	let llmIsLoading = $state(false);
@@ -427,48 +415,12 @@
 		{/if}
 
 		<!-- Context Window -->
-		<div class="context-size-row">
-			<label class="context-size-label" for="ob-llm-context-size-toggle">
-				Context Window
-				{#if llmContextEnabled}
-					<span class="context-size-value">{formatContextSize(snapContextSize(llmContextSize as number))}</span>
-				{:else}
-					<span class="context-size-value">Default</span>
-				{/if}
-			</label>
-			<button
-				id="ob-llm-context-size-toggle"
-				class="toggle-btn"
-				class:enabled={llmContextEnabled}
-				onclick={() => handleContextSizeToggle(!llmContextEnabled)}
-				aria-label="Toggle context window scaling"
-			>
-				<span class="toggle-track">
-					<span class="toggle-thumb"></span>
-				</span>
-			</button>
-		</div>
-		{#if llmContextEnabled}
-			<div class="context-size-slider-row">
-				<input
-					type="range"
-					class="context-size-slider"
-					min="0"
-					max={CONTEXT_SIZE_STEPS.length - 1}
-					step="1"
-					value={CONTEXT_SIZE_STEPS.indexOf(snapContextSize(llmContextSize as number))}
-					oninput={(e) => handleContextSizeChange(CONTEXT_SIZE_STEPS[Number(e.currentTarget.value)])}
-				/>
-				<div class="context-size-ticks">
-					{#each CONTEXT_SIZE_STEPS as step}
-						<span>{formatContextSize(step)}</span>
-					{/each}
-				</div>
-			</div>
-		{/if}
-		<p class="provider-note">
-			When enabled, memory injection and chat history are scaled to fit the selected model's context window.
-		</p>
+		<ContextSizeSlider
+			contextSize={llmContextSize}
+			onChange={handleContextSizeChange}
+			toggleClass="toggle-btn"
+			id="ob-llm-context-size-toggle"
+		/>
 	</div>
 
 	<!-- TTS Section -->
@@ -794,45 +746,4 @@
 		color: var(--text-tertiary);
 	}
 
-	.context-size-row {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		gap: 0.75rem;
-	}
-
-	.context-size-label {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		flex: 1;
-		font-size: 0.875rem;
-		font-weight: 500;
-		color: var(--text-secondary);
-	}
-
-	.context-size-value {
-		font-size: 0.8rem;
-		color: var(--text-tertiary);
-		font-variant-numeric: tabular-nums;
-	}
-
-	.context-size-slider-row {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-
-	.context-size-slider {
-		width: 100%;
-		cursor: pointer;
-	}
-
-	.context-size-ticks {
-		display: flex;
-		justify-content: space-between;
-		font-size: 0.7rem;
-		color: var(--text-tertiary);
-		padding: 0 0.25rem;
-	}
 </style>

--- a/src/lib/components/onboarding/steps/ServicesStep.svelte
+++ b/src/lib/components/onboarding/steps/ServicesStep.svelte
@@ -17,10 +17,33 @@
 
 	let { onNext, onBack }: Props = $props();
 
+	const contextSizeSteps = [1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072];
+
+	function formatContextSize(value: number): string {
+		if (value >= 1024) return `${value / 1024}k`;
+		return String(value);
+	}
+
+	function snapContextSize(value: number): number {
+		return contextSizeSteps.reduce((prev, curr) =>
+			Math.abs(curr - value) < Math.abs(prev - value) ? curr : prev
+		);
+	}
+
+	function handleContextSizeChange(value: number) {
+		modulesStore.setModuleSetting('consciousness', 'contextSize', value);
+	}
+
+	function handleContextSizeToggle(enabled: boolean) {
+		modulesStore.setModuleSetting('consciousness', 'contextSize', enabled ? 32768 : undefined);
+	}
+
 	// LLM State
 	const llmSettings = $derived(modulesStore.getModuleSettings('consciousness'));
 	const llmProvider = $derived(getLLMProvider(llmSettings.activeProvider as string));
 	const staticLLMModels = $derived(llmProvider?.models ?? []);
+	const llmContextSize = $derived((llmSettings.contextSize as number | undefined) ?? undefined);
+	const llmContextEnabled = $derived(llmContextSize !== undefined && llmContextSize > 0);
 
 	// Dynamic model fetching state for LLM
 	let llmIsLoading = $state(false);
@@ -408,6 +431,50 @@
 				disabledMessage="Enter API key first"
 			/>
 		{/if}
+
+		<!-- Context Window -->
+		<div class="context-size-row">
+			<label class="context-size-label" for="ob-llm-context-size-toggle">
+				Context Window
+				{#if llmContextEnabled}
+					<span class="context-size-value">{formatContextSize(snapContextSize(llmContextSize as number))}</span>
+				{:else}
+					<span class="context-size-value">Default</span>
+				{/if}
+			</label>
+			<button
+				id="ob-llm-context-size-toggle"
+				class="toggle-btn"
+				class:enabled={llmContextEnabled}
+				onclick={() => handleContextSizeToggle(!llmContextEnabled)}
+				aria-label="Toggle context window scaling"
+			>
+				<span class="toggle-track">
+					<span class="toggle-thumb"></span>
+				</span>
+			</button>
+		</div>
+		{#if llmContextEnabled}
+			<div class="context-size-slider-row">
+				<input
+					type="range"
+					class="context-size-slider"
+					min="0"
+					max={contextSizeSteps.length - 1}
+					step="1"
+					value={contextSizeSteps.indexOf(snapContextSize(llmContextSize as number))}
+					oninput={(e) => handleContextSizeChange(contextSizeSteps[Number(e.currentTarget.value)])}
+				/>
+				<div class="context-size-ticks">
+					{#each contextSizeSteps as step}
+						<span>{formatContextSize(step)}</span>
+					{/each}
+				</div>
+			</div>
+		{/if}
+		<p class="provider-note">
+			When enabled, memory injection and chat history are scaled to fit the selected model's context window.
+		</p>
 	</div>
 
 	<!-- TTS Section -->
@@ -731,5 +798,47 @@
 		margin: 0;
 		font-size: 0.8rem;
 		color: var(--text-tertiary);
+	}
+
+	.context-size-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.context-size-label {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		flex: 1;
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--text-secondary);
+	}
+
+	.context-size-value {
+		font-size: 0.8rem;
+		color: var(--text-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.context-size-slider-row {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.context-size-slider {
+		width: 100%;
+		cursor: pointer;
+	}
+
+	.context-size-ticks {
+		display: flex;
+		justify-content: space-between;
+		font-size: 0.7rem;
+		color: var(--text-tertiary);
+		padding: 0 0.25rem;
 	}
 </style>

--- a/src/lib/components/onboarding/steps/ServicesStep.svelte
+++ b/src/lib/components/onboarding/steps/ServicesStep.svelte
@@ -9,6 +9,12 @@
 		debounce,
 		type ModelInfo
 	} from '$lib/services/providers/use-model-fetch';
+	import {
+		CONTEXT_SIZE_STEPS,
+		DEFAULT_CONTEXT_SIZE,
+		formatContextSize,
+		snapContextSize
+	} from '$lib/utils/context-window';
 
 	interface Props {
 		onNext: () => void;
@@ -17,32 +23,20 @@
 
 	let { onNext, onBack }: Props = $props();
 
-	const contextSizeSteps = [1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072];
-
-	function formatContextSize(value: number): string {
-		if (value >= 1024) return `${value / 1024}k`;
-		return String(value);
-	}
-
-	function snapContextSize(value: number): number {
-		return contextSizeSteps.reduce((prev, curr) =>
-			Math.abs(curr - value) < Math.abs(prev - value) ? curr : prev
-		);
-	}
 
 	function handleContextSizeChange(value: number) {
 		modulesStore.setModuleSetting('consciousness', 'contextSize', value);
 	}
 
 	function handleContextSizeToggle(enabled: boolean) {
-		modulesStore.setModuleSetting('consciousness', 'contextSize', enabled ? 32768 : undefined);
+		modulesStore.setModuleSetting('consciousness', 'contextSize', enabled ? DEFAULT_CONTEXT_SIZE : undefined);
 	}
 
 	// LLM State
 	const llmSettings = $derived(modulesStore.getModuleSettings('consciousness'));
 	const llmProvider = $derived(getLLMProvider(llmSettings.activeProvider as string));
 	const staticLLMModels = $derived(llmProvider?.models ?? []);
-	const llmContextSize = $derived((llmSettings.contextSize as number | undefined) ?? undefined);
+	const llmContextSize = $derived(llmSettings.contextSize as number | undefined);
 	const llmContextEnabled = $derived(llmContextSize !== undefined && llmContextSize > 0);
 
 	// Dynamic model fetching state for LLM
@@ -460,13 +454,13 @@
 					type="range"
 					class="context-size-slider"
 					min="0"
-					max={contextSizeSteps.length - 1}
+					max={CONTEXT_SIZE_STEPS.length - 1}
 					step="1"
-					value={contextSizeSteps.indexOf(snapContextSize(llmContextSize as number))}
-					oninput={(e) => handleContextSizeChange(contextSizeSteps[Number(e.currentTarget.value)])}
+					value={CONTEXT_SIZE_STEPS.indexOf(snapContextSize(llmContextSize as number))}
+					oninput={(e) => handleContextSizeChange(CONTEXT_SIZE_STEPS[Number(e.currentTarget.value)])}
 				/>
 				<div class="context-size-ticks">
-					{#each contextSizeSteps as step}
+					{#each CONTEXT_SIZE_STEPS as step}
 						<span>{formatContextSize(step)}</span>
 					{/each}
 				</div>

--- a/src/lib/components/onboarding/steps/ServicesStep.svelte
+++ b/src/lib/components/onboarding/steps/ServicesStep.svelte
@@ -418,7 +418,6 @@
 		<ContextSizeSlider
 			contextSize={llmContextSize}
 			onChange={handleContextSizeChange}
-			toggleClass="toggle-btn"
 			id="ob-llm-context-size-toggle"
 		/>
 	</div>

--- a/src/lib/components/ui/ContextSizeSlider.svelte
+++ b/src/lib/components/ui/ContextSizeSlider.svelte
@@ -9,7 +9,6 @@
 	interface Props {
 		contextSize: number | undefined;
 		onChange: (value: number | undefined) => void;
-		toggleClass?: string;
 		id?: string;
 		note?: string;
 	}
@@ -17,7 +16,6 @@
 	let {
 		contextSize,
 		onChange,
-		toggleClass = 'service-toggle',
 		id = 'llm-context-size-toggle',
 		note = 'When enabled, memory injection and chat history are scaled to fit the selected model\'s context window.'
 	}: Props = $props();
@@ -45,7 +43,7 @@
 	</label>
 	<button
 		{id}
-		class={toggleClass}
+		class="context-size-toggle"
 		class:enabled
 		onclick={handleToggle}
 		aria-label="Toggle context window scaling"
@@ -73,7 +71,7 @@
 		</div>
 	</div>
 {/if}
-<p class="provider-note">{note}</p>
+<p class="context-size-note">{note}</p>
 
 <style>
 	.context-size-row {
@@ -99,6 +97,46 @@
 		font-variant-numeric: tabular-nums;
 	}
 
+	.context-size-toggle {
+		margin-left: auto;
+		position: relative;
+		width: 40px;
+		height: 22px;
+		background: transparent;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+	}
+
+	.context-size-toggle .toggle-track {
+		display: block;
+		width: 100%;
+		height: 100%;
+		background: var(--bg-tertiary);
+		border-radius: var(--radius-full);
+		transition: background 0.2s ease;
+	}
+
+	.context-size-toggle.enabled .toggle-track {
+		background: var(--accent);
+	}
+
+	.context-size-toggle .toggle-thumb {
+		position: absolute;
+		top: 2px;
+		left: 2px;
+		width: 18px;
+		height: 18px;
+		background: #fff;
+		border-radius: var(--radius-full);
+		transition: transform 0.2s ease;
+		box-shadow: var(--shadow-xs);
+	}
+
+	.context-size-toggle.enabled .toggle-thumb {
+		transform: translateX(18px);
+	}
+
 	.context-size-slider-row {
 		display: flex;
 		flex-direction: column;
@@ -116,5 +154,11 @@
 		font-size: 0.65rem;
 		color: var(--text-tertiary);
 		padding: 0 0.25rem;
+	}
+
+	.context-size-note {
+		margin: 0;
+		font-size: 0.75rem;
+		color: var(--text-tertiary);
 	}
 </style>

--- a/src/lib/components/ui/ContextSizeSlider.svelte
+++ b/src/lib/components/ui/ContextSizeSlider.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import {
+		CONTEXT_SIZE_STEPS,
+		DEFAULT_CONTEXT_SIZE,
+		formatContextSize,
+		snapContextSize
+	} from '$lib/utils/context-window';
+
+	interface Props {
+		contextSize: number | undefined;
+		onChange: (value: number | undefined) => void;
+		toggleClass?: string;
+		id?: string;
+		note?: string;
+	}
+
+	let {
+		contextSize,
+		onChange,
+		toggleClass = 'service-toggle',
+		id = 'llm-context-size-toggle',
+		note = 'When enabled, memory injection and chat history are scaled to fit the selected model\'s context window.'
+	}: Props = $props();
+
+	const enabled = $derived(contextSize !== undefined && contextSize > 0);
+
+	function handleToggle() {
+		onChange(enabled ? undefined : DEFAULT_CONTEXT_SIZE);
+	}
+
+	function handleSliderInput(e: Event) {
+		const index = Number((e.target as HTMLInputElement).value);
+		onChange(CONTEXT_SIZE_STEPS[index]);
+	}
+</script>
+
+<div class="context-size-row">
+	<label class="context-size-label" for={id}>
+		Context Window
+		{#if enabled}
+			<span class="context-size-value">{formatContextSize(snapContextSize(contextSize as number))}</span>
+		{:else}
+			<span class="context-size-value">Default</span>
+		{/if}
+	</label>
+	<button
+		{id}
+		class={toggleClass}
+		class:enabled
+		onclick={handleToggle}
+		aria-label="Toggle context window scaling"
+	>
+		<span class="toggle-track">
+			<span class="toggle-thumb"></span>
+		</span>
+	</button>
+</div>
+{#if enabled}
+	<div class="context-size-slider-row">
+		<input
+			type="range"
+			class="context-size-slider"
+			min="0"
+			max={CONTEXT_SIZE_STEPS.length - 1}
+			step="1"
+			value={CONTEXT_SIZE_STEPS.indexOf(snapContextSize(contextSize as number))}
+			oninput={handleSliderInput}
+		/>
+		<div class="context-size-ticks">
+			{#each CONTEXT_SIZE_STEPS as step}
+				<span>{formatContextSize(step)}</span>
+			{/each}
+		</div>
+	</div>
+{/if}
+<p class="provider-note">{note}</p>
+
+<style>
+	.context-size-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.context-size-label {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		flex: 1;
+		font-size: 0.8rem;
+		font-weight: 500;
+		color: var(--text-secondary);
+	}
+
+	.context-size-value {
+		font-size: 0.75rem;
+		color: var(--text-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.context-size-slider-row {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.context-size-slider {
+		width: 100%;
+		cursor: pointer;
+	}
+
+	.context-size-ticks {
+		display: flex;
+		justify-content: space-between;
+		font-size: 0.65rem;
+		color: var(--text-tertiary);
+		padding: 0 0.25rem;
+	}
+</style>

--- a/src/lib/components/ui/index.ts
+++ b/src/lib/components/ui/index.ts
@@ -9,3 +9,4 @@ export { default as TopLeftButtons } from './TopLeftButtons.svelte';
 export { default as InfoModal } from './InfoModal.svelte';
 export { default as ProviderDropdown } from './ProviderDropdown.svelte';
 export { default as ModelDropdown } from './ModelDropdown.svelte';
+export { default as ContextSizeSlider } from './ContextSizeSlider.svelte';

--- a/src/lib/engine/memory.ts
+++ b/src/lib/engine/memory.ts
@@ -7,7 +7,14 @@ import type {
 	MemorySearchOptions,
 	NewFact
 } from '$lib/types/memory';
-import { MAX_WORKING_MEMORY_TURNS, MAX_RELEVANT_FACTS, MAX_RECENT_SESSIONS, DEFAULT_FACT_IMPORTANCE, DEFAULT_FACT_CONFIDENCE } from '$lib/types/memory';
+import {
+	MAX_WORKING_MEMORY_TURNS,
+	MAX_RELEVANT_FACTS,
+	MAX_RECENT_SESSIONS,
+	DEFAULT_FACT_IMPORTANCE,
+	DEFAULT_FACT_CONFIDENCE,
+	getMemoryBudget
+} from '$lib/types/memory';
 import * as memoryStorage from '$lib/services/storage/memory';
 import { embedText, findSimilarFacts, isEmbeddingReady } from '$lib/services/embeddings';
 import { hasCurrentEmbedding } from './embedding-version';
@@ -194,10 +201,16 @@ export const memoryApi = {
 	}
 };
 
-// Retrieve relevant context for prompt building
-export async function retrieveRelevantContext(userMessage: string): Promise<RelevantContext> {
+// Retrieve relevant context for prompt building.
+// When contextSize is provided, recent turns are bounded by the memory budget
+// so the 20-turn tier for large context windows is actually reachable.
+export async function retrieveRelevantContext(
+	userMessage: string,
+	contextSize?: number
+): Promise<RelevantContext> {
 	// Get recent turns from working memory
-	const recentTurns = getRecentTurns(10);
+	const turnLimit = contextSize ? getMemoryBudget(contextSize).workingMemoryTurns : 10;
+	const recentTurns = getRecentTurns(turnLimit);
 
 	// Search for relevant facts based on user message
 	let relevantFacts: Fact[] = [];

--- a/src/lib/services/chat/companion-chat.ts
+++ b/src/lib/services/chat/companion-chat.ts
@@ -15,7 +15,7 @@ import { getLLMProvider, getTTSProvider } from '$lib/services/providers/registry
 import { streamChatDirect } from '$lib/services/chat/client-chat';
 import { processCompanionTurn } from '$lib/services/chat/companion-turn';
 import { retrieveRelevantContext } from '$lib/engine/memory';
-import { buildSystemPrompt, truncateMessagesToContext, type PromptContext } from '$lib/ai/prompt-builder';
+import { buildSystemPrompt, truncateChatHistory, type PromptContext } from '$lib/ai/prompt-builder';
 import { keepImage, type PreparedImage } from '$lib/services/storage/keepsakes';
 import { toOpenAIContent, type ContentPart } from '$lib/services/chat/content';
 import { isTauri } from '$lib/services/platform';
@@ -183,19 +183,9 @@ export async function sendCompanionMessage(
 		// Truncate message history to the configured context window. This applies
 		// to every provider so users can size prompts to their model's limit.
 		// Image turns use a non-string content shape; token estimation for them is
-		// skipped by substituting a placeholder, and the resulting suffix length is
-		// applied to the original message array.
+		// handled by substituting a placeholder inside the helper.
 		if (contextSize && contextSize > 0 && messages.length > 0) {
-			const messagesWithSystem = [
-				{ role: 'system' as const, content: systemPrompt },
-				...messages.map((m) => ({
-					role: m.role,
-					content: typeof m.content === 'string' ? m.content : '[image content]'
-				}))
-			];
-			truncateMessagesToContext(messagesWithSystem, contextSize);
-			const keptHistoryCount = messagesWithSystem.length - 1;
-			messages = messages.slice(-keptHistoryCount);
+			messages = truncateChatHistory(messages, systemPrompt, contextSize);
 		}
 
 		// Advanced parameters are only supported for OpenAI-compatible endpoints.

--- a/src/lib/services/chat/companion-chat.ts
+++ b/src/lib/services/chat/companion-chat.ts
@@ -45,7 +45,7 @@ async function buildCompanionPrompt(
 	const context: PromptContext = {
 		persona: personaStore.activeCard,
 		state: characterStore.state,
-		memories: await retrieveRelevantContext(userMessage),
+		memories: await retrieveRelevantContext(userMessage, contextSize),
 		userMessage,
 		systemTime: new Date(),
 		hasImages,

--- a/src/lib/services/chat/companion-chat.ts
+++ b/src/lib/services/chat/companion-chat.ts
@@ -15,7 +15,7 @@ import { getLLMProvider, getTTSProvider } from '$lib/services/providers/registry
 import { streamChatDirect } from '$lib/services/chat/client-chat';
 import { processCompanionTurn } from '$lib/services/chat/companion-turn';
 import { retrieveRelevantContext } from '$lib/engine/memory';
-import { buildSystemPrompt, type PromptContext } from '$lib/ai/prompt-builder';
+import { buildSystemPrompt, truncateMessagesToContext, type PromptContext } from '$lib/ai/prompt-builder';
 import { keepImage, type PreparedImage } from '$lib/services/storage/keepsakes';
 import { toOpenAIContent, type ContentPart } from '$lib/services/chat/content';
 import { isTauri } from '$lib/services/platform';
@@ -37,14 +37,19 @@ export interface CompanionChatHooks {
 	beforeStream?: () => void;
 }
 
-async function buildCompanionPrompt(userMessage: string, hasImages: boolean): Promise<string> {
+async function buildCompanionPrompt(
+	userMessage: string,
+	hasImages: boolean,
+	contextSize?: number
+): Promise<string> {
 	const context: PromptContext = {
 		persona: personaStore.activeCard,
 		state: characterStore.state,
 		memories: await retrieveRelevantContext(userMessage),
 		userMessage,
 		systemTime: new Date(),
-		hasImages
+		hasImages,
+		contextSize
 	};
 	return buildSystemPrompt(context);
 }
@@ -160,7 +165,8 @@ export async function sendCompanionMessage(
 			throw new Error('Please configure a provider in Settings > Modules > Consciousness');
 		}
 
-		const systemPrompt = await buildCompanionPrompt(content, images.length > 0);
+		const contextSize = (consciousnessSettings.contextSize as number | undefined) || undefined;
+		const systemPrompt = await buildCompanionPrompt(content, images.length > 0, contextSize);
 		const providerConfig = settingsStore.getProviderConfig(provider);
 		const apiKey = providerConfig.apiKey;
 		const providerMeta = getLLMProvider(provider);
@@ -171,8 +177,26 @@ export async function sendCompanionMessage(
 		chatStore.addMessage('assistant', '');
 		const selectedModel = model || providerMeta?.models?.[0]?.id || '';
 		const baseURL = providerConfig.baseUrl || providerMeta?.defaultBaseUrl;
-		const messages = buildMessages(images);
+		let messages = buildMessages(images);
 		const onDelta = (full: string) => chatStore.updateLastMessage(full);
+
+		// Truncate message history to the configured context window. This applies
+		// to every provider so users can size prompts to their model's limit.
+		// Image turns use a non-string content shape; token estimation for them is
+		// skipped by substituting a placeholder, and the resulting suffix length is
+		// applied to the original message array.
+		if (contextSize && contextSize > 0 && messages.length > 0) {
+			const messagesWithSystem = [
+				{ role: 'system' as const, content: systemPrompt },
+				...messages.map((m) => ({
+					role: m.role,
+					content: typeof m.content === 'string' ? m.content : '[image content]'
+				}))
+			];
+			truncateMessagesToContext(messagesWithSystem, contextSize);
+			const keptHistoryCount = messagesWithSystem.length - 1;
+			messages = messages.slice(-keptHistoryCount);
+		}
 
 		// Advanced parameters are only supported for OpenAI-compatible endpoints.
 		const advancedParams = providerMeta?.custom

--- a/src/lib/services/modules/essential/consciousness.ts
+++ b/src/lib/services/modules/essential/consciousness.ts
@@ -48,6 +48,12 @@ export const consciousnessModule: ModuleDefinition = {
 				description: 'Maximum tokens in response. Leave empty to use the provider default.'
 			},
 			{
+				key: 'contextSize',
+				type: 'number',
+				label: 'Context Window',
+				description: 'Maximum context size of the selected model in tokens. Used to scale memory injection and truncate history. Leave empty to keep the default behavior.'
+			},
+			{
 				key: 'presencePenalty',
 				type: 'number',
 				label: 'Presence Penalty',

--- a/src/lib/types/memory.ts
+++ b/src/lib/types/memory.ts
@@ -97,6 +97,29 @@ export interface MessageAnalysis {
 	nonLatinDominant: boolean;
 }
 
+// Memory injection budget derived from the configured model context size.
+// Only fields that are actually consumed by the prompt builder are included.
+export interface MemoryBudget {
+	workingMemoryTurns: number;
+	relevantFacts: number;
+}
+
+/**
+ * Scale memory injection based on the configured model context window.
+ * Larger context windows allow more recent turns and relevant facts to be
+ * injected into each prompt. When no context size is configured, callers
+ * should fall back to the historical defaults (6 turns, 5 facts).
+ */
+export function getMemoryBudget(contextSize: number): MemoryBudget {
+	if (contextSize <= 4096) {
+		return { workingMemoryTurns: 6, relevantFacts: 3 };
+	}
+	if (contextSize <= 8192) {
+		return { workingMemoryTurns: 10, relevantFacts: 5 };
+	}
+	return { workingMemoryTurns: 20, relevantFacts: 10 };
+}
+
 // Constants
 export const MAX_WORKING_MEMORY_TURNS = 20;
 export const MAX_RELEVANT_FACTS = 10;

--- a/src/lib/utils/context-window.ts
+++ b/src/lib/utils/context-window.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared context-window helpers used by both the settings page and onboarding.
+ */
+
+export const CONTEXT_SIZE_STEPS = [1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072];
+
+// Conservative default: 8k fits most local / entry-level models while still
+// enabling the memory-budget scaling path.
+export const DEFAULT_CONTEXT_SIZE = 8192;
+
+export function formatContextSize(value: number): string {
+	if (value >= 1024) return `${value / 1024}k`;
+	return String(value);
+}
+
+export function snapContextSize(value: number): number {
+	return CONTEXT_SIZE_STEPS.reduce((prev, curr) =>
+		Math.abs(curr - value) < Math.abs(prev - value) ? curr : prev
+	);
+}

--- a/src/routes/app/settings/persona/AiServicesSection.svelte
+++ b/src/routes/app/settings/persona/AiServicesSection.svelte
@@ -4,28 +4,21 @@
 	import { getLLMProvider, getTTSProvider } from '$lib/services/providers/registry';
 	import { Icon, ProviderDropdown, ModelDropdown } from '$lib/components/ui';
 	import type { PersonaPageState } from './persona-page.svelte';
+	import {
+		CONTEXT_SIZE_STEPS,
+		DEFAULT_CONTEXT_SIZE,
+		formatContextSize,
+		snapContextSize
+	} from '$lib/utils/context-window';
 
 	let { page }: { page: PersonaPageState } = $props();
-
-	const contextSizeSteps = [1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072];
-
-	function formatContextSize(value: number): string {
-		if (value >= 1024) return `${value / 1024}k`;
-		return String(value);
-	}
-
-	function snapContextSize(value: number): number {
-		return contextSizeSteps.reduce((prev, curr) =>
-			Math.abs(curr - value) < Math.abs(prev - value) ? curr : prev
-		);
-	}
 
 	function handleContextSizeChange(value: number) {
 		page.handleLLMNumberSetting('contextSize', value);
 	}
 
 	function handleContextSizeToggle(enabled: boolean) {
-		page.handleLLMNumberSetting('contextSize', enabled ? 32768 : undefined);
+		page.handleLLMNumberSetting('contextSize', enabled ? DEFAULT_CONTEXT_SIZE : undefined);
 	}
 </script>
 
@@ -267,13 +260,13 @@
 									type="range"
 									class="llm-param-slider"
 									min="0"
-									max={contextSizeSteps.length - 1}
+									max={CONTEXT_SIZE_STEPS.length - 1}
 									step="1"
-									value={contextSizeSteps.indexOf(snapContextSize(contextSize))}
-									oninput={(e) => handleContextSizeChange(contextSizeSteps[Number(e.currentTarget.value)])}
+									value={CONTEXT_SIZE_STEPS.indexOf(snapContextSize(contextSize))}
+									oninput={(e) => handleContextSizeChange(CONTEXT_SIZE_STEPS[Number(e.currentTarget.value)])}
 								/>
 								<div class="context-size-ticks">
-									{#each contextSizeSteps as step}
+									{#each CONTEXT_SIZE_STEPS as step}
 										<span>{formatContextSize(step)}</span>
 									{/each}
 								</div>

--- a/src/routes/app/settings/persona/AiServicesSection.svelte
+++ b/src/routes/app/settings/persona/AiServicesSection.svelte
@@ -6,6 +6,27 @@
 	import type { PersonaPageState } from './persona-page.svelte';
 
 	let { page }: { page: PersonaPageState } = $props();
+
+	const contextSizeSteps = [1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072];
+
+	function formatContextSize(value: number): string {
+		if (value >= 1024) return `${value / 1024}k`;
+		return String(value);
+	}
+
+	function snapContextSize(value: number): number {
+		return contextSizeSteps.reduce((prev, curr) =>
+			Math.abs(curr - value) < Math.abs(prev - value) ? curr : prev
+		);
+	}
+
+	function handleContextSizeChange(value: number) {
+		page.handleLLMNumberSetting('contextSize', value);
+	}
+
+	function handleContextSizeToggle(enabled: boolean) {
+		page.handleLLMNumberSetting('contextSize', enabled ? 32768 : undefined);
+	}
 </script>
 
 <!-- AI Services (collapsible) -->
@@ -215,6 +236,52 @@
 								disabledMessage="Enter API key first"
 							/>
 						{/if}
+
+						<!-- Context Window -->
+						{@const contextSize = page.consciousnessSettings.contextSize as number | undefined}
+						{@const contextEnabled = contextSize !== undefined && contextSize > 0}
+						<div class="context-size-row">
+							<label class="context-size-label" for="llm-context-size-toggle">
+								Context Window
+								{#if contextEnabled}
+									<span class="context-size-value">{formatContextSize(snapContextSize(contextSize))}</span>
+								{:else}
+									<span class="context-size-value">Default</span>
+								{/if}
+							</label>
+							<button
+								id="llm-context-size-toggle"
+								class="service-toggle"
+								class:enabled={contextEnabled}
+								onclick={() => handleContextSizeToggle(!contextEnabled)}
+								aria-label="Toggle context window scaling"
+							>
+								<span class="toggle-track">
+									<span class="toggle-thumb"></span>
+								</span>
+							</button>
+						</div>
+						{#if contextEnabled}
+							<div class="context-size-slider-row">
+								<input
+									type="range"
+									class="llm-param-slider"
+									min="0"
+									max={contextSizeSteps.length - 1}
+									step="1"
+									value={contextSizeSteps.indexOf(snapContextSize(contextSize))}
+									oninput={(e) => handleContextSizeChange(contextSizeSteps[Number(e.currentTarget.value)])}
+								/>
+								<div class="context-size-ticks">
+									{#each contextSizeSteps as step}
+										<span>{formatContextSize(step)}</span>
+									{/each}
+								</div>
+							</div>
+						{/if}
+						<p class="provider-note">
+							When enabled, memory injection and chat history are scaled to fit the selected model's context window.
+						</p>
 					{/if}
 				{/if}
 			</div>
@@ -607,5 +674,42 @@
 	.llm-param-slider {
 		width: 100%;
 		cursor: pointer;
+	}
+
+	.context-size-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.context-size-label {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		flex: 1;
+		font-size: 0.8rem;
+		font-weight: 500;
+		color: var(--text-secondary);
+	}
+
+	.context-size-value {
+		font-size: 0.75rem;
+		color: var(--text-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.context-size-slider-row {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.context-size-ticks {
+		display: flex;
+		justify-content: space-between;
+		font-size: 0.65rem;
+		color: var(--text-tertiary);
+		padding: 0 0.25rem;
 	}
 </style>

--- a/src/routes/app/settings/persona/AiServicesSection.svelte
+++ b/src/routes/app/settings/persona/AiServicesSection.svelte
@@ -2,23 +2,13 @@
 	import { slideOpen } from '$lib/utils/motion';
 	import { settingsStore } from '$lib/stores/settings.svelte';
 	import { getLLMProvider, getTTSProvider } from '$lib/services/providers/registry';
-	import { Icon, ProviderDropdown, ModelDropdown } from '$lib/components/ui';
+	import { Icon, ProviderDropdown, ModelDropdown, ContextSizeSlider } from '$lib/components/ui';
 	import type { PersonaPageState } from './persona-page.svelte';
-	import {
-		CONTEXT_SIZE_STEPS,
-		DEFAULT_CONTEXT_SIZE,
-		formatContextSize,
-		snapContextSize
-	} from '$lib/utils/context-window';
 
 	let { page }: { page: PersonaPageState } = $props();
 
-	function handleContextSizeChange(value: number) {
+	function handleContextSizeChange(value: number | undefined) {
 		page.handleLLMNumberSetting('contextSize', value);
-	}
-
-	function handleContextSizeToggle(enabled: boolean) {
-		page.handleLLMNumberSetting('contextSize', enabled ? DEFAULT_CONTEXT_SIZE : undefined);
 	}
 </script>
 
@@ -231,50 +221,10 @@
 						{/if}
 
 						<!-- Context Window -->
-						{@const contextSize = page.consciousnessSettings.contextSize as number | undefined}
-						{@const contextEnabled = contextSize !== undefined && contextSize > 0}
-						<div class="context-size-row">
-							<label class="context-size-label" for="llm-context-size-toggle">
-								Context Window
-								{#if contextEnabled}
-									<span class="context-size-value">{formatContextSize(snapContextSize(contextSize))}</span>
-								{:else}
-									<span class="context-size-value">Default</span>
-								{/if}
-							</label>
-							<button
-								id="llm-context-size-toggle"
-								class="service-toggle"
-								class:enabled={contextEnabled}
-								onclick={() => handleContextSizeToggle(!contextEnabled)}
-								aria-label="Toggle context window scaling"
-							>
-								<span class="toggle-track">
-									<span class="toggle-thumb"></span>
-								</span>
-							</button>
-						</div>
-						{#if contextEnabled}
-							<div class="context-size-slider-row">
-								<input
-									type="range"
-									class="llm-param-slider"
-									min="0"
-									max={CONTEXT_SIZE_STEPS.length - 1}
-									step="1"
-									value={CONTEXT_SIZE_STEPS.indexOf(snapContextSize(contextSize))}
-									oninput={(e) => handleContextSizeChange(CONTEXT_SIZE_STEPS[Number(e.currentTarget.value)])}
-								/>
-								<div class="context-size-ticks">
-									{#each CONTEXT_SIZE_STEPS as step}
-										<span>{formatContextSize(step)}</span>
-									{/each}
-								</div>
-							</div>
-						{/if}
-						<p class="provider-note">
-							When enabled, memory injection and chat history are scaled to fit the selected model's context window.
-						</p>
+						<ContextSizeSlider
+							contextSize={page.consciousnessSettings.contextSize as number | undefined}
+							onChange={handleContextSizeChange}
+						/>
 					{/if}
 				{/if}
 			</div>
@@ -667,42 +617,5 @@
 	.llm-param-slider {
 		width: 100%;
 		cursor: pointer;
-	}
-
-	.context-size-row {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		gap: 0.75rem;
-	}
-
-	.context-size-label {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		flex: 1;
-		font-size: 0.8rem;
-		font-weight: 500;
-		color: var(--text-secondary);
-	}
-
-	.context-size-value {
-		font-size: 0.75rem;
-		color: var(--text-tertiary);
-		font-variant-numeric: tabular-nums;
-	}
-
-	.context-size-slider-row {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-
-	.context-size-ticks {
-		display: flex;
-		justify-content: space-between;
-		font-size: 0.65rem;
-		color: var(--text-tertiary);
-		padding: 0 0.25rem;
 	}
 </style>

--- a/src/routes/app/settings/persona/AiServicesSection.svelte
+++ b/src/routes/app/settings/persona/AiServicesSection.svelte
@@ -224,6 +224,7 @@
 						<ContextSizeSlider
 							contextSize={page.consciousnessSettings.contextSize as number | undefined}
 							onChange={handleContextSizeChange}
+							id="llm-context-size-toggle"
 						/>
 					{/if}
 				{/if}


### PR DESCRIPTION
   ```markdown                                                                                                                                                                                                                             
     This PR adds a **Context Window** setting to the LLM configuration that works for every provider (cloud + local).                                                                                                                     
                                                                                                                                                                                                                                           
     ## What it does                                                                                                                                                                                                                       
                                                                                                                                                                                                                                           
     - **Memory retrieval scaling** — `retrieveRelevantContext` now uses the configured context size to decide how many recent turns to fetch from working memory (6 / 10 / 20 turns). Previously the 20-turn tier was unreachable because 
   retrieval was hard-coded to 10.                                                                                                                                                                                                         
     - **Memory injection scaling** — The number of recent conversation turns and relevant facts injected into the prompt scales with the selected context size. Small local models get a minimal memory layer; larger models get more.    
     - **History truncation** — Before sending a request, the chat history is trimmed so system prompt + history + a response reserve fit inside the configured window. The system prompt and the user's newest message are always kept;   
   older history is dropped first.                                                                                                                                                                                                         
     - **CJK-aware token estimation** — `estimateTokens` counts CJK/Hiragana/Katakana/Hangul more conservatively so non-Latin chats don't lose history too aggressively.                                                                   
                                                                                                                                                                                                                                           
     ## UI                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                           
     - New shared `ContextSizeSlider.svelte` component used in both **Settings > AI Services** and the onboarding **Services** step, removing ~55 lines of duplicated markup.                                                              
     - Toggle renders as a proper switch and includes a scaled helper note.                                                                                                                                                                
     - Default is **8192** tokens when enabled.                                                                                                                                                                                            
                                                                                                                                                                                                                                           
     ## Provider support                                                                                                                                                                                                                   
                                                                                                                                                                                                                                           
     The setting is provider-agnostic and applies to every LLM provider (OpenAI, Anthropic, Google, DeepSeek, xAI, Ollama, LM Studio, OpenAI-Compatible).                                                                                  
                                                                                                                                                                                                                                           
     ## Docs                                                                                                                                                                                                                               
                                                                                                                                                                                                                                           
     - `README.md`: added a "Context Window and Memory Budget" section and updated the configuration steps.                                                                                                                                
     - `src/content/docs/technology/companion-system.md`: added architecture notes on memory retrieval, scaling, and history truncation.                                                                                                   
                                                                                                                                                                                                                                           
     ## Tests                                                                                                                                                                                                                              
                                                                                                                                                                                                                                           
     - `prompt-builder.test.ts`:                                                                                                                                                                                                           
       - `getMemoryBudget` boundary values                                                                                                                                                                                                 
       - `estimateTokens` for empty, Latin, and CJK text                                                                                                                                                                                   
       - Default memory budget fallback (6 turns / 5 facts)                                                                                                                                                                                
       - Truncation edge cases (oversized system prompt, multiple system messages, empty history)                                                                                                                                          
       - `truncateChatHistory` integration including image-content placeholders                                                                                                                                                            
                                                                                                                                                                                                                                           
     ## Notes                                                                                                                                                                                                                              
                                                                                                                                                                                                                                           
     - When no context size is configured, behavior is unchanged from before (historical defaults apply).                                                                                                                                  
     - No NSFW / unfiltered mode changes are included here.                                                                                                                                                                                
   ```    