### PR TITLE
chore: bump version to 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-07-07
+
+### Added
+- **Temporary VRM preview in Developer Tools**: upload a .vrm file and preview it in the viewport without saving anything. The model lives in memory only, and your real avatar returns automatically when you leave the page or click Restore Original. Contributed by @dezihh.
+
+### Fixed
+- With a Context Window configured, an oversized message in chat history (a large paste, for example) no longer slips through truncation and overflows the model's window. The message that breaks the budget is now dropped along with everything older, while your newest message is always kept.
+
+### Changed
+- The landing page now shows AR mode among the feature callouts, with a real capture from an Android device.
+
 ## [0.9.1] - 2026-07-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.9.1"
+version = "0.9.2"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "pnpm build",


### PR DESCRIPTION
## Summary
Release housekeeping for 0.9.2: version bump in package.json, tauri.conf.json, Cargo.toml, and Cargo.lock, plus the CHANGELOG entry covering #106, #103, and #107.

## Testing
- Full gates on the combined post-merge main before branching: 241/241 tests, svelte-check clean