### PR TITLE
fix: reminder system-event wiring, interaction counting, and session rotation

### DIFF
--- a/src/lib/engine/memory.ts
+++ b/src/lib/engine/memory.ts
@@ -104,14 +104,6 @@ export async function hydrateWorkingMemory(): Promise<void> {
 	workingMemory.turns = recentTurns;
 	workingMemory.messageCount = recentTurns.length;
 
-	// Restore the current session from the most recent turn so reminders and
-	// other session-scoped state survive a browser restart.
-	const latestTurn = recentTurns[recentTurns.length - 1];
-	if (latestTurn?.sessionId !== undefined) {
-		workingMemory.currentSessionId = latestTurn.sessionId;
-		workingMemory.sessionStartedAt = latestTurn.createdAt;
-	}
-
 	// Backfill summaries for past sessions that ended without one, so the
 	// "last time you talked" prompt context actually has something to read.
 	await finalizeStaleSessions();

--- a/src/lib/services/chat/companion-chat.ts
+++ b/src/lib/services/chat/companion-chat.ts
@@ -19,7 +19,7 @@ import { buildSystemPrompt, truncateChatHistory, type PromptContext } from '$lib
 import { keepImage, type PreparedImage } from '$lib/services/storage/keepsakes';
 import { extractReminderTags, tryExtractReminderFromUserMessage } from '$lib/utils/reminders';
 import { reminderStore } from '$lib/stores/reminders.svelte';
-import { getWorkingMemory } from '$lib/engine/memory';
+import { getWorkingMemory, ensureSession } from '$lib/engine/memory';
 import { toOpenAIContent, type ContentPart } from '$lib/services/chat/content';
 import { isTauri } from '$lib/services/platform';
 import type { LLMProvider, TTSProvider } from '$lib/types';
@@ -283,7 +283,9 @@ export async function sendCompanionMessage(
 		if (directReminder) {
 			const { reminders: llmReminders } = extractReminderTags(fullContent);
 			if (llmReminders.length === 0) {
-				const sessionId = getWorkingMemory().currentSessionId;
+				// ensureSession creates a session on demand, so a reminder phrased right
+				// after a reload still gets scheduled without resuming stale sessions.
+				const sessionId = await ensureSession();
 				if (sessionId) {
 					try {
 						await reminderStore.addReminder(

--- a/src/lib/services/chat/companion-turn.ts
+++ b/src/lib/services/chat/companion-turn.ts
@@ -123,7 +123,7 @@ export async function processCompanionTurn(input: CompanionTurnInput): Promise<C
 		: mergeUpdates(baselineUpdates || {}, validatedLLMUpdates || {}, {
 				trustLLMDeltas: userAnalysis?.nonLatinDominant ?? false
 			});
-	characterStore.applyUpdates(finalUpdates);
+	characterStore.applyUpdates(finalUpdates, { countInteraction: !systemEvent });
 
 	// Save the model's memory observation
 	if (finalUpdates.newMemory) {

--- a/src/lib/services/chat/reminder-chat.ts
+++ b/src/lib/services/chat/reminder-chat.ts
@@ -1,7 +1,24 @@
 import { chatStore } from '$lib/stores/chat.svelte';
 import type { SendCompanionMessageOptions } from './companion-chat';
+import type { Reminder } from '$lib/types/memory';
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Build the fired-reminder handler shared by the main app and the overlay.
+ * Both surfaces must deliver the trigger through sendReminderMessage with the
+ * systemEvent option intact; wiring this in one place keeps the two pages from
+ * drifting (the main app previously dropped the options argument, which sent
+ * fired reminders through the normal user path).
+ */
+export function createReminderFiredHandler(
+	sendFn: (content: string, options: SendCompanionMessageOptions) => void
+): (reminder: Reminder) => void {
+	return (reminder) => {
+		const msg = `⏰ REMINDER TRIGGERED: "${reminder.content}" — This is your reminder. React to it NOW by performing the described action or saying something enthusiastic and fitting.`;
+		sendReminderMessage(sendFn, msg);
+	};
+}
 
 /**
  * Send a fired reminder through the chat pipeline as a system event. If the LLM

--- a/src/lib/stores/character.svelte.ts
+++ b/src/lib/stores/character.svelte.ts
@@ -175,8 +175,12 @@ function createCharacterStore() {
 		save();
 	}
 
-	// Apply state updates
-	function applyUpdates(updates: StateUpdates): void {
+	// Apply state updates. countInteraction is false for system events (e.g.
+	// fired reminders): the model's own mood/stat deltas still apply, but the
+	// turn must not count as the user interacting (totalInteractions gates stage
+	// transitions and events; lastInteraction drives decay timing).
+	function applyUpdates(updates: StateUpdates, options: { countInteraction?: boolean } = {}): void {
+		const { countInteraction = true } = options;
 		const newState = { ...state };
 		const isCompanionMode = state.appMode === 'companion';
 
@@ -225,9 +229,12 @@ function createCharacterStore() {
 			}
 		}
 
-		// Update timestamp and interaction count
-		newState.lastInteraction = new Date();
-		newState.totalInteractions++;
+		// Update timestamp and interaction count. System events keep both frozen
+		// so machine-generated turns can't advance progression or reset decay.
+		if (countInteraction) {
+			newState.lastInteraction = new Date();
+			newState.totalInteractions++;
+		}
 		newState.updatedAt = new Date();
 
 		// Update state with reactive assignment

--- a/src/lib/stores/reminders.svelte.ts
+++ b/src/lib/stores/reminders.svelte.ts
@@ -243,17 +243,6 @@ export function removeReminderFiredListener(callback: (reminder: Reminder) => vo
 	onReminderFiredCallbacks.delete(callback);
 }
 
-/**
- * @deprecated Use addReminderFiredListener instead. This setter replaces any
- * previously registered callback and is kept only for quick backward compatibility.
- */
-export function setOnReminderFired(callback: ((reminder: Reminder) => void) | null) {
-	onReminderFiredCallbacks.clear();
-	if (callback) {
-		onReminderFiredCallbacks.add(callback);
-	}
-}
-
 export const reminderStore = {
 	get upcoming() {
 		return upcoming;
@@ -267,6 +256,5 @@ export const reminderStore = {
 	deleteReminder,
 	dismissRecentFired,
 	addReminderFiredListener,
-	removeReminderFiredListener,
-	setOnReminderFired
+	removeReminderFiredListener
 };

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -20,7 +20,7 @@
 	import { canShowImages } from '$lib/services/providers/vision';
 	import { onDestroy } from 'svelte';
 	import { sendCompanionMessage, type SendCompanionMessageOptions } from '$lib/services/chat/companion-chat';
-	import { sendReminderMessage } from '$lib/services/chat/reminder-chat';
+	import { createReminderFiredHandler } from '$lib/services/chat/reminder-chat';
 	import { reminderStore } from '$lib/stores/reminders.svelte';
 	import { type PreparedImage } from '$lib/services/storage/keepsakes';
 	import { isTauri } from '$lib/services/platform';
@@ -128,10 +128,9 @@
 	// through the companion pipeline. This lets the LLM decide the action
 	// (speech, web search, etc.) instead of showing a passive toast.
 	$effect(() => {
-		const unsubscribeReminder = reminderStore.addReminderFiredListener((reminder) => {
-			const msg = `⏰ REMINDER TRIGGERED: "${reminder.content}" — This is your reminder. React to it NOW by performing the described action or saying something enthusiastic and fitting.`;
-			sendReminderMessage((content) => handleSend(content), msg);
-		});
+		const unsubscribeReminder = reminderStore.addReminderFiredListener(
+			createReminderFiredHandler((content, options) => handleSend(content, [], options))
+		);
 		reminderStore.startPolling();
 		return () => {
 			reminderStore.stopPolling();

--- a/src/routes/overlay/+page.svelte
+++ b/src/routes/overlay/+page.svelte
@@ -22,7 +22,7 @@
 	import { overlayStore } from '$lib/stores/overlay.svelte';
 	import { isTauri, startDragging } from '$lib/services/platform';
 	import { sendCompanionMessage, type SendCompanionMessageOptions } from '$lib/services/chat/companion-chat';
-	import { sendReminderMessage } from '$lib/services/chat/reminder-chat';
+	import { createReminderFiredHandler } from '$lib/services/chat/reminder-chat';
 	import { type PreparedImage } from '$lib/services/storage/keepsakes';
 	import { eventsApi } from '$lib/engine/events';
 	import { completionMarkers } from '$lib/engine/event-completion';
@@ -175,10 +175,9 @@
 	// main app window is hidden. Fired reminders are sent back through the LLM
 	// so the companion can react (speech, search, etc.).
 	$effect(() => {
-		const unsubscribeReminder = reminderStore.addReminderFiredListener((reminder) => {
-			const msg = `⏰ REMINDER TRIGGERED: "${reminder.content}" — This is your reminder. React to it NOW by performing the described action or saying something enthusiastic and fitting.`;
-			sendReminderMessage((content, options) => handleReminderSend(content, options), msg);
-		});
+		const unsubscribeReminder = reminderStore.addReminderFiredListener(
+			createReminderFiredHandler(handleReminderSend)
+		);
 		reminderStore.startPolling();
 		return () => {
 			reminderStore.stopPolling();


### PR DESCRIPTION
Follow-ups to #112, as promised in the review there. Three defects found while tracing and live-testing the merged feature:

## Fixes

1. **Main app dropped the systemEvent flag.** `app/+page.svelte` wired the fired-reminder callback as `(content) => handleSend(content)`, discarding the `{ systemEvent: true }` options argument that `sendReminderMessage` passes; the overlay forwarded it correctly. On the primary surface a fired reminder therefore ran the normal user path: fake user bubble, streak bump, baseline sentiment, fact extraction. Both pages now share `createReminderFiredHandler` in `reminder-chat.ts` so the wiring cannot drift again.

2. **applyUpdates counted system events as interactions.** Even on the systemEvent path, `characterStore.applyUpdates` unconditionally bumped `totalInteractions` and refreshed `lastInteraction`. `totalInteractions` gates stage transitions and events; `lastInteraction` drives decay timing, so every fired reminder advanced progression and reset "time since you talked". `applyUpdates` now takes `countInteraction` (false for system events); the model's own mood and stat deltas still apply.

3. **Session rotation was frozen.** `hydrateWorkingMemory` resumed the latest session unconditionally on every load, so `ensureSession` never created a new session again: the eternal session was never summarized and the "last time you talked" context froze for every user. Reverted; the direct-reminder fallback in `companion-chat.ts` now calls `ensureSession()` on demand instead of reading a restored id.

Also removed the deprecated `setOnReminderFired` (cleared all listeners, zero users).

## Verification

- `pnpm check` 0 errors / 0 warnings; `pnpm test` 263/263.
- Live e2e on a clean profile, full matrix, on both Ollama gemma3:4b and OpenAI GPT-4o Mini:
  - **Live fire:** reaction reply lands, no user bubble, no user turn, `totalInteractions` / `lastInteraction` / streak / facts all frozen.
  - **Idle fire** (reminder firing with no user activity): same invariants hold.
  - **Missed timer:** scheduled a 1-minute reminder, left the app past trigger + grace, reopened; the startup check claimed it (`executed=1`) and the companion reacted in character, stats untouched.
  - **Session rotation:** reload then message created a new session row ("last time you talked" unfreezes).
  - **Control:** a plain chat turn still counts exactly one interaction.