### PR TITLE
fix: clarify local Ollama origin setup in docs and connection errors

### DIFF
--- a/src/content/docs/guides/local-llm-setup.md
+++ b/src/content/docs/guides/local-llm-setup.md
@@ -63,23 +63,45 @@ If the dropdown is empty, check your installed Ollama models with:
 ollama list
 ```
 
-If you are using the hosted website at `https://www.utsuwa.ai`, your browser connects directly to Ollama on your machine. Start Ollama with the Utsuwa origin allowed:
+### Allowing Utsuwa to reach Ollama
 
-```bash
-OLLAMA_ORIGINS=https://www.utsuwa.ai,https://utsuwa.ai ollama serve
+Ollama only answers requests from origins on its allowlist. If it isn't allowing Utsuwa, you'll see the model list stay empty and Ollama's own log will show `403` responses on `/api/tags`. Which origin you need to allow depends on how you run Utsuwa.
+
+**Desktop app**
+
+| Your OS | Setup needed | What to do |
+|---------|--------------|------------|
+| macOS | None | Ollama already allows the macOS app's `tauri://localhost` origin. Just run `ollama serve`. |
+| Windows | Yes | Allow `http://tauri.localhost` (see below). |
+| Linux | Yes | Allow `http://tauri.localhost` (see below). |
+
+The desktop app on Windows and Linux reports its origin to Ollama as `http://tauri.localhost`, which is not on Ollama's default allowlist, so you have to add it once.
+
+On **Windows**, set it and then fully restart Ollama:
+
+```
+setx OLLAMA_ORIGINS "http://tauri.localhost"
 ```
 
-If you are testing a Vercel preview, use the exact preview origin shown in the browser address bar, without the trailing slash:
+`setx` only applies to programs started afterward, so quit Ollama from the system tray (right-click the tray icon, Quit) and start it again. If you run `ollama serve` in a terminal instead, use `set OLLAMA_ORIGINS=http://tauri.localhost` in that same window before running it.
+
+On **Linux**, start Ollama with the origin in its environment:
 
 ```bash
-OLLAMA_ORIGINS=https://your-preview.vercel.app ollama serve
+OLLAMA_ORIGINS=http://tauri.localhost ollama serve
 ```
 
-For local development, use:
+If Ollama runs as a systemd service, run `systemctl edit ollama`, add `Environment="OLLAMA_ORIGINS=http://tauri.localhost"` under `[Service]`, then `sudo systemctl restart ollama`.
+
+**Hosted website (app.utsuwa.ai)**
+
+The web app runs at `app.utsuwa.ai`, and your browser connects directly to Ollama on your machine, so allow that origin:
 
 ```bash
-OLLAMA_ORIGINS=http://localhost:5173 ollama serve
+OLLAMA_ORIGINS=https://app.utsuwa.ai ollama serve
 ```
+
+Match whatever is in your browser's address bar. For local development use `http://localhost:5173`. For a Vercel preview, use the exact origin shown in the address bar (no trailing slash), such as `https://your-preview.vercel.app`. Comma-separate multiple origins, or use `OLLAMA_ORIGINS=*` to allow any origin on your machine.
 
 ## LM Studio
 
@@ -134,24 +156,12 @@ For Ollama, either `http://localhost:11434` or `http://localhost:11434/v1` works
 
 ### "Failed to fetch models"
 
-The LLM server may not be running or your browser may not be allowed to access it. Start the server:
+The LLM server may not be running, or it may not be allowing Utsuwa's origin. Start the server:
 
 - Ollama: `ollama serve`
 - LM Studio: Go to the Server tab and click Start Server
 
-If you are using the hosted website with Ollama, restart Ollama with:
-
-```bash
-OLLAMA_ORIGINS=https://www.utsuwa.ai,https://utsuwa.ai ollama serve
-```
-
-For a Vercel preview, use the exact preview origin:
-
-```bash
-OLLAMA_ORIGINS=https://your-preview.vercel.app ollama serve
-```
-
-Then click the refresh icon in Utsuwa's model dropdown.
+If the server is running but the list is still empty, it's almost always an origin problem. Ollama's log will show `403` on `/api/tags`. Allow Utsuwa's origin as described in [Allowing Utsuwa to reach Ollama](#allowing-utsuwa-to-reach-ollama): on the **Windows or Linux desktop app** that means `OLLAMA_ORIGINS=http://tauri.localhost`; on the **hosted website** it's `OLLAMA_ORIGINS=https://app.utsuwa.ai`. The macOS desktop app needs nothing. Restart Ollama after changing it, then click the refresh icon in Utsuwa's model dropdown.
 
 ### "model not found"
 
