### PR TITLE
feat(vrm): add temporary VRM model preview to DeveloperFeature/temporary vrm model

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 ## Features
 
 - **VRM Model Viewer**: Load and display VRM 3D avatar models with orbit controls, automatic camera framing per model, and live camera settings (zoom, height, field of view)
+- **Developer Tools**: Test VRM facial expressions and animations, or upload a temporary `.vrm` file for a non-persistent preview that reverts when you leave the page
 - **AR Mode**: On WebXR-capable devices (Android Chrome, headset browsers), place your companion on your real floor, drag her around, and pinch to resize
 - **Model-Centric UI**: Full-screen 3D model with unobtrusive overlay controls
 - **3D Speech Bubbles**: Chat responses appear as bubbles that track the model's head in 3D space

--- a/src/lib/stores/vrm.svelte.ts
+++ b/src/lib/stores/vrm.svelte.ts
@@ -365,11 +365,16 @@ function createVrmStore() {
 		availableExpressions = [];
 	}
 
-	async function restoreOriginalModel(): Promise<void> {
+	function restoreOriginalModel(): void {
 		const result = tempModelManager.restore(models, DEFAULT_MODELS);
 		if (result.originalId) {
 			activeModelId = result.originalId;
 			modelUrl = result.url;
+		} else {
+			// Defensive fallback: if neither original nor defaults are available,
+			// clear the temp model state so the scene does not stay stuck.
+			activeModelId = null;
+			modelUrl = null;
 		}
 	}
 

--- a/src/lib/stores/vrm.svelte.ts
+++ b/src/lib/stores/vrm.svelte.ts
@@ -2,6 +2,7 @@ import { browser } from '$app/environment';
 import type { VRM } from '@pixiv/three-vrm';
 import localforage from 'localforage';
 import { isTauri } from '$lib/services/platform/platform';
+import { createTempVrmManager } from '$lib/utils/temp-vrm';
 
 export interface VrmModel {
 	id: string;
@@ -66,6 +67,10 @@ function createVrmStore() {
 
 	// Available expressions on current model (persists across navigation)
 	let availableExpressions = $state<string[]>([]);
+
+	// ── Temporary model (for Developer Tools preview) ──
+	// Kept in memory only; never persisted to storage.
+	const tempModelManager = createTempVrmManager();
 
 	// Animation state
 	let currentAnimation = $state<string | null>(null);
@@ -353,6 +358,21 @@ function createVrmStore() {
 		isTalking = false;
 	}
 
+	async function loadTempModel(file: File): Promise<void> {
+		const result = await tempModelManager.load(file, activeModelId);
+		modelUrl = result.url;
+		activeModelId = null;
+		availableExpressions = [];
+	}
+
+	async function restoreOriginalModel(): Promise<void> {
+		const result = tempModelManager.restore(models, DEFAULT_MODELS);
+		if (result.originalId) {
+			activeModelId = result.originalId;
+			modelUrl = result.url;
+		}
+	}
+
 	async function addModel(file: File, previewDataUrl?: string): Promise<void> {
 		const id = `custom-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 		const name = file.name.replace(/\.vrm$/i, '');
@@ -471,6 +491,9 @@ function createVrmStore() {
 		get headScreenPosition() {
 			return headScreenPosition;
 		},
+		get tempModelActive() {
+			return tempModelManager.getState().active;
+		},
 		setModelUrl,
 		setHeadPosition,
 		setHeadScreenPosition,
@@ -485,6 +508,8 @@ function createVrmStore() {
 		removeModel,
 		getActiveModel,
 		setModelPreview,
+		loadTempModel,
+		restoreOriginalModel,
 		whenReady: () => ready
 	};
 }

--- a/src/lib/stores/vrm.svelte.ts
+++ b/src/lib/stores/vrm.svelte.ts
@@ -2,7 +2,7 @@ import { browser } from '$app/environment';
 import type { VRM } from '@pixiv/three-vrm';
 import localforage from 'localforage';
 import { isTauri } from '$lib/services/platform/platform';
-import { createTempVrmManager } from '$lib/utils/temp-vrm';
+import { createTempVrmStoreIntegration } from '$lib/utils/temp-vrm-store';
 
 export interface VrmModel {
 	id: string;
@@ -70,7 +70,50 @@ function createVrmStore() {
 
 	// ── Temporary model (for Developer Tools preview) ──
 	// Kept in memory only; never persisted to storage.
-	const tempModelManager = createTempVrmManager();
+	const tempVrm = createTempVrmStoreIntegration();
+	let tempModelActive = $state(false);
+	let tempModelLoading = $state(false);
+	let tempModelLoadError = $state(false);
+
+	// Reactive bridge between the integration helper and the store's $state.
+	const tempState = {
+		get modelUrl() {
+			return modelUrl;
+		},
+		set modelUrl(value: string | null) {
+			modelUrl = value;
+		},
+		get activeModelId() {
+			return activeModelId;
+		},
+		set activeModelId(value: string | null) {
+			activeModelId = value;
+		},
+		get availableExpressions() {
+			return availableExpressions;
+		},
+		set availableExpressions(value: string[]) {
+			availableExpressions = value;
+		},
+		get tempModelActive() {
+			return tempModelActive;
+		},
+		set tempModelActive(value: boolean) {
+			tempModelActive = value;
+		},
+		get tempModelLoading() {
+			return tempModelLoading;
+		},
+		set tempModelLoading(value: boolean) {
+			tempModelLoading = value;
+		},
+		get tempModelLoadError() {
+			return tempModelLoadError;
+		},
+		set tempModelLoadError(value: boolean) {
+			tempModelLoadError = value;
+		}
+	};
 
 	// Animation state
 	let currentAnimation = $state<string | null>(null);
@@ -214,7 +257,7 @@ function createVrmStore() {
 	}
 
 	async function saveToStorage() {
-		if (!vrmStorage || !storageReady) return;
+		if (!vrmStorage || !storageReady || !tempVrm.canSave(tempState)) return;
 		try {
 			// Save custom models (not defaults) — strip blob URLs since they're ephemeral
 			const customModels = models
@@ -242,13 +285,26 @@ function createVrmStore() {
 
 	function setLoading(loading: boolean) {
 		isLoading = loading;
+		if (!loading) {
+			// The temporary model has finished parsing (or gave up).
+			tempVrm.onLoadingFinished(tempState);
+		}
 	}
 
-	function setError(err: string | null) {
-		// Clear any existing timeout
+	function clearError() {
 		if (errorTimeout) {
 			clearTimeout(errorTimeout);
 			errorTimeout = null;
+		}
+		error = null;
+	}
+
+	function setError(err: string | null) {
+		clearError();
+		// Track temp-load failures separately from other errors so the Developer
+		// page can restore the original avatar without catching unrelated errors.
+		if (err) {
+			tempVrm.onError(tempState);
 		}
 		error = err;
 		isLoading = false;
@@ -278,7 +334,7 @@ function createVrmStore() {
 	}
 
 	async function syncActiveModel() {
-		if (!storageReady) return;
+		if (!storageReady || tempModelActive) return;
 		const savedActiveId = await vrmStorage?.getItem<string>('active-model-id');
 		if (!savedActiveId || savedActiveId === activeModelId) return;
 
@@ -358,23 +414,19 @@ function createVrmStore() {
 		isTalking = false;
 	}
 
-	async function loadTempModel(file: File): Promise<void> {
-		const result = await tempModelManager.load(file, activeModelId);
-		modelUrl = result.url;
-		activeModelId = null;
-		availableExpressions = [];
+	function loadTempModel(file: File): void {
+		tempVrm.load(tempState, file);
 	}
 
 	function restoreOriginalModel(): void {
-		const result = tempModelManager.restore(models, DEFAULT_MODELS);
-		if (result.originalId) {
-			activeModelId = result.originalId;
-			modelUrl = result.url;
-		} else {
-			// Defensive fallback: if neither original nor defaults are available,
-			// clear the temp model state so the scene does not stay stuck.
-			activeModelId = null;
-			modelUrl = null;
+		// Clear any earlier temp-load error so a successful restore does not
+		// keep a stale "Failed to parse VRM" message on screen.
+		clearError();
+		tempVrm.restore(tempState, models, DEFAULT_MODELS);
+		// Defensive: if neither the original nor any default could be restored,
+		// surface an error instead of leaving the viewport blank silently.
+		if (!tempModelActive && activeModelId === null && modelUrl === null) {
+			setError('No VRM model available to restore.');
 		}
 	}
 
@@ -497,7 +549,13 @@ function createVrmStore() {
 			return headScreenPosition;
 		},
 		get tempModelActive() {
-			return tempModelManager.getState().active;
+			return tempModelActive;
+		},
+		get tempModelLoading() {
+			return tempModelLoading;
+		},
+		get tempModelLoadError() {
+			return tempModelLoadError;
 		},
 		setModelUrl,
 		setHeadPosition,

--- a/src/lib/utils/temp-vrm-store.test.ts
+++ b/src/lib/utils/temp-vrm-store.test.ts
@@ -1,0 +1,166 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createTempVrmStoreIntegration, type TempVrmStoreState } from './temp-vrm-store.ts';
+
+function makeFile(name = 'test.vrm'): File {
+	return new File(['vrm'], name, { type: 'model/vrm' });
+}
+
+function createState(overrides: Partial<TempVrmStoreState> = {}): TempVrmStoreState {
+	return {
+		modelUrl: '/models/default.vrm',
+		activeModelId: 'default-id',
+		availableExpressions: ['neutral'],
+		tempModelActive: false,
+		tempModelLoading: false,
+		tempModelLoadError: false,
+		...overrides
+	};
+}
+
+test('load switches to the temporary model and marks uploading', () => {
+	const integration = createTempVrmStoreIntegration();
+	const state = createState({ activeModelId: 'original-id' });
+
+	integration.load(state, makeFile('preview.vrm'));
+
+	assert.equal(state.tempModelActive, true);
+	assert.equal(state.tempModelLoading, true);
+	assert.equal(state.tempModelLoadError, false);
+	assert.equal(state.activeModelId, null);
+	assert.equal(state.availableExpressions.length, 0);
+	assert.ok(state.modelUrl?.startsWith('blob:'));
+});
+
+test('restore returns the original model and clears temp state', () => {
+	const integration = createTempVrmStoreIntegration();
+	const state = createState({ activeModelId: 'original-id' });
+	integration.load(state, makeFile());
+
+	integration.restore(
+		state,
+		[{ id: 'original-id', url: '/models/original.vrm' }],
+		[{ id: 'default-id', url: '/models/default.vrm' }]
+	);
+
+	assert.equal(state.tempModelActive, false);
+	assert.equal(state.tempModelLoading, false);
+	assert.equal(state.tempModelLoadError, false);
+	assert.equal(state.activeModelId, 'original-id');
+	assert.equal(state.modelUrl, '/models/original.vrm');
+});
+
+test('restore is a no-op when no temp model is active', () => {
+	const integration = createTempVrmStoreIntegration();
+	const state = createState();
+
+	integration.restore(
+		state,
+		[{ id: 'original-id', url: '/models/original.vrm' }],
+		[{ id: 'default-id', url: '/models/default.vrm' }]
+	);
+
+	assert.equal(state.tempModelActive, false);
+	assert.equal(state.activeModelId, 'default-id');
+	assert.equal(state.modelUrl, '/models/default.vrm');
+});
+
+test('originalId is frozen after the first load', () => {
+	const integration = createTempVrmStoreIntegration();
+	const state = createState({ activeModelId: 'first-id' });
+	integration.load(state, makeFile('first.vrm'));
+
+	// Simulate the user switching to another model before loading a second temp file.
+	state.activeModelId = 'second-id';
+	integration.load(state, makeFile('second.vrm'));
+
+	integration.restore(
+		state,
+		[
+			{ id: 'first-id', url: '/models/first.vrm' },
+			{ id: 'second-id', url: '/models/second.vrm' }
+		],
+		[{ id: 'default-id', url: '/models/default.vrm' }]
+	);
+
+	assert.equal(state.activeModelId, 'first-id');
+	assert.equal(state.modelUrl, '/models/first.vrm');
+});
+
+test('restore falls back to the first default when the original is missing', () => {
+	const integration = createTempVrmStoreIntegration();
+	const state = createState({ activeModelId: 'deleted-id' });
+	integration.load(state, makeFile());
+
+	integration.restore(state, [], [
+		{ id: 'fallback-id', url: '/models/fallback.vrm' }
+	]);
+
+	assert.equal(state.activeModelId, 'fallback-id');
+	assert.equal(state.modelUrl, '/models/fallback.vrm');
+	assert.equal(state.tempModelActive, false);
+	assert.equal(state.tempModelLoading, false);
+	assert.equal(state.tempModelLoadError, false);
+});
+
+test('restore clears the model when original and defaults are missing', () => {
+	const integration = createTempVrmStoreIntegration();
+	const state = createState({ activeModelId: 'original-id' });
+	integration.load(state, makeFile());
+
+	integration.restore(state, [], []);
+
+	assert.equal(state.activeModelId, null);
+	assert.equal(state.modelUrl, null);
+	assert.equal(state.tempModelActive, false);
+	assert.equal(state.tempModelLoading, false);
+	assert.equal(state.tempModelLoadError, false);
+});
+
+test('onLoadingFinished resets uploading only while a temp model is active', () => {
+	const integration = createTempVrmStoreIntegration();
+	const active = createState({ tempModelActive: true, tempModelLoading: true });
+	const inactive = createState({ tempModelActive: false, tempModelLoading: true });
+
+	integration.onLoadingFinished(active);
+	integration.onLoadingFinished(inactive);
+
+	assert.equal(active.tempModelLoading, false);
+	assert.equal(inactive.tempModelLoading, true);
+});
+
+test('onError flags temp-load failures only during an active upload', () => {
+	const integration = createTempVrmStoreIntegration();
+	const duringUpload = createState({
+		tempModelActive: true,
+		tempModelLoading: true
+	});
+	const activeButNotUploading = createState({
+		tempModelActive: true,
+		tempModelLoading: false
+	});
+	const notActive = createState({
+		tempModelActive: false,
+		tempModelLoading: true
+	});
+
+	integration.onError(duringUpload);
+	integration.onError(activeButNotUploading);
+	integration.onError(notActive);
+
+	assert.equal(duringUpload.tempModelLoadError, true);
+	assert.equal(duringUpload.tempModelLoading, false);
+	assert.equal(activeButNotUploading.tempModelLoadError, false);
+	assert.equal(activeButNotUploading.tempModelLoading, false);
+	assert.equal(notActive.tempModelLoadError, false);
+	assert.equal(notActive.tempModelLoading, true);
+});
+
+test('canSave returns false while a temp model is active', () => {
+	const integration = createTempVrmStoreIntegration();
+	const active = createState({ tempModelActive: true });
+	const inactive = createState({ tempModelActive: false });
+
+	assert.equal(integration.canSave(active), false);
+	assert.equal(integration.canSave(inactive), true);
+});

--- a/src/lib/utils/temp-vrm-store.ts
+++ b/src/lib/utils/temp-vrm-store.ts
@@ -1,0 +1,85 @@
+import { createTempVrmManager, type VrmModelRef } from './temp-vrm.ts';
+
+export interface TempVrmStoreState {
+	modelUrl: string | null;
+	activeModelId: string | null;
+	availableExpressions: string[];
+	tempModelActive: boolean;
+	tempModelLoading: boolean;
+	tempModelLoadError: boolean;
+}
+
+/**
+ * Bridges the temporary-VRM manager and the reactive VRM store.
+ *
+ * All state mutations are applied to the supplied {@link TempVrmStoreState}
+ * object so the caller can back the fields with Svelte runes, plain values,
+ * or test doubles without this module knowing the difference.
+ */
+export function createTempVrmStoreIntegration() {
+	const manager = createTempVrmManager();
+
+	function load(state: TempVrmStoreState, file: File): void {
+		const result = manager.load(file, state.activeModelId);
+		state.modelUrl = result.url;
+		state.activeModelId = null;
+		state.availableExpressions = [];
+		state.tempModelActive = result.active;
+		state.tempModelLoading = true;
+		state.tempModelLoadError = false;
+	}
+
+	function restore(
+		state: TempVrmStoreState,
+		models: VrmModelRef[],
+		defaultModels: VrmModelRef[]
+	): void {
+		// No-op if no temporary model is currently active. This prevents
+		// accidental restore calls from clearing the real avatar.
+		if (!state.tempModelActive) return;
+
+		const result = manager.restore(models, defaultModels);
+		if (result.originalId) {
+			state.activeModelId = result.originalId;
+			state.modelUrl = result.url;
+		} else {
+			// Defensive fallback: if neither original nor defaults are available,
+			// clear the temp model state so the scene does not stay stuck.
+			state.activeModelId = null;
+			state.modelUrl = null;
+		}
+		state.tempModelActive = result.active;
+		state.tempModelLoading = false;
+		state.tempModelLoadError = false;
+	}
+
+	/**
+	 * Called when the VRM engine finishes parsing (or fails) a model load.
+	 * Only resets the loading flag while a temp model is active so normal
+	 * avatar loads are not affected.
+	 */
+	function onLoadingFinished(state: TempVrmStoreState): void {
+		if (state.tempModelActive) {
+			state.tempModelLoading = false;
+		}
+	}
+
+	/**
+	 * Marks a temp-load failure so the UI can restore the original avatar.
+	 * Only touches state while a temp model is active.
+	 */
+	function onError(state: TempVrmStoreState): void {
+		if (!state.tempModelActive) return;
+		if (state.tempModelLoading) {
+			state.tempModelLoadError = true;
+		}
+		state.tempModelLoading = false;
+	}
+
+	/** Persisting the active model ID is not meaningful while previewing. */
+	function canSave(state: TempVrmStoreState): boolean {
+		return !state.tempModelActive;
+	}
+
+	return { load, restore, onLoadingFinished, onError, canSave };
+}

--- a/src/lib/utils/temp-vrm.test.ts
+++ b/src/lib/utils/temp-vrm.test.ts
@@ -112,3 +112,25 @@ test('restore returns no model when original and defaults are missing', async ()
 	assert.equal(result.originalId, null);
 	assert.equal(result.url, null);
 });
+
+test('originalId is frozen after the first temp load', async () => {
+	const manager = createTempVrmManager();
+	await manager.load(makeFile('first.vrm'), 'first-active-id');
+	await manager.load(makeFile('second.vrm'), 'second-active-id');
+
+	const state = manager.getState();
+	assert.equal(state.active, true);
+	assert.equal(state.originalId, 'first-active-id');
+
+	const result = manager.restore(
+		[
+			{ id: 'first-active-id', url: '/models/first.vrm' },
+			{ id: 'second-active-id', url: '/models/second.vrm' }
+		],
+		[{ id: 'default-id', url: '/models/default.vrm' }]
+	);
+
+	assert.equal(result.active, false);
+	assert.equal(result.originalId, 'first-active-id');
+	assert.equal(result.url, '/models/first.vrm');
+});

--- a/src/lib/utils/temp-vrm.test.ts
+++ b/src/lib/utils/temp-vrm.test.ts
@@ -75,3 +75,40 @@ test('restore without a prior temp model is a no-op', () => {
 	assert.equal(result.originalId, null);
 	assert.equal(result.url, null);
 });
+
+test('load with null activeModelId still creates a temp model', async () => {
+	const manager = createTempVrmManager();
+	const result = await manager.load(makeFile(), null);
+
+	assert.equal(result.active, true);
+	assert.equal(result.originalId, null);
+	assert.ok(result.url?.startsWith('blob:'));
+});
+
+test('double restore is idempotent', async () => {
+	const manager = createTempVrmManager();
+	await manager.load(makeFile(), 'original-id');
+	const first = manager.restore(
+		[{ id: 'original-id', url: '/models/original.vrm' }],
+		[{ id: 'default-id', url: '/models/default.vrm' }]
+	);
+	const second = manager.restore(
+		[{ id: 'original-id', url: '/models/original.vrm' }],
+		[{ id: 'default-id', url: '/models/default.vrm' }]
+	);
+
+	assert.equal(first.originalId, 'original-id');
+	assert.equal(second.originalId, null);
+	assert.equal(second.url, null);
+	assert.equal(second.active, false);
+});
+
+test('restore returns no model when original and defaults are missing', async () => {
+	const manager = createTempVrmManager();
+	await manager.load(makeFile(), 'original-id');
+	const result = manager.restore([], []);
+
+	assert.equal(result.active, false);
+	assert.equal(result.originalId, null);
+	assert.equal(result.url, null);
+});

--- a/src/lib/utils/temp-vrm.test.ts
+++ b/src/lib/utils/temp-vrm.test.ts
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createTempVrmManager } from './temp-vrm.ts';
+
+function makeFile(name = 'test.vrm'): File {
+	return new File(['vrm'], name, { type: 'model/vrm' });
+}
+
+test('temp model manager starts inactive', () => {
+	const manager = createTempVrmManager();
+	const state = manager.getState();
+	assert.equal(state.active, false);
+	assert.equal(state.url, null);
+	assert.equal(state.originalId, null);
+});
+
+test('load creates a blob URL and remembers the original active model', async () => {
+	const manager = createTempVrmManager();
+	const result = await manager.load(makeFile(), 'original-id');
+
+	assert.equal(result.active, true);
+	assert.ok(result.url?.startsWith('blob:'));
+	assert.equal(result.originalId, 'original-id');
+	assert.equal(manager.getState().active, true);
+});
+
+test('second load revokes the previous blob URL', async () => {
+	const manager = createTempVrmManager();
+	const first = await manager.load(makeFile('first.vrm'), 'original-id');
+	const second = await manager.load(makeFile('second.vrm'), 'original-id');
+
+	assert.notEqual(first.url, second.url);
+	assert.equal(second.active, true);
+	assert.equal(manager.getState().active, true);
+});
+
+test('restore revokes the temp URL and returns the original model', async () => {
+	const manager = createTempVrmManager();
+	await manager.load(makeFile(), 'original-id');
+	const result = manager.restore(
+		[{ id: 'original-id', url: '/models/original.vrm' }],
+		[{ id: 'default-id', url: '/models/default.vrm' }]
+	);
+
+	assert.equal(result.active, false);
+	assert.equal(result.url, '/models/original.vrm');
+	assert.equal(result.originalId, 'original-id');
+	assert.equal(manager.getState().active, false);
+});
+
+test('restore falls back to the first default when the original is missing', async () => {
+	const manager = createTempVrmManager();
+	await manager.load(makeFile(), 'deleted-id');
+	const result = manager.restore(
+		[{ id: 'other-id', url: '/models/other.vrm' }],
+		[
+			{ id: 'default-id', url: '/models/default.vrm' },
+			{ id: 'fallback-id', url: '/models/fallback.vrm' }
+		]
+	);
+
+	assert.equal(result.active, false);
+	assert.equal(result.originalId, 'default-id');
+	assert.equal(result.url, '/models/default.vrm');
+});
+
+test('restore without a prior temp model is a no-op', () => {
+	const manager = createTempVrmManager();
+	const result = manager.restore(
+		[{ id: 'original-id', url: '/models/original.vrm' }],
+		[{ id: 'default-id', url: '/models/default.vrm' }]
+	);
+
+	assert.equal(result.active, false);
+	assert.equal(result.originalId, null);
+	assert.equal(result.url, null);
+});

--- a/src/lib/utils/temp-vrm.ts
+++ b/src/lib/utils/temp-vrm.ts
@@ -1,0 +1,71 @@
+interface VrmModel {
+	id: string;
+	url: string;
+}
+
+export interface TempVrmState {
+	url: string | null;
+	originalId: string | null;
+	active: boolean;
+}
+
+/**
+ * Manages an in-memory temporary VRM preview.
+ *
+ * The temporary model is never persisted. Loading creates a blob URL from the
+ * provided file; restoring revokes that URL and returns the previously active
+ * model (or the first default as a fallback).
+ */
+export function createTempVrmManager() {
+	let state: TempVrmState = { url: null, originalId: null, active: false };
+
+	async function load(file: File, currentActiveModelId: string | null): Promise<TempVrmState> {
+		// Revoke any previous temp URL to avoid leaking blob URLs.
+		if (state.url) {
+			URL.revokeObjectURL(state.url);
+		}
+
+		// Remember the originally active model only on the first temp load.
+		if (!state.originalId) {
+			state.originalId = currentActiveModelId;
+		}
+
+		const blob = new Blob([await file.arrayBuffer()], { type: 'model/vrm' });
+		state.url = URL.createObjectURL(blob);
+		state.active = true;
+
+		return { ...state };
+	}
+
+	function restore(models: VrmModel[], defaultModels: VrmModel[]): TempVrmState {
+		if (state.url) {
+			URL.revokeObjectURL(state.url);
+			state.url = null;
+		}
+
+		let restoredId: string | null = null;
+		let restoredUrl: string | null = null;
+
+		if (state.originalId) {
+			const original = models.find((m) => m.id === state.originalId);
+			if (original) {
+				restoredId = original.id;
+				restoredUrl = original.url;
+			} else if (defaultModels.length > 0) {
+				// Fallback to default if the original was deleted in the meantime.
+				restoredId = defaultModels[0].id;
+				restoredUrl = defaultModels[0].url;
+			}
+			state.originalId = null;
+		}
+
+		state.active = false;
+		return { ...state, originalId: restoredId, url: restoredUrl };
+	}
+
+	function getState(): TempVrmState {
+		return { ...state };
+	}
+
+	return { load, restore, getState };
+}

--- a/src/lib/utils/temp-vrm.ts
+++ b/src/lib/utils/temp-vrm.ts
@@ -1,7 +1,7 @@
 // Minimal shape needed by restore(). This intentionally uses `Pick`-like
 // naming (VrmModelRef) so it is not confused with the full VrmModel type
 // exported by the store, while still accepting any object with id + url.
-interface VrmModelRef {
+export interface VrmModelRef {
 	id: string;
 	url: string;
 }
@@ -22,7 +22,7 @@ export interface TempVrmState {
 export function createTempVrmManager() {
 	let state: TempVrmState = { url: null, originalId: null, active: false };
 
-	async function load(file: File, currentActiveModelId: string | null): Promise<TempVrmState> {
+	function load(file: File, currentActiveModelId: string | null): TempVrmState {
 		// Revoke any previous temp URL to avoid leaking blob URLs.
 		if (state.url) {
 			URL.revokeObjectURL(state.url);
@@ -34,7 +34,13 @@ export function createTempVrmManager() {
 		}
 
 		// Use the File directly instead of copying it into a new Blob.
-		state.url = URL.createObjectURL(file);
+		try {
+			state.url = URL.createObjectURL(file);
+		} catch (e) {
+			state.url = null;
+			state.active = false;
+			throw new Error(`Failed to create object URL for temporary VRM: ${e}`);
+		}
 		state.active = true;
 
 		return { ...state };

--- a/src/lib/utils/temp-vrm.ts
+++ b/src/lib/utils/temp-vrm.ts
@@ -1,4 +1,7 @@
-interface VrmModel {
+// Minimal shape needed by restore(). This intentionally uses `Pick`-like
+// naming (VrmModelRef) so it is not confused with the full VrmModel type
+// exported by the store, while still accepting any object with id + url.
+interface VrmModelRef {
 	id: string;
 	url: string;
 }
@@ -30,14 +33,14 @@ export function createTempVrmManager() {
 			state.originalId = currentActiveModelId;
 		}
 
-		const blob = new Blob([await file.arrayBuffer()], { type: 'model/vrm' });
-		state.url = URL.createObjectURL(blob);
+		// Use the File directly instead of copying it into a new Blob.
+		state.url = URL.createObjectURL(file);
 		state.active = true;
 
 		return { ...state };
 	}
 
-	function restore(models: VrmModel[], defaultModels: VrmModel[]): TempVrmState {
+	function restore(models: VrmModelRef[], defaultModels: VrmModelRef[]): TempVrmState {
 		if (state.url) {
 			URL.revokeObjectURL(state.url);
 			state.url = null;

--- a/src/routes/app/settings/developer/+page.svelte
+++ b/src/routes/app/settings/developer/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import { vrmStore } from '$lib/stores/vrm.svelte';
 	import VrmScene from '$lib/components/vrm/VrmScene.svelte';
 	import { Icon } from '$lib/components/ui';
@@ -211,6 +212,37 @@
 		}, 500);
 	}
 
+	// ── Temporary VRM Upload ──
+	let tempModelUploading = $state(false);
+	let tempModelName = $state('');
+
+	function handleTempModelSelect(e: Event) {
+		const input = e.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file || !file.name.endsWith('.vrm')) return;
+
+		tempModelName = file.name;
+		tempModelUploading = true;
+		vrmStore.loadTempModel(file).then(() => {
+			tempModelUploading = false;
+		}).catch((err) => {
+			console.error('Failed to load temp model:', err);
+			tempModelUploading = false;
+			tempModelName = '';
+		});
+		input.value = ''; // reset so same file can be selected again
+	}
+
+	function restoreOriginalModel() {
+		vrmStore.restoreOriginalModel();
+		tempModelName = '';
+	}
+
+	// Restore original avatar when leaving the developer page
+	onDestroy(() => {
+		vrmStore.restoreOriginalModel();
+	});
+
 	// Clear all VRM storage (IndexedDB)
 	let clearingStorage = $state(false);
 	async function clearVrmStorage() {
@@ -273,6 +305,41 @@
 
 		<!-- Controls Panel -->
 		<div class="controls-panel">
+			<!-- Temporary VRM Model Upload -->
+			<section class="section">
+				<h3>Temporary VRM Model</h3>
+				<p class="hint">
+					Upload a .vrm file to preview it in the viewport. The model is loaded in memory only
+					and is <strong>not saved</strong>. When you leave this page or click "Restore Original",
+					the previously active avatar returns automatically.
+				</p>
+				{#if vrmStore.tempModelActive}
+					<div class="temp-model-info">
+						<span class="temp-model-name">{tempModelName || 'Temporary model'}</span>
+						<button
+							class="action-btn reset"
+							onclick={restoreOriginalModel}
+							disabled={tempModelUploading}
+						>
+							<Icon name="rotate-ccw" size={14} />
+							Restore Original
+						</button>
+					</div>
+				{:else}
+					<label class="upload-btn">
+						<Icon name="upload" size={14} />
+						{tempModelUploading ? 'Loading…' : 'Upload VRM'}
+						<input
+							type="file"
+							accept=".vrm"
+							onchange={handleTempModelSelect}
+							disabled={tempModelUploading}
+							style="display: none;"
+						/>
+					</label>
+				{/if}
+			</section>
+
 			<!-- Animation Selection -->
 		<section class="section">
 			<h3>Animation</h3>
@@ -554,6 +621,44 @@
 	.action-btn.reset:hover {
 		background: color-mix(in srgb, var(--bg-tertiary), var(--text-primary) 8%);
 		color: var(--color-error);
+	}
+
+	.upload-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem 1rem;
+		background: var(--accent);
+		border-radius: var(--radius-full);
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--accent-contrast, #fff);
+		cursor: pointer;
+		transition: background 0.15s, transform 0.1s;
+	}
+
+	.upload-btn:hover {
+		background: color-mix(in srgb, var(--accent), var(--text-primary) 15%);
+	}
+
+	.upload-btn:active {
+		transform: scale(0.98);
+	}
+
+	.temp-model-info {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding: 0.5rem 0.75rem;
+		background: var(--bg-tertiary);
+		border-radius: var(--radius-lg);
+	}
+
+	.temp-model-name {
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		word-break: break-all;
 	}
 
 	.event-buttons {

--- a/src/routes/app/settings/developer/+page.svelte
+++ b/src/routes/app/settings/developer/+page.svelte
@@ -213,23 +213,29 @@
 	}
 
 	// ── Temporary VRM Upload ──
-	let tempModelUploading = $state(false);
 	let tempModelName = $state('');
+
+	// If parsing the temporary model fails, restore the original avatar so the
+	// expression list and viewport do not stay empty/corrupted.
+	$effect(() => {
+		if (vrmStore.tempModelLoadError) {
+			vrmStore.restoreOriginalModel();
+			tempModelName = '';
+		}
+	});
 
 	function handleTempModelSelect(e: Event) {
 		const input = e.target as HTMLInputElement;
 		const file = input.files?.[0];
-		if (!file || !file.name.endsWith('.vrm')) return;
+		if (!file || !/\.vrm$/i.test(file.name)) return;
 
 		tempModelName = file.name;
-		tempModelUploading = true;
-		vrmStore.loadTempModel(file).then(() => {
-			tempModelUploading = false;
-		}).catch((err) => {
+		try {
+			vrmStore.loadTempModel(file);
+		} catch (err) {
 			console.error('Failed to load temp model:', err);
-			tempModelUploading = false;
 			tempModelName = '';
-		});
+		}
 		input.value = ''; // reset so same file can be selected again
 	}
 
@@ -317,24 +323,24 @@
 					<div class="temp-model-info">
 						<span class="temp-model-name">{tempModelName || 'Temporary model'}</span>
 						<button
-							class="action-btn reset"
+							class="action-btn"
 							onclick={restoreOriginalModel}
-							disabled={tempModelUploading}
+							disabled={vrmStore.tempModelLoading}
 						>
 							<Icon name="rotate-ccw" size={14} />
 							Restore Original
 						</button>
 					</div>
 				{:else}
-					<label class="upload-btn">
+					<label class="upload-btn" class:disabled={vrmStore.tempModelLoading}>
 						<Icon name="upload" size={14} />
-						{tempModelUploading ? 'Loading…' : 'Upload VRM'}
+						{vrmStore.tempModelLoading ? 'Loading…' : 'Upload VRM'}
 						<input
 							type="file"
-							accept=".vrm"
+							accept=".vrm,.VRM"
 							onchange={handleTempModelSelect}
-							disabled={tempModelUploading}
-							style="display: none;"
+							disabled={vrmStore.tempModelLoading}
+							class="sr-only"
 						/>
 					</label>
 				{/if}
@@ -643,6 +649,11 @@
 
 	.upload-btn:active {
 		transform: scale(0.98);
+	}
+
+	.upload-btn.disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
 	}
 
 	.temp-model-info {


### PR DESCRIPTION
 ```markdown                                                                                                                                       
     ## Summary                                                                                                                                      
     Adds a "Temporary VRM Model" section to **Settings → Developer Tools** so users can upload a `.vrm` file and preview it in the viewport without
   saving it. The original avatar is automatically restored when leaving the page or clicking "Restore Original".                                    
                                                                                                                                                     
     ## What's changed                                                                                                                               
     - New `Temporary VRM Model` card on the Developer Tools page with file upload and restore button.                                               
     - New `createTempVrmManager()` in `src/lib/utils/temp-vrm.ts` to handle blob URL lifecycle (create/revoke) and remember the original model ID.  
     - New `createTempVrmStoreIntegration()` in `src/lib/utils/temp-vrm-store.ts` to bridge the manager with the reactive VRM store, including:      
       - `load` / `restore`                                                                                                                          
       - `onLoadingFinished` and `onError` hooks for the parsing phase                                                                               
       - `canSave` guard so the active model ID is not persisted while previewing                                                                    
     - `vrm.svelte.ts` exposes `tempModelActive`, `tempModelLoading`, and `tempModelLoadError`.                                                      
     - `syncActiveModel()` is skipped while a temp model is active to avoid Tauri multi-window sync overwriting the preview.                         
     - File input uses `sr-only`, `.vrm`/`.VRM` are accepted, and the loading state covers upload + GPU parsing.                                     
                                                                                                                                                     
     ## Tests                                                                                                                                        
     - `src/lib/utils/temp-vrm.test.ts` – manager unit tests (10 cases)                                                                              
     - `src/lib/utils/temp-vrm-store.test.ts` – store integration tests (9 cases)                                                                    
                                                                                                                                                     
     ```bash                                                                                                                                         
     pnpm check   # 0 errors, 0 warnings                                                                                                             
     pnpm test    # 239 tests pass                                                                                                                   
   ```                                                                                                                                               
                                                                                                                                                     
   Notes                                                                                                                                             
                                                                                                                                                     
   • The temporary model is kept in memory only; no data is written to IndexedDB.                                                                    
   • If parsing fails, the original avatar is restored automatically and the user sees a brief error toast.      
```