### PR TITLE
feat: spring-bone physics intensity setting with frame-delta clamp

### DIFF
--- a/src/lib/components/ui/CameraSettingsPanel.svelte
+++ b/src/lib/components/ui/CameraSettingsPanel.svelte
@@ -6,6 +6,11 @@
 		CAMERA_LIMITS,
 		type CameraProfile
 	} from '$lib/stores/display.svelte';
+	import {
+		PHYSICS_INTENSITY_MIN,
+		PHYSICS_INTENSITY_MAX,
+		PHYSICS_INTENSITY_DEFAULT
+	} from '$lib/engine/spring-physics';
 
 	interface Props {
 		onclose: () => void;
@@ -78,6 +83,33 @@
 	<button class="reset-btn" onclick={() => displayStore.resetCamera(profile)} disabled={isDefault}>
 		Reset camera
 	</button>
+
+	<div class="section-divider">
+		<span class="section-label">Physics</span>
+	</div>
+
+	<label class="control">
+		<span class="control-label">
+			Movement intensity
+			<span class="control-value">
+				{displayStore.physicsIntensity === PHYSICS_INTENSITY_DEFAULT
+					? 'Default'
+					: `${displayStore.physicsIntensity.toFixed(2)}x`}
+			</span>
+		</span>
+		<input
+			type="range"
+			min={PHYSICS_INTENSITY_MIN}
+			max={PHYSICS_INTENSITY_MAX}
+			step="0.05"
+			value={displayStore.physicsIntensity}
+			oninput={(e) => displayStore.setPhysicsIntensity(parseFloat(e.currentTarget.value))}
+		/>
+		<span class="range-ends" aria-hidden="true">
+			<span>Subtle</span>
+			<span>Lively</span>
+		</span>
+	</label>
 </div>
 
 <style>
@@ -212,5 +244,34 @@
 	.reset-btn:disabled {
 		opacity: 0.45;
 		cursor: default;
+	}
+
+	.section-divider {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-top: 0.125rem;
+	}
+
+	.section-divider::after {
+		content: '';
+		flex: 1;
+		height: 1px;
+		background: var(--border-subtle);
+	}
+
+	.section-label {
+		font-size: 0.6875rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--text-tertiary);
+	}
+
+	.range-ends {
+		display: flex;
+		justify-content: space-between;
+		font-size: 0.6875rem;
+		color: var(--text-tertiary);
 	}
 </style>

--- a/src/lib/components/vrm/VrmModel.svelte
+++ b/src/lib/components/vrm/VrmModel.svelte
@@ -5,6 +5,12 @@
 	import { VRMAnimationLoaderPlugin, createVRMAnimationClip } from '@pixiv/three-vrm-animation';
 	import { vrmStore } from '$lib/stores/vrm.svelte';
 	import { ttsStore } from '$lib/stores/tts.svelte';
+	import { displayStore } from '$lib/stores/display.svelte';
+	import {
+		computeSpringJointParams,
+		clampFrameDelta,
+		type SpringJointParams
+	} from '$lib/engine/spring-physics';
 	import { lipSyncAnalyzer } from '$lib/services/lipsync/analyzer';
 	import { untrack } from 'svelte';
 	import * as THREE from 'three';
@@ -52,6 +58,44 @@
 	let { url }: Props = $props();
 	let vrm = $state<VRM | null>(null);
 	let group = $state<THREE.Group | null>(null);
+
+	// === Spring-bone physics ===
+	// Authored per-joint values captured at load. The intensity setting always
+	// multiplies these bases (never the current values), so re-applying is
+	// idempotent and a model switch starts clean from its own rig tuning.
+	let springBase: Array<{
+		settings: { stiffness: number; gravityPower: number; dragForce: number };
+		base: SpringJointParams;
+	}> = [];
+
+	function snapshotSpringBase(target: VRM) {
+		springBase = [];
+		const joints = target.springBoneManager?.joints;
+		if (!joints) return;
+		for (const joint of joints) {
+			springBase.push({
+				settings: joint.settings,
+				base: {
+					stiffness: joint.settings.stiffness,
+					gravityPower: joint.settings.gravityPower,
+					dragForce: joint.settings.dragForce
+				}
+			});
+		}
+	}
+
+	// Applied live so slider tuning is immediate; re-runs on model switch since
+	// the load path re-assigns `vrm` after rebuilding the snapshot.
+	$effect(() => {
+		const intensity = displayStore.physicsIntensity;
+		if (!vrm) return;
+		for (const { settings, base } of springBase) {
+			const next = computeSpringJointParams(base, intensity);
+			settings.stiffness = next.stiffness;
+			settings.gravityPower = next.gravityPower;
+			settings.dragForce = next.dragForce;
+		}
+	});
 
 	// === Animation State ===
 	let mixer = $state<THREE.AnimationMixer | null>(null);
