### PR TITLE
chore: bump version to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-07-06
+
+### Added
+- **Context window control**: a new Context Window setting in AI Services and onboarding, for every LLM provider. When enabled, memory injection scales to your model's window (small local models get a lean memory layer, larger models get more turns and facts) and older chat history is trimmed so prompts fit, always keeping the persona and your newest message. Leave it off and behavior is unchanged. This is our first community-contributed feature, from @dezihh, thank you.
+
+### Fixed
+- Custom OpenAI-compatible endpoints: a base URL entered without /v1 now works for chat, not just the model dropdown, and keyless endpoints no longer receive a fabricated Authorization header that strict gateways rejected.
+- Switching TTS providers no longer carries the previous provider's voice along, which could make the new provider fail silently with a voice it doesn't know. The voice now resets to the new provider's default, and playback failures show a brief message naming the actual problem instead of the companion just going quiet.
+
 ## [0.9.0] - 2026-07-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.9.0"
+version = "0.9.1"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "pnpm build",


### PR DESCRIPTION
## Summary
Release housekeeping for 0.9.1: version bump in package.json, tauri.conf.json, Cargo.toml, and Cargo.lock, plus the CHANGELOG entry covering #100, #101, and #98.

## Testing
- Full gates run on the combined post-merge main before branching: 220/220 tests, svelte-check clean
- Context Window UI verified live on the #101 Vercel preview (onboarding toggle, slider steps, value display)