### PR TITLE
fix: drop the message that overflows the context budget during truncation

### DIFF
--- a/src/lib/ai/prompt-builder.test.ts
+++ b/src/lib/ai/prompt-builder.test.ts
@@ -293,6 +293,34 @@ test('memory budget defaults are used when contextSize is unset', () => {
 	assert.equal(facts, 5, 'default keeps 5 facts');
 });
 
+test('truncateMessagesToContext drops an oversized older message instead of keeping it', () => {
+	const messages = [
+		{ role: 'system', content: 'x'.repeat(4000) }, // ~1000 tokens
+		{ role: 'user', content: 'old small question' },
+		{ role: 'user', content: 'p'.repeat(80000) }, // ~20000 tokens, a big paste
+		{ role: 'assistant', content: 'short answer' },
+		{ role: 'user', content: 'newest message' }
+	];
+	truncateMessagesToContext(messages, 4096);
+	// The paste blows the budget, so it goes, along with everything older.
+	assert.equal(messages.length, 3);
+	assert.equal(messages[0].role, 'system');
+	assert.equal(messages[1].content, 'short answer');
+	assert.equal(messages[2].content, 'newest message');
+});
+
+test('truncateMessagesToContext keeps a newest message that alone exceeds the budget', () => {
+	const messages = [
+		{ role: 'system', content: 'x'.repeat(4000) },
+		{ role: 'user', content: 'older' },
+		{ role: 'user', content: 'n'.repeat(80000) }
+	];
+	truncateMessagesToContext(messages, 4096);
+	assert.equal(messages.length, 2);
+	assert.equal(messages[0].role, 'system');
+	assert.equal(messages[1].content.length, 80000);
+});
+
 test('truncateMessagesToContext keeps newest user message when system prompt nearly fills window', () => {
 	const messages = [
 		{ role: 'system', content: 'x'.repeat(6000) }, // ~1500 tokens

--- a/src/lib/ai/prompt-builder.ts
+++ b/src/lib/ai/prompt-builder.ts
@@ -470,10 +470,11 @@ export function truncateMessagesToContext(
 		const tokens = estimateTokens(messages[i].content);
 		totalHistoryTokens += tokens;
 		if (totalHistoryTokens > maxHistoryTokens) {
-			// Keep message i (it already tipped us over budget) and remove all
-			// older history before it. The loop goes newest→oldest, so i is the
-			// oldest message we can still afford.
-			const removed = i - historyStart;
+			// Message i tipped us over budget, so it goes too, along with all
+			// older history. The one exception is the newest message: it is
+			// always kept, even oversized, so the user's current turn survives.
+			const keepFrom = i === messages.length - 1 ? i : i + 1;
+			const removed = keepFrom - historyStart;
 			if (isDev && removed > 0) {
 				console.warn(
 					`[truncateMessagesToContext] removed ${removed} older messages to fit context window (${contextSize} tokens)`


### PR DESCRIPTION
## Summary
Follow-up to #101, as noted in its merge comment. The backward walk in truncateMessagesToContext kept the message that tipped the token budget over, so an oversized message in history (a large paste, for example) sailed through the configured window: with a 4096 window, a ~1k-token system prompt, and a ~20k-token paste two turns back, the kept set was still ~21k tokens. That is the overflow the setting exists to prevent on small local models.

The overflowing message is now dropped along with everything older. The one exception is unchanged: the newest message is always kept, even oversized, so the user's current turn survives.

## Testing
- TDD: the new oversized-paste test failed against the old behavior (kept 4 messages, ~21k tokens), passes with the fix (keeps system + short answer + newest)
- Second new test pins the newest-message exception (an oversized newest message is still kept)
- All of #101's original truncation tests pass unchanged
- 222/222 tests, svelte-check clean

## Notes
- Queued for the release after 0.9.1
- cc @dezihh