@@ -507,6 +551,10 @@
 				// Set a natural idle pose (arms down instead of T-pose)
 				setIdlePose(loadedVrm);
 
+				// Capture this rig's authored spring values before `vrm` flips the
+				// physics-intensity effect, so it applies over fresh bases.
+				snapshotSpringBase(loadedVrm);
+
 				vrm = loadedVrm;
 				group = loadedVrm.scene;
 				const newMixer = new THREE.AnimationMixer(loadedVrm.scene);
@@ -605,6 +653,7 @@
 				vrmStore.setVrm(null);
 				vrm = null;
 				group = null;
+				springBase = [];
 			}
 		};
 	});
@@ -621,8 +670,9 @@
 		// Update animation mixer
 		mixer?.update(delta);
 
-		// Update VRM core
-		vrm.update(delta);
+		// Update VRM core. The delta is clamped because a huge frame gap (tab
+		// refocus, window drag) otherwise launches the spring bones violently.
+		vrm.update(clampFrameDelta(delta));
 
 		// Track head position for 3D speech bubble
 		const headBone = vrm.humanoid.getNormalizedBoneNode('head');

--- a/src/lib/engine/spring-physics.test.ts
+++ b/src/lib/engine/spring-physics.test.ts
@@ -1,0 +1,86 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	computeSpringJointParams,
+	clampFrameDelta,
+	clampPhysicsIntensity,
+	PHYSICS_INTENSITY_DEFAULT,
+	PHYSICS_INTENSITY_MIN,
+	PHYSICS_INTENSITY_MAX
+} from './spring-physics.ts';
+
+const base = { stiffness: 1.2, gravityPower: 0.1, dragForce: 0.4 };
+
+test('intensity 1 returns the authored values unchanged', () => {
+	const out = computeSpringJointParams(base, 1);
+	assert.deepEqual(out, base);
+});
+
+test('higher intensity softens springs, raises gravity, lowers drag', () => {
+	const out = computeSpringJointParams(base, 1.6);
+	assert.ok(out.stiffness < base.stiffness);
+	assert.ok(out.gravityPower > base.gravityPower);
+	assert.ok(out.dragForce < base.dragForce);
+});
+
+test('lower intensity stiffens springs, lowers gravity, raises drag', () => {
+	const out = computeSpringJointParams(base, 0.5);
+	assert.ok(out.stiffness > base.stiffness);
+	assert.ok(out.gravityPower < base.gravityPower);
+	assert.ok(out.dragForce > base.dragForce);
+});
+
+test('multiplies authored values rather than overwriting with absolutes', () => {
+	const stiffRig = { stiffness: 4, gravityPower: 0.5, dragForce: 0.9 };
+	const softRig = { stiffness: 0.3, gravityPower: 0.02, dragForce: 0.2 };
+	const stiffOut = computeSpringJointParams(stiffRig, 1.4);
+	const softOut = computeSpringJointParams(softRig, 1.4);
+	// The same intensity preserves each rig's relative tuning
+	assert.ok(stiffOut.stiffness > softOut.stiffness);
+	assert.ok(stiffOut.gravityPower > softOut.gravityPower);
+	assert.equal(stiffOut.stiffness, stiffRig.stiffness / 1.4);
+	assert.equal(softOut.gravityPower, softRig.gravityPower * 1.4);
+});
+
+test('drag stays inside its stable range', () => {
+	// 0.9 / 0.5 would be 1.8: must clamp to 1
+	const high = computeSpringJointParams({ ...base, dragForce: 0.9 }, 0.5);
+	assert.equal(high.dragForce, 1);
+	// 0.05 floor guards against zero-drag oscillation
+	const low = computeSpringJointParams({ ...base, dragForce: 0.02 }, 1.6);
+	assert.ok(low.dragForce >= 0.05);
+});
+
+test('degenerate authored values never produce NaN or negatives', () => {
+	const zero = computeSpringJointParams({ stiffness: 0, gravityPower: 0, dragForce: 0 }, 1.6);
+	assert.ok(Number.isFinite(zero.stiffness) && zero.stiffness >= 0);
+	assert.ok(Number.isFinite(zero.gravityPower) && zero.gravityPower >= 0);
+	assert.ok(Number.isFinite(zero.dragForce) && zero.dragForce >= 0.05);
+});
+
+test('does not mutate the authored base', () => {
+	const authored = { stiffness: 1, gravityPower: 0.2, dragForce: 0.5 };
+	const copy = { ...authored };
+	computeSpringJointParams(authored, 1.5);
+	assert.deepEqual(authored, copy);
+});
+
+test('intensity is clamped to the supported range', () => {
+	assert.equal(clampPhysicsIntensity(0.1), PHYSICS_INTENSITY_MIN);
+	assert.equal(clampPhysicsIntensity(5), PHYSICS_INTENSITY_MAX);
+	assert.equal(clampPhysicsIntensity(NaN), PHYSICS_INTENSITY_DEFAULT);
+	const out = computeSpringJointParams(base, 99);
+	assert.equal(out.gravityPower, base.gravityPower * PHYSICS_INTENSITY_MAX);
+});
+
+test('clampFrameDelta passes normal frames and clamps stalls', () => {
+	assert.equal(clampFrameDelta(1 / 60), 1 / 60);
+	assert.equal(clampFrameDelta(0.5), 1 / 30);
+	assert.equal(clampFrameDelta(5), 1 / 30);
+});
+
+test('clampFrameDelta guards degenerate deltas', () => {
+	assert.equal(clampFrameDelta(-1), 0);
+	assert.equal(clampFrameDelta(NaN), 0);
+	assert.equal(clampFrameDelta(Infinity), 1 / 30);
+});