@@ -177,6 +187,10 @@ The port doesn't match. Default ports:
 
 Make sure the URL in Utsuwa matches the port your server is using.
 
+### Models still won't load (try 127.0.0.1)
+
+If Ollama is running and you've allowed the origin but the model list is still empty, change the base URL in Utsuwa from `http://localhost:11434` to `http://127.0.0.1:11434`. On some systems (most often Windows) `localhost` resolves to the IPv6 address `::1` first, while Ollama listens on the IPv4 address `127.0.0.1`, so the connection never reaches it. Pointing Utsuwa straight at `127.0.0.1` avoids the mismatch. This is machine-dependent, so it won't affect everyone.
+
 ### Slow responses
 
 - Try a smaller model (3B parameters instead of 7B+)
@@ -188,7 +202,7 @@ Make sure the URL in Utsuwa matches the port your server is using.
 If you're running Utsuwa in a browser and getting CORS errors with Ollama, set the origins environment variable before starting the server:
 
 ```bash
-OLLAMA_ORIGINS=https://www.utsuwa.ai,https://utsuwa.ai ollama serve
+OLLAMA_ORIGINS=https://app.utsuwa.ai ollama serve
 ```
 
 Ollama documents this under [allowing additional web origins](https://docs.ollama.com/faq#how-can-i-allow-additional-web-origins-to-access-ollama).
@@ -201,4 +215,4 @@ OLLAMA_ORIGINS=https://your-preview.vercel.app ollama serve
 
 If you use multiple Utsuwa origins, comma-separate them. Use `OLLAMA_ORIGINS=http://localhost:5173` for local development, or `OLLAMA_ORIGINS=*` only if you intentionally want to allow any browser origin on your machine.
 
-This isn't needed when using the desktop app.
+The **desktop app** hits the same Ollama allowlist. macOS works with no setup, but the Windows and Linux desktop apps need `OLLAMA_ORIGINS=http://tauri.localhost`. See [Allowing Utsuwa to reach Ollama](#allowing-utsuwa-to-reach-ollama).

--- a/src/content/docs/guides/local-stt-setup.md
+++ b/src/content/docs/guides/local-stt-setup.md
@@ -55,13 +55,13 @@ Running the server on a different machine or port? Enter the full URL in the Loc
 
 Local STT works best in the **desktop app**, where it needs no extra setup. The desktop app talks to your local server directly, with no browser origin, mixed-content, or local-network restrictions.
 
-On the **hosted website** (`https://www.utsuwa.ai`) it can still work, but because a public HTTPS page is reaching a server on your own machine, the browser adds a few rules:
+On the **hosted website** (`https://app.utsuwa.ai`) it can still work, but because a public HTTPS page is reaching a server on your own machine, the browser adds a few rules:
 
 - **Same machine only.** The server has to be on `localhost` / `127.0.0.1`. A server on another machine over plain `http://` is blocked by the browser as mixed content. (`localhost` is exempt, which is the only reason the local case works.) The remote-machine base URL above therefore works in the desktop app but not on the hosted site.
-- **The server must allow the site's origin.** Your STT server needs to send CORS headers permitting `https://www.utsuwa.ai`. A hardened or proxied server may need the origin added explicitly.
+- **The server must allow the site's origin.** Your STT server needs to send CORS headers permitting `https://app.utsuwa.ai`. A hardened or proxied server may need the origin added explicitly. (In that case the desktop app's origin is `tauri://localhost` on macOS and `http://tauri.localhost` on Windows and Linux.)
 - **Your browser may ask permission.** Recent versions of Chrome treat a public site reaching `localhost` as a local-network request and may prompt you to allow it. Allow it if asked.
 
-None of this applies to the desktop app. It's the same set of rules local LLMs and Local TTS follow on the hosted site.
+With a default server, none of this applies to the desktop app. The only case that needs attention is a server you've hardened to restrict origins, which would need the desktop origin above allowed. This is the same set of rules local LLMs and Local TTS follow on the hosted site.
 
 ## Troubleshooting
 
@@ -73,7 +73,7 @@ The server isn't running or isn't reachable at the base URL. Confirm it's up:
 curl http://localhost:8000/v1/models
 ```
 
-If that returns data but Utsuwa still can't reach it from a browser, it's almost certainly an origin or local-network block. On the hosted site the server has to allow the `https://www.utsuwa.ai` origin, and your browser may prompt to allow access to local-network devices. See [Desktop app vs hosted website](#desktop-app-vs-hosted-website). None of this applies to the **desktop app**, which is the smoothest way to run local STT.
+If that returns data but Utsuwa still can't reach it from a browser, it's almost certainly an origin or local-network block. On the hosted site the server has to allow the `https://app.utsuwa.ai` origin, and your browser may prompt to allow access to local-network devices. See [Desktop app vs hosted website](#desktop-app-vs-hosted-website). None of this applies to the **desktop app**, which is the smoothest way to run local STT.
 
 ### 400 or 404 from the server
 

--- a/src/content/docs/guides/local-tts-setup.md
+++ b/src/content/docs/guides/local-tts-setup.md
@@ -54,13 +54,13 @@ Running the server on a different machine or port? Enter the full URL in the Loc
 
 Local TTS works best in the **desktop app**, where it needs no extra setup. The desktop app talks to your local server directly, with no browser origin, mixed-content, or local-network restrictions. If you want the smoothest experience, use the desktop app.
 
-On the **hosted website** (`https://www.utsuwa.ai`) it can still work, but because a public HTTPS page is reaching a server on your own machine, the browser adds a few rules:
+On the **hosted website** (`https://app.utsuwa.ai`) it can still work, but because a public HTTPS page is reaching a server on your own machine, the browser adds a few rules:
 
 - **Same machine only.** The server has to be on `localhost` / `127.0.0.1`. A TTS server on another machine over plain `http://` is blocked by the browser as mixed content. (`localhost` is exempt from that block, which is the only reason the local case works at all.) The remote-machine base URL above therefore works in the desktop app but not on the hosted site.
-- **The server must allow the site's origin.** Your TTS server needs to send CORS headers permitting `https://www.utsuwa.ai`. Kokoro-FastAPI and openedai-speech allow all origins by default, so this usually just works; a hardened or proxied server may need the origin added explicitly.
+- **The server must allow the site's origin.** Your TTS server needs to send CORS headers permitting `https://app.utsuwa.ai`. Kokoro-FastAPI and openedai-speech allow all origins by default, so this usually just works; a hardened or proxied server may need the origin added explicitly. (In that case the desktop app's origin is `tauri://localhost` on macOS and `http://tauri.localhost` on Windows and Linux.)
 - **Your browser may ask permission.** Recent versions of Chrome treat a public site reaching `localhost` as a local-network request and may prompt you to allow it (or require the server to opt in). Allow it if asked.
 
-None of this applies to the desktop app. It is the same set of rules local LLMs (Ollama, LM Studio) follow on the hosted site.
+With the default servers, none of this applies to the desktop app. The only case that needs attention is a server you've hardened to restrict origins, which would need the desktop origin above allowed. This is the same set of rules local LLMs (Ollama, LM Studio) follow on the hosted site.
 
 ## Troubleshooting
 
@@ -76,7 +76,7 @@ The server isn't running or isn't reachable at the base URL. Confirm it's up:
 curl http://localhost:8880/v1/audio/voices
 ```
 
-If that returns data but Utsuwa still can't reach it from a browser, it's almost certainly an origin or local-network block. On the hosted site the server has to allow the `https://www.utsuwa.ai` origin (Kokoro-FastAPI allows all origins by default; a proxied or hardened server may need it added), and your browser may prompt to allow access to local-network devices. See [Desktop app vs hosted website](#desktop-app-vs-hosted-website) for the full list. None of this applies to the **desktop app**, which is the smoothest way to run local TTS.
+If that returns data but Utsuwa still can't reach it from a browser, it's almost certainly an origin or local-network block. On the hosted site the server has to allow the `https://app.utsuwa.ai` origin (Kokoro-FastAPI allows all origins by default; a proxied or hardened server may need it added), and your browser may prompt to allow access to local-network devices. See [Desktop app vs hosted website](#desktop-app-vs-hosted-website) for the full list. None of this applies to the **desktop app**, which is the smoothest way to run local TTS.
 
 ### "Local TTS server returned 400/404"
 

--- a/src/content/docs/guides/troubleshooting.md
+++ b/src/content/docs/guides/troubleshooting.md
@@ -136,7 +136,7 @@ If you selected **Local TTS** but hear nothing:
 2. **Voice is set** - The voice field must hold a name your server knows (e.g. `af_bella` for Kokoro)
 3. **Base URL** - It should point at the server's `/v1`; Utsuwa normalizes the trailing slash for you
 4. **Desktop app** - Just needs the server running on `localhost`; no origin or CORS setup is required
-5. **Hosted site** (`https://www.utsuwa.ai`) - The server must be on `localhost` (one on another machine is blocked as mixed content), must allow the `utsuwa.ai` origin (Kokoro-FastAPI does by default), and your browser may prompt to allow local-network access. Allow it if asked
+5. **Hosted site** (`https://app.utsuwa.ai`) - The server must be on `localhost` (one on another machine is blocked as mixed content), must allow the `app.utsuwa.ai` origin (Kokoro-FastAPI does by default), and your browser may prompt to allow local-network access. Allow it if asked
 
 See [Local TTS Setup](/docs/guides/local-tts-setup#desktop-app-vs-hosted-website) for the hosted vs desktop details.
 
@@ -178,12 +178,13 @@ See the [Desktop Guide](/docs/guides/desktop-guide) for the full install walkthr
 
 ### Local LLM or TTS won't connect (desktop)
 
-On the desktop app, local providers need **only** that the server is running. The browser origin, CORS, and local-network rules that apply on the hosted website do **not** apply here, so there's no `OLLAMA_ORIGINS` or CORS setup to do.
+On the desktop app, most local providers need only that the server is running. The one exception is **Ollama on Windows and Linux**: the desktop app's origin is `http://tauri.localhost`, which Ollama does not allow by default, so it rejects every request with a `403`. macOS is fine out of the box, and LM Studio and the common local TTS/STT servers (Kokoro-FastAPI, openedai-speech) allow all origins by default.
 
-1. **Ollama** - Start it with `ollama serve` and pull a model (`ollama pull <model>`)
-2. **LM Studio** - Load a model and click Start Server
-3. **Local TTS** - Start your TTS server (e.g. Kokoro-FastAPI on `http://localhost:8880`)
-4. **Base URL** - Confirm the port in **Settings > Character** matches the port your server is using
+1. **Ollama (macOS)** - Start it with `ollama serve` and pull a model (`ollama pull <model>`)
+2. **Ollama (Windows/Linux)** - Same, plus allow the app's origin: `setx OLLAMA_ORIGINS "http://tauri.localhost"` on Windows (then restart Ollama from the tray), or `OLLAMA_ORIGINS=http://tauri.localhost ollama serve` on Linux. Full steps: [Local LLM Setup](/docs/guides/local-llm-setup#allowing-utsuwa-to-reach-ollama)
+3. **LM Studio** - Load a model and click Start Server
+4. **Local TTS** - Start your TTS server (e.g. Kokoro-FastAPI on `http://localhost:8880`)
+5. **Base URL** - Confirm the port in **Settings > Character** matches the port your server is using
 
 ### No sound (desktop)
 
@@ -246,7 +247,7 @@ For local LLMs, the browser connects directly to your local server:
 1. **Ollama running** - Start it with `ollama serve`
 2. **LM Studio running** - Load a model and click Start Server
 3. **Correct base URL** - Use `http://localhost:11434` for Ollama or `http://localhost:1234/v1` for LM Studio
-4. **Hosted website CORS** - For Ollama on `https://www.utsuwa.ai`, start Ollama with `OLLAMA_ORIGINS=https://www.utsuwa.ai,https://utsuwa.ai ollama serve`. For Vercel previews, use the exact preview origin from the address bar, such as `OLLAMA_ORIGINS=https://your-preview.vercel.app ollama serve`. See Ollama's [additional web origins FAQ](https://docs.ollama.com/faq#how-can-i-allow-additional-web-origins-to-access-ollama).
+4. **Ollama origin (CORS)** - Ollama rejects origins it doesn't allow with a `403` on `/api/tags`. On the **hosted website** (the app runs at `app.utsuwa.ai`) allow that origin: `OLLAMA_ORIGINS=https://app.utsuwa.ai ollama serve` (for a Vercel preview use the exact origin from the address bar). On the **Windows or Linux desktop app** allow `OLLAMA_ORIGINS=http://tauri.localhost`; the macOS desktop app needs nothing. Full per-platform steps: [Local LLM Setup](/docs/guides/local-llm-setup#allowing-utsuwa-to-reach-ollama). Background: Ollama's [additional web origins FAQ](https://docs.ollama.com/faq#how-can-i-allow-additional-web-origins-to-access-ollama).
 5. **Installed model** - If you see `model not found`, run `ollama list`, pull or load a model, refresh the dropdown, and select an installed model
 
 ### "Page not found" after deployment

--- a/src/lib/components/onboarding/steps/ServicesStep.svelte
+++ b/src/lib/components/onboarding/steps/ServicesStep.svelte
@@ -10,6 +10,18 @@
 		debounce,
 		type ModelInfo
 	} from '$lib/services/providers/use-model-fetch';
+	import { DOCS_URL } from '$lib/config/site';
+	import { isTauri } from '$lib/services/platform';
+
+	const LOCAL_LLM_DOCS_URL = `${DOCS_URL}/guides/local-llm-setup#allowing-utsuwa-to-reach-ollama`;
+
+	// Always open the docs subdomain; on desktop route it to the system browser.
+	function openLocalLlmDocs(e: MouseEvent) {
+		if (isTauri()) {
+			e.preventDefault();
+			import('@tauri-apps/plugin-opener').then(({ openUrl }) => openUrl(LOCAL_LLM_DOCS_URL));
+		}
+	}
 
 	interface Props {
 		onNext: () => void;
@@ -316,6 +328,17 @@
 	}
 </script>
 
+{#snippet troubleHelp()}
+	<p class="provider-help">
+		Having trouble? Click <a
+			href={LOCAL_LLM_DOCS_URL}
+			target="_blank"
+			rel="noopener"
+			onclick={openLocalLlmDocs}>here</a
+		>
+	</p>
+{/snippet}
+
 <div class="ob-step services-step">
 	<div class="ob-head">
 		<h2 class="ob-title">Configure AI services</h2>
@@ -357,10 +380,13 @@
 		<!-- Base URL for local providers and custom OpenAI-compatible endpoints -->
 		{#if llmProvider?.isLocal || llmProvider?.custom}
 			{#if llmProvider.isLocal && llmFetchError}
-				<p class="provider-note error">
-					<Icon name="alert-circle" size={14} />
-					{llmFetchError}
-				</p>
+				<div class="provider-error">
+					<p class="provider-note error">
+						<Icon name="alert-circle" size={14} />
+						{llmFetchError}
+					</p>
+					{@render troubleHelp()}
+				</div>
 			{/if}
 			<input
 				type="text"
@@ -375,8 +401,11 @@
 			{#if llmProvider.isLocal}
 				<p class="provider-note">
 					<Icon name="check-circle" size={14} />
-					Local provider - no API key needed
+					Local provider, no API key needed
 				</p>
+				{#if !llmFetchError}
+					{@render troubleHelp()}
+				{/if}
 			{/if}
 		{/if}
 
@@ -737,8 +766,40 @@
 		color: var(--color-success);
 	}
 
+	.provider-note :global(svg) {
+		flex-shrink: 0;
+	}
+
 	.provider-note.error {
+		align-items: flex-start;
+		line-height: 1.45;
 		color: var(--color-error);
+	}
+
+	.provider-error {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.provider-error .provider-help {
+		margin: 0;
+	}
+
+	.provider-help {
+		margin: 0.375rem 0 0;
+		font-size: 0.75rem;
+		color: var(--text-tertiary);
+	}
+
+	.provider-help a {
+		color: var(--text-secondary);
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+
+	.provider-help a:hover {
+		color: var(--text-primary);
 	}
 
 	.skip-note {

--- a/src/lib/services/providers/local-endpoints.test.ts
+++ b/src/lib/services/providers/local-endpoints.test.ts
@@ -74,10 +74,6 @@ test('provides local provider troubleshooting hints', () => {
 		),
 		/OLLAMA_ORIGINS="https:\/\/utsuwa-git-fix-ollama-local-provider\.vercel\.app"/
 	);
-	assert.match(
-		getLocalProviderConnectionHint('ollama', 'http://localhost:11434'),
-		/docs\.ollama\.com\/faq#how-can-i-allow-additional-web-origins-to-access-ollama/
-	);
 	assert.match(getLocalProviderConnectionHint('lmstudio', 'http://localhost:1234/v1'), /Start Server/);
 });
 

--- a/src/lib/services/providers/local-endpoints.ts
+++ b/src/lib/services/providers/local-endpoints.ts
@@ -4,9 +4,6 @@ const LOCAL_LLM_PROVIDERS = new Set(['ollama', 'lmstudio']);
 const LOCAL_TTS_PROVIDERS = new Set(['local-tts']);
 const LOCAL_STT_PROVIDERS = new Set(['local-stt']);
 
-const OLLAMA_ORIGINS_DOC_URL =
-	'https://docs.ollama.com/faq#how-can-i-allow-additional-web-origins-to-access-ollama';
-
 function trimTrailingSlashes(url: string): string {
 	return url.replace(/\/+$/, '');
 }
@@ -117,14 +114,14 @@ export function getLocalProviderConnectionHint(
 
 	if (providerId === 'ollama') {
 		const originHint = siteOrigin
-			? ` For this site, restart Ollama with OLLAMA_ORIGINS="${siteOrigin}" ollama serve.`
-			: ` Set OLLAMA_ORIGINS to this site's origin before starting Ollama.`;
-		return `Could not reach Ollama at ${chatBaseUrl}. Make sure Ollama is running with "ollama serve", the model is pulled with "ollama pull <model>", and browser users allow this site's origin with OLLAMA_ORIGINS.${originHint} More help: ${OLLAMA_ORIGINS_DOC_URL}`;
+			? ` and allow this origin: OLLAMA_ORIGINS="${siteOrigin}" ollama serve`
+			: ` and allow this site's origin via OLLAMA_ORIGINS`;
+		return `Could not reach Ollama at ${chatBaseUrl}. Make sure it's running with "ollama serve"${originHint}.`;
 	}
 
 	if (providerId === 'lmstudio') {
-		return `Could not reach LM Studio at ${chatBaseUrl}. Open LM Studio, go to the Developer or Server tab, load a model, and click Start Server.`;
+		return `Could not reach LM Studio at ${chatBaseUrl}. Open it, load a model, and click Start Server.`;
 	}
 
-	return `Could not reach local provider at ${chatBaseUrl}. Make sure the local server is running and reachable from this device.`;
+	return `Could not reach the local provider at ${chatBaseUrl}. Make sure the server is running and reachable from this device.`;
 }

--- a/src/routes/app/settings/persona/AiServicesSection.svelte
+++ b/src/routes/app/settings/persona/AiServicesSection.svelte
@@ -3,14 +3,37 @@
 	import { settingsStore } from '$lib/stores/settings.svelte';
 	import { getLLMProvider, getTTSProvider } from '$lib/services/providers/registry';
 	import { Icon, ProviderDropdown, ModelDropdown, ContextSizeSlider } from '$lib/components/ui';
+	import { DOCS_URL } from '$lib/config/site';
+	import { isTauri } from '$lib/services/platform';
 	import type { PersonaPageState } from './persona-page.svelte';
 
 	let { page }: { page: PersonaPageState } = $props();
+
+	const LOCAL_LLM_DOCS_URL = `${DOCS_URL}/guides/local-llm-setup#allowing-utsuwa-to-reach-ollama`;
+
+	// Always open the docs subdomain; on desktop route it to the system browser.
+	function openLocalLlmDocs(e: MouseEvent) {
+		if (isTauri()) {
+			e.preventDefault();
+			import('@tauri-apps/plugin-opener').then(({ openUrl }) => openUrl(LOCAL_LLM_DOCS_URL));
+		}
+	}
 
 	function handleContextSizeChange(value: number | undefined) {
 		page.handleLLMNumberSetting('contextSize', value);
 	}
 </script>
+
+{#snippet troubleHelp()}
+	<p class="provider-help">
+		Having trouble? Click <a
+			href={LOCAL_LLM_DOCS_URL}
+			target="_blank"
+			rel="noopener"
+			onclick={openLocalLlmDocs}>here</a
+		>
+	</p>
+{/snippet}
 
 <!-- AI Services (collapsible) -->
 <div class="services-section">
@@ -62,10 +85,13 @@
 						<!-- Base URL for local providers and custom OpenAI-compatible endpoints -->
 						{#if provider?.isLocal || provider?.custom}
 							{#if page.llmFetchError}
-								<p class="provider-note error">
-									<Icon name="alert-circle" size={14} />
-									{page.llmFetchError}
-								</p>
+								<div class="provider-error">
+									<p class="provider-note error">
+										<Icon name="alert-circle" size={14} />
+										{page.llmFetchError}
+									</p>
+									{@render troubleHelp()}
+								</div>
 							{/if}
 							<div class="api-key-row">
 								<input
@@ -79,6 +105,9 @@
 									onblur={provider.custom ? undefined : page.fetchLLMModels}
 								/>
 							</div>
+							{#if provider?.isLocal && !page.llmFetchError}
+								{@render troubleHelp()}
+							{/if}
 						{/if}
 
 						<!-- Model: manual entry for custom endpoints, discovered dropdown otherwise -->
@@ -531,8 +560,40 @@
 		color: var(--text-tertiary);
 	}
 
+	.provider-note :global(svg) {
+		flex-shrink: 0;
+	}
+
 	.provider-note.error {
+		align-items: flex-start;
+		line-height: 1.45;
 		color: var(--color-error);
+	}
+
+	.provider-error {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.provider-error .provider-help {
+		margin: 0;
+	}
+
+	.provider-help {
+		margin: 0.375rem 0 0;
+		font-size: 0.75rem;
+		color: var(--text-tertiary);
+	}
+
+	.provider-help a {
+		color: var(--text-secondary);
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+
+	.provider-help a:hover {
+		color: var(--text-primary);
 	}
 
 	.api-key-input {


### PR DESCRIPTION
## Problem

Local Ollama works in the desktop app on macOS but fails on Windows and Linux. The Tauri webview reports a different origin per OS: `tauri://localhost` on macOS (which Ollama allows by default via `tauri://*`) but `http://tauri.localhost` on Windows and Linux (which Ollama does not allow), so Ollama rejects those with a `403` on `/api/tags`. The docs made this worse by stating the desktop app needs no `OLLAMA_ORIGINS` setup, which is only true on macOS.

A separate, environment-dependent issue: on some Windows setups `localhost` resolves to IPv6 `::1` while Ollama listens on IPv4 `127.0.0.1`, so the connection never lands until the base URL is pinned to `127.0.0.1`.

## Changes

Docs:
- `local-llm-setup.md`: new per-platform "Allowing Utsuwa to reach Ollama" section (macOS: nothing; Windows: `setx OLLAMA_ORIGINS "http://tauri.localhost"` + tray restart; Linux: env/systemd), corrected the wrong "not needed on desktop" line, added a "try 127.0.0.1" troubleshooting note.
- `troubleshooting.md`: fixed the two desktop sections that claimed no origin setup is ever needed.
- Hosted-app origins now point at `app.utsuwa.ai` (the real app subdomain) instead of `www.utsuwa.ai`.
- `local-tts-setup.md` / `local-stt-setup.md`: kept the accurate "default servers just work on desktop" message, added the correct desktop origin values for the hardened-server case.

App:
- Trimmed the local-provider connection error to two sentences while keeping the actionable `ollama serve` + `OLLAMA_ORIGINS="<origin>"` command.
- Added a "Having trouble? Click here" docs link grouped directly with the error (and shown under the local-provider note when there is no error) in both onboarding (`ServicesStep.svelte`) and settings (`AiServicesSection.svelte`). It targets `docs.utsuwa.ai/guides/local-llm-setup#allowing-utsuwa-to-reach-ollama` and, on desktop, opens in the system browser via the same `openUrl` pattern used by the info modal.
- Fixed the note layout (top-aligned icon, full-width wrap) so it no longer splits awkwardly.

## Verification

- `pnpm check`: 0 errors, 0 warnings.
- `pnpm test`: 241 pass (updated the connection-hint test to match the concise copy; the `ollama serve` and `OLLAMA_ORIGINS="..."` assertions still hold).
- Live e2e on a dev build: drove onboarding and settings with Ollama selected. Confirmed the concise error renders with the icon top-aligned, the "Having trouble? Click here" link sits directly under it with "here" underlined, and the link resolves to `/docs/guides/local-llm-setup` (which loads and has the `#allowing-utsuwa-to-reach-ollama` anchor). Verified the rendered docs contain the new origin section, the 127.0.0.1 note, and the `app.utsuwa.ai` values.