--- a/src/lib/engine/spring-physics.ts
+++ b/src/lib/engine/spring-physics.ts
@@ -1,0 +1,50 @@
+// Spring-bone physics intensity mapping. Every VRM rig ships its own authored
+// stiffness/gravity/drag per joint, so the intensity setting multiplies those
+// base values rather than overwriting them with absolutes, and everything is
+// clamped to ranges that stay numerically stable at both slider extremes.
+
+export interface SpringJointParams {
+	stiffness: number;
+	gravityPower: number;
+	dragForce: number;
+}
+
+export const PHYSICS_INTENSITY_MIN = 0.5;
+export const PHYSICS_INTENSITY_MAX = 1.6;
+export const PHYSICS_INTENSITY_DEFAULT = 1.0;
+
+// Softer springs move more, so stiffness divides by intensity while gravity
+// multiplies. Drag divides too (less damping = livelier), with a hard floor:
+// zero drag lets a joint oscillate forever.
+const DRAG_MIN = 0.05;
+const DRAG_MAX = 1;
+const GRAVITY_MAX = 10;
+
+// Frames after a tab refocus or window drag can arrive with a huge delta,
+// which launches spring bones violently. Clamping to a 30 fps step keeps the
+// worst frame a physics solver ever sees boring.
+export const FRAME_DELTA_MAX = 1 / 30;
+
+const clamp = (v: number, min: number, max: number) => Math.max(min, Math.min(max, v));
+
+export function clampPhysicsIntensity(intensity: number): number {
+	if (!Number.isFinite(intensity)) return PHYSICS_INTENSITY_DEFAULT;
+	return clamp(intensity, PHYSICS_INTENSITY_MIN, PHYSICS_INTENSITY_MAX);
+}
+
+export function computeSpringJointParams(
+	base: SpringJointParams,
+	intensity: number
+): SpringJointParams {
+	const i = clampPhysicsIntensity(intensity);
+	return {
+		stiffness: Math.max(0, base.stiffness / i),
+		gravityPower: clamp(base.gravityPower * i, 0, GRAVITY_MAX),
+		dragForce: clamp(base.dragForce / i, DRAG_MIN, DRAG_MAX)
+	};
+}
+
+export function clampFrameDelta(delta: number, max: number = FRAME_DELTA_MAX): number {
+	if (Number.isNaN(delta) || delta < 0) return 0;
+	return Math.min(delta, max);
+}

--- a/src/lib/stores/display.svelte.ts
+++ b/src/lib/stores/display.svelte.ts
@@ -1,4 +1,8 @@
 import { browser } from '$app/environment';
+import {
+	clampPhysicsIntensity,
+	PHYSICS_INTENSITY_DEFAULT
+} from '$lib/engine/spring-physics';
 
 const STORAGE_KEY = 'utsuwa-display';
 
@@ -40,6 +44,8 @@ function createDisplayStore() {
 	// so each keeps its own camera profile
 	let camera = $state<CameraSettings>({ ...CAMERA_DEFAULTS });
 	let overlayCamera = $state<CameraSettings>({ ...CAMERA_DEFAULTS });
+	// One physics intensity for both surfaces: it's a model-feel setting, not framing
+	let physicsIntensity = $state(PHYSICS_INTENSITY_DEFAULT);
 
 	if (browser) {
 		const saved = localStorage.getItem(STORAGE_KEY);
@@ -54,6 +60,9 @@ function createDisplayStore() {
 				else if (typeof parsed.cameraDistance === 'number') {
 					camera = sanitize({ zoom: 2.0 / parsed.cameraDistance });
 				}
+				if (typeof parsed.physicsIntensity === 'number') {
+					physicsIntensity = clampPhysicsIntensity(parsed.physicsIntensity);
+				}
 			} catch (e) {
 				console.error('Failed to load display settings:', e);
 			}
@@ -66,7 +75,8 @@ function createDisplayStore() {
 				STORAGE_KEY,
 				JSON.stringify({
 					camera: $state.snapshot(camera),
-					overlayCamera: $state.snapshot(overlayCamera)
+					overlayCamera: $state.snapshot(overlayCamera),
+					physicsIntensity
 				})
 			);
 		}
@@ -92,6 +102,11 @@ function createDisplayStore() {
 		save();
 	}
 
+	function setPhysicsIntensity(value: number) {
+		physicsIntensity = clampPhysicsIntensity(value);
+		save();
+	}
+
 	return {
 		get camera() {
 			return camera;
@@ -99,8 +114,12 @@ function createDisplayStore() {
 		get overlayCamera() {
 			return overlayCamera;
 		},
+		get physicsIntensity() {
+			return physicsIntensity;
+		},
 		setCamera,
-		resetCamera
+		resetCamera,
+		setPhysicsIntensity
 	};
 }
 


### PR DESCRIPTION
Phase B of the photo mode + physics plan: the physics slider and the delta-clamp fix, small and self-contained ahead of the photo mode PRs.

## What

- **Movement intensity slider** in the Controls panel (Camera popover), new Physics section: 0.5x (Subtle) to 1.6x (Lively), default 1.0. Applied live while dragging; persists in `utsuwa-display`.
- **Multiplies authored rig values, never overwrites.** Each joint's authored stiffness / gravityPower / dragForce is snapshotted at model load; the setting maps over those bases (`stiffness / i`, `gravity * i`, `drag / i`) with clamps (drag floored at 0.05 so nothing oscillates forever). Model switch rebuilds the snapshot from the new rig and re-applies the current setting, so every model keeps its own tuning.
- **Frame-delta clamp**: `vrm.update()` now receives `min(delta, 1/30)`, fixing the spring-bone explosion after tab refocus or window drags deliver a giant delta.

## Where

- `src/lib/engine/spring-physics.ts` + tests: pure mapping and clamp logic (TDD, 10 cases: identity at 1.0, per-parameter direction, multiplier-not-absolute across two rigs, clamp ranges, degenerate zero inputs, non-mutation, delta guards).
- `src/lib/stores/display.svelte.ts`: persisted `physicsIntensity` alongside the camera profiles.
- `src/lib/components/vrm/VrmModel.svelte`: base snapshot at load, live-apply effect, delta clamp.
- `src/lib/components/ui/CameraSettingsPanel.svelte`: the slider UI (available on both the main app and desktop overlay, which share this panel).

## Verification

- `pnpm check` 0 errors / 0 warnings; `pnpm test` 273/273 (10 new).
- Live e2e on the dev build: slider renders in the panel with Subtle/Lively endpoints and a Default label at 1.0; setting to 1.6 persists across reload and applies at boot; full page loads and a model switch (Tsuki to Momo) at max intensity produce zero console errors and normal animation.
- The one thing not judged here is feel: how much livelier 1.6 reads is a taste call, and the mapping constants are all in one file if the endpoints want tuning.