### PR TITLE
feat: photo mode skeleton with poses, free camera, and dock

### DIFF
--- a/src/lib/components/photomode/PhotoModeDock.svelte
+++ b/src/lib/components/photomode/PhotoModeDock.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+	import { Icon } from '$lib/components/ui';
+	import { photomodeStore } from '$lib/stores/photomode.svelte';
+	import { displayStore, CAMERA_LIMITS } from '$lib/stores/display.svelte';
+	import { loadPoseManifest, type PoseEntry } from '$lib/services/poses';
+
+	let poses = $state<PoseEntry[]>([]);
+
+	$effect(() => {
+		let cancelled = false;
+		loadPoseManifest().then((entries) => {
+			if (!cancelled) poses = entries;
+		});
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') photomodeStore.exit();
+	}
+
+	function resetFraming() {
+		displayStore.resetCamera();
+		photomodeStore.requestReframe();
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<div class="photo-dock" role="toolbar" aria-label="Photo mode">
+	<div class="dock-header">
+		<span class="dock-title">Photo Mode</span>
+		<button class="dock-close" onclick={() => photomodeStore.exit()} aria-label="Exit photo mode">
+			<Icon name="x" size={16} />
+		</button>
+	</div>
+
+	<div class="dock-row">
+		<span class="row-label">Pose</span>
+		<div class="pose-carousel">
+			<button
+				class="pose-chip"
+				class:selected={photomodeStore.selectedPoseId === null}
+				onclick={() => photomodeStore.setPose(null)}
+			>
+				Natural
+			</button>
+			{#each poses as pose (pose.id)}
+				<button
+					class="pose-chip"
+					class:selected={photomodeStore.selectedPoseId === pose.id}
+					onclick={() => photomodeStore.setPose(pose.id)}
+				>
+					{pose.name}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	<div class="dock-row">
+		<span class="row-label">
+			Lens
+			<span class="row-value">{displayStore.camera.fov.toFixed(0)} deg</span>
+		</span>
+		<input
+			type="range"
+			min={CAMERA_LIMITS.fov.min}
+			max={CAMERA_LIMITS.fov.max}
+			step="1"
+			value={displayStore.camera.fov}
+			oninput={(e) => displayStore.setCamera({ fov: parseFloat(e.currentTarget.value) })}
+			aria-label="Field of view"
+		/>
+	</div>
+
+	<div class="dock-actions">
+		<button class="dock-btn" onclick={resetFraming}>Reset framing</button>
+	</div>
+</div>
+
+<style>
+	.photo-dock {
+		position: fixed;
+		bottom: 1rem;
+		left: 50%;
+		transform: translateX(-50%);
+		z-index: 45;
+		width: min(560px, calc(100vw - 2rem));
+		padding: 0.875rem 1rem;
+		background: color-mix(in srgb, var(--bg-primary), transparent 8%);
+		backdrop-filter: blur(14px);
+		-webkit-backdrop-filter: blur(14px);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-xl);
+		box-shadow: var(--shadow-lg);
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		animation: dockIn 0.28s cubic-bezier(0.16, 1, 0.3, 1) both;
+	}
+
+	@keyframes dockIn {
+		from {
+			opacity: 0;
+			transform: translateX(-50%) translateY(10px);
+		}
+		to {
+			opacity: 1;
+			transform: translateX(-50%) translateY(0);
+		}
+	}
+
+	.dock-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.dock-title {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.dock-close {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 26px;
+		height: 26px;
+		border: none;
+		border-radius: var(--radius-full);
+		background: transparent;
+		color: var(--text-tertiary);
+		cursor: pointer;
+		transition: color 0.15s ease, background 0.15s ease;
+	}
+
+	.dock-close:hover {
+		color: var(--text-primary);
+		background: var(--bg-tertiary);
+	}
+
+	.dock-row {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+	}
+
+	.row-label {
+		display: flex;
+		justify-content: space-between;
+		font-size: 0.75rem;
+		font-weight: 500;
+		color: var(--text-secondary);
+	}
+
+	.row-value {
+		color: var(--text-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.pose-carousel {
+		display: flex;
+		gap: 0.375rem;
+		overflow-x: auto;
+		padding-bottom: 0.25rem;
+		scrollbar-width: thin;
+	}
+
+	.pose-chip {
+		flex-shrink: 0;
+		padding: 0.375rem 0.75rem;
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-full);
+		background: var(--bg-secondary);
+		color: var(--text-secondary);
+		font-size: 0.75rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+	}
+
+	.pose-chip:hover {
+		color: var(--text-primary);
+	}
+
+	.pose-chip.selected {
+		background: var(--accent);
+		border-color: var(--accent);
+		color: white;
+	}
+
+	.dock-row input[type='range'] {
+		-webkit-appearance: none;
+		appearance: none;
+		width: 100%;
+		height: 4px;
+		border-radius: 2px;
+		background: var(--bg-tertiary);
+		outline: none;
+		cursor: pointer;
+	}
+
+	.dock-row input[type='range']::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		appearance: none;
+		width: 16px;
+		height: 16px;
+		border-radius: 50%;
+		background: var(--accent);
+		border: none;
+		cursor: pointer;
+	}
+
+	.dock-row input[type='range']::-moz-range-thumb {
+		width: 16px;
+		height: 16px;
+		border-radius: 50%;
+		background: var(--accent);
+		border: none;
+		cursor: pointer;
+	}
+
+	.dock-actions {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.dock-btn {
+		flex: 1;
+		padding: 0.5rem;
+		border: none;
+		border-radius: var(--radius-md);
+		background: var(--bg-tertiary);
+		color: var(--text-secondary);
+		font-size: 0.75rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition: color 0.15s ease, background 0.15s ease;
+	}
+
+	.dock-btn:hover {
+		color: var(--text-primary);
+	}
+</style>

--- a/src/lib/components/ui/TopLeftButtons.svelte
+++ b/src/lib/components/ui/TopLeftButtons.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Icon } from '$lib/components/ui';
-	import { screenshotStore } from '$lib/stores/screenshot.svelte';
+	import { photomodeStore } from '$lib/stores/photomode.svelte';
 
 	interface Props {
 		onOpenMemoryGraph?: () => void;
@@ -8,14 +8,10 @@
 	}
 
 	let { onOpenMemoryGraph, onBoardClick }: Props = $props();
-
-	function takeScreenshot() {
-		screenshotStore.take();
-	}
 </script>
 
 <div class="top-left-buttons">
-	<button class="icon-btn" onclick={takeScreenshot} aria-label="Take screenshot">
+	<button class="icon-btn" onclick={() => photomodeStore.enter()} aria-label="Open photo mode">
 		<Icon name="camera" size={20} />
 	</button>
 	{#if onOpenMemoryGraph}

--- a/src/lib/components/vrm/Scene.svelte
+++ b/src/lib/components/vrm/Scene.svelte
@@ -11,6 +11,7 @@
 	import OverlayRaycastHandler from '$lib/components/overlay/OverlayRaycastHandler.svelte';
 	import { vrmStore } from '$lib/stores/vrm.svelte';
 	import { displayStore } from '$lib/stores/display.svelte';
+	import { photomodeStore } from '$lib/stores/photomode.svelte';
 	import { screenshotStore } from '$lib/stores/screenshot.svelte';
 	import { onMount } from 'svelte';
 
@@ -174,13 +175,54 @@
 		}
 	}
 
-	// Re-frame when the model or the camera settings change
+	// Re-frame when the model or the camera settings change. In photo mode the
+	// user owns the framing, so FOV changes only adjust the lens in place
+	// instead of snapping the camera back to the fitted position.
 	$effect(() => {
 		void vrmStore.vrm;
 		void camSettings.fov;
 		void camSettings.zoom;
 		void camSettings.height;
+		if (photomodeStore.active) {
+			const cam = camera.current;
+			if (cam instanceof PerspectiveCamera) {
+				cam.fov = camSettings.fov;
+				cam.updateProjectionMatrix();
+			}
+			return;
+		}
 		applyCamera();
+	});
+
+	// The dock's reset chip explicitly asks for the fitted framing back
+	$effect(() => {
+		void photomodeStore.reframeCounter;
+		if (photomodeStore.active) applyCamera();
+	});
+
+	// Photo-mode camera profile: damping for deliberate motion, a wider zoom
+	// range for close portraits and full-body shots, and a polar clamp that
+	// keeps the camera above the floor. Exiting restores the chat profile and
+	// re-applies the fitted framing.
+	$effect(() => {
+		if (!controls) return;
+		if (photomodeStore.active) {
+			controls.enableDamping = true;
+			controls.dampingFactor = 0.08;
+			controls.minDistance = 0.3;
+			controls.maxDistance = 8;
+			controls.minPolarAngle = 0.05;
+			controls.maxPolarAngle = Math.PI * 0.6;
+			return () => {
+				if (!controls) return;
+				controls.enableDamping = false;
+				controls.minDistance = 0;
+				controls.maxDistance = Infinity;
+				controls.minPolarAngle = 0;
+				controls.maxPolarAngle = Math.PI;
+				applyCamera();
+			};
+		}
 	});
 
 	// Setup OrbitControls (skip when locked)

--- a/src/lib/components/vrm/VrmModel.svelte
+++ b/src/lib/components/vrm/VrmModel.svelte
@@ -6,6 +6,8 @@
 	import { vrmStore } from '$lib/stores/vrm.svelte';
 	import { ttsStore } from '$lib/stores/tts.svelte';
 	import { displayStore } from '$lib/stores/display.svelte';
+	import { photomodeStore } from '$lib/stores/photomode.svelte';
+	import { loadPoseAnimation, loadPoseManifest } from '$lib/services/poses';
 	import {
 		computeSpringJointParams,
 		clampFrameDelta,
@@ -271,10 +273,10 @@
 		const loops = 1 + Math.random();
 		const delay = duration * loops * 1000;
 		idleCycleTimeout = setTimeout(() => {
-			if (!shouldTalk && !isEmotePlaying) {
+			if (!shouldTalk && !isEmotePlaying && !photomodeStore.active) {
 				playNextIdleAnimation(targetVrm, targetMixer);
 			} else {
-				// Retry later if we're busy
+				// Retry later if we're busy (talking, emoting, or posing for a photo)
 				scheduleIdleCycle(targetVrm, targetMixer, duration);
 			}
 		}, delay);
@@ -353,6 +355,100 @@
 		);
 	}
 
+	// === Photo mode ===
+	// A held pose is a single-frame clip: play, pause at t=0, and let the weight
+	// crossfade do the transition. vrm.update() keeps running in the render task,
+	// so spring bones and blinking stay alive while posed.
+	let poseAction: THREE.AnimationAction | null = null;
+	// Rapid pose taps race their async loads; only the latest application wins.
+	let poseToken = 0;
+
+	async function applyPhotoPose(poseId: string | null) {
+		const targetVrm = vrm;
+		const targetMixer = mixer;
+		if (!targetVrm || !targetMixer) return;
+		const token = ++poseToken;
+
+		if (poseId === null) {
+			// Natural: fade any pose out and hold the idle stance
+			if (poseAction) {
+				poseAction.fadeOut(0.3);
+				poseAction = null;
+			}
+			if (idleAction) {
+				idleAction.reset().fadeIn(0.3).play();
+				idleAction.paused = true;
+			}
+			return;
+		}
+
+		const manifest = await loadPoseManifest();
+		const entry = manifest.find((p) => p.id === poseId);
+		if (!entry) return;
+
+		try {
+			const animation = await loadPoseAnimation(entry.file);
+			// Model swapped or a newer pose was requested while this one loaded
+			if (mixer !== targetMixer || token !== poseToken) return;
+			if (!photomodeStore.active) return;
+
+			const clip = createVRMAnimationClip(animation, targetVrm);
+			const previous = poseAction ?? idleAction;
+			if (previous) previous.fadeOut(0.3);
+
+			const action = targetMixer.clipAction(clip);
+			action.reset();
+			action.setLoop(THREE.LoopOnce, 1);
+			action.clampWhenFinished = true;
+			action.fadeIn(0.3).play();
+			// Freeze on the first frame; the fade still blends the held pose in
+			action.paused = true;
+			action.time = 0;
+			poseAction = action;
+		} catch (e) {
+			console.error('[PhotoMode] Failed to apply pose:', e);
+		}
+	}
+
+	// Enter/exit lifecycle: freeze the current stance on the way in, and re-run
+	// the normal idle start path on the way out so cycling resumes cleanly.
+	let wasPhotoActive = false;
+	$effect(() => {
+		const active = photomodeStore.active;
+		untrack(() => {
+			const targetVrm = vrm;
+			const targetMixer = mixer;
+			if (!targetVrm || !targetMixer) {
+				wasPhotoActive = active;
+				return;
+			}
+			if (active && !wasPhotoActive) {
+				if (talkingAction) talkingAction.fadeOut(0.2);
+				if (idleAction) idleAction.paused = true;
+			} else if (!active && wasPhotoActive) {
+				if (poseAction) {
+					poseAction.fadeOut(0.3);
+					poseAction = null;
+				}
+				if (idleAction) idleAction.paused = false;
+				startIdleAnimation(targetVrm, targetMixer);
+			}
+			wasPhotoActive = active;
+		});
+	});
+
+	// Apply pose selections while photo mode is active
+	$effect(() => {
+		const active = photomodeStore.active;
+		const poseId = photomodeStore.selectedPoseId;
+		if (!active) return;
+		untrack(() => {
+			// Entering starts on Natural, which the enter lifecycle already froze
+			if (poseId === null && !poseAction) return;
+			applyPhotoPose(poseId);
+		});
+	});
+
 	// Update lip-sync analyser when TTS state changes
 	$effect(() => {
 		lipSyncAnalyzer.setAnalyser(ttsStore.currentAnalyser);
@@ -366,8 +462,9 @@
 		const currentTalkingClip = untrack(() => talkingClip);
 		const currentEmotePlaying = untrack(() => isEmotePlaying);
 
-		// Don't switch if emote is playing or no mixer/clips available
-		if (!currentMixer || currentEmotePlaying) return;
+		// Don't switch if emote is playing or no mixer/clips available. A held
+		// photo pose must not be stomped by TTS either; exit restores the loop.
+		if (!currentMixer || currentEmotePlaying || photomodeStore.active) return;
 
 		if (speaking && currentTalkingClip) {
 			// Start talking animation, fade out idle

--- a/src/lib/services/poses.ts
+++ b/src/lib/services/poses.ts
@@ -1,0 +1,64 @@
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { VRMAnimationLoaderPlugin, type VRMAnimation } from '@pixiv/three-vrm-animation';
+
+// Pose catalog for photo mode. Poses ship as .vrma files listed in
+// /static/poses/manifest.json, so adding one is a data change: drop the file,
+// add an entry. Clips are model-specific (createVRMAnimationClip needs the
+// VRM), so this service caches the parsed VRMAnimation per URL and lets the
+// caller build the clip against whichever model is loaded.
+
+export interface PoseEntry {
+	id: string;
+	name: string;
+	file: string;
+	thumbnail?: string;
+}
+
+let manifestPromise: Promise<PoseEntry[]> | null = null;
+
+export function loadPoseManifest(): Promise<PoseEntry[]> {
+	if (!manifestPromise) {
+		manifestPromise = fetch('/poses/manifest.json')
+			.then((res) => {
+				if (!res.ok) throw new Error(`Pose manifest: ${res.status}`);
+				return res.json();
+			})
+			.then((entries: PoseEntry[]) =>
+				entries.filter((e) => e && typeof e.id === 'string' && typeof e.file === 'string')
+			)
+			.catch((e) => {
+				console.error('[Poses] Failed to load manifest:', e);
+				manifestPromise = null; // allow a retry on next open
+				return [];
+			});
+	}
+	return manifestPromise;
+}
+
+const animationCache = new Map<string, Promise<VRMAnimation>>();
+
+export function loadPoseAnimation(file: string): Promise<VRMAnimation> {
+	let cached = animationCache.get(file);
+	if (!cached) {
+		cached = new Promise<VRMAnimation>((resolve, reject) => {
+			const loader = new GLTFLoader();
+			loader.register((parser) => new VRMAnimationLoaderPlugin(parser));
+			loader.load(
+				file,
+				(gltf) => {
+					const anims: VRMAnimation[] | undefined = gltf.userData.vrmAnimations;
+					if (anims && anims.length > 0) {
+						resolve(anims[0]);
+					} else {
+						reject(new Error(`No VRM animation in ${file}`));
+					}
+				},
+				undefined,
+				(error) => reject(error)
+			);
+		});
+		cached.catch(() => animationCache.delete(file)); // failed loads retry
+		animationCache.set(file, cached);
+	}
+	return cached;
+}

--- a/src/lib/stores/photomode.svelte.ts
+++ b/src/lib/stores/photomode.svelte.ts
@@ -1,0 +1,45 @@
+// Photo mode state. The scene, model, and dock all key off this store:
+// entering pauses the idle-cycle scheduler and talking swaps (VrmModel),
+// switches the camera to the free photo profile (Scene), and hides the chat
+// UI behind the dock (app page). Exiting restores the live-companion loop.
+
+let active = $state(false);
+// null = Natural (the frozen idle stance); otherwise a pose id from the manifest
+let selectedPoseId = $state<string | null>(null);
+// Bumped when the dock asks the scene to re-fit the camera (photo mode
+// otherwise leaves the framing entirely to the user)
+let reframeCounter = $state(0);
+
+function enter() {
+	selectedPoseId = null;
+	active = true;
+}
+
+function exit() {
+	active = false;
+	selectedPoseId = null;
+}
+
+function setPose(id: string | null) {
+	selectedPoseId = id;
+}
+
+function requestReframe() {
+	reframeCounter++;
+}
+
+export const photomodeStore = {
+	get active() {
+		return active;
+	},
+	get selectedPoseId() {
+		return selectedPoseId;
+	},
+	get reframeCounter() {
+		return reframeCounter;
+	},
+	enter,
+	exit,
+	setPose,
+	requestReframe
+};

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -3,6 +3,8 @@
 	import FloatingStatIndicators from '$lib/components/ui/FloatingStatIndicators.svelte';
 	import { TopRightButtons, TopLeftButtons, InfoModal } from '$lib/components/ui';
 	import BottomChatBar from '$lib/components/chat/BottomChatBar.svelte';
+	import PhotoModeDock from '$lib/components/photomode/PhotoModeDock.svelte';
+	import { photomodeStore } from '$lib/stores/photomode.svelte';
 	import SpeechBubble from '$lib/components/chat/SpeechBubble.svelte';
 	import ThinkingImages from '$lib/components/chat/ThinkingImages.svelte';
 	import Photoboard from '$lib/components/chat/Photoboard.svelte';
@@ -209,14 +211,16 @@
 </script>
 
 <div class="app-container">
-	<TopLeftButtons onOpenMemoryGraph={() => showMemoryGraph = true} onBoardClick={() => showBoard = true} />
-	<TopRightButtons
-		onInfoClick={() => showInfoModal = true}
-		upcomingReminders={reminderStore.upcoming}
-		onDeleteReminder={reminderStore.deleteReminder}
-		recentFired={reminderStore.recentFired}
-		onDismissRecentFired={reminderStore.dismissRecentFired}
-	/>
+	{#if !photomodeStore.active}
+		<TopLeftButtons onOpenMemoryGraph={() => showMemoryGraph = true} onBoardClick={() => showBoard = true} />
+		<TopRightButtons
+			onInfoClick={() => showInfoModal = true}
+			upcomingReminders={reminderStore.upcoming}
+			onDeleteReminder={reminderStore.deleteReminder}
+			recentFired={reminderStore.recentFired}
+			onDismissRecentFired={reminderStore.dismissRecentFired}
+		/>
+	{/if}
 	{#if showInfoModal}
 		<InfoModal onClose={() => showInfoModal = false} />
 	{/if}
@@ -258,27 +262,31 @@
 			</div>
 		</div>
 
-		<!-- Floating Stat Indicators -->
-		<FloatingStatIndicators />
+		{#if !photomodeStore.active}
+			<!-- Floating Stat Indicators -->
+			<FloatingStatIndicators />
 
-		<!-- Speech Bubble (shows latest response, click to dismiss) -->
-		<SpeechBubble
-			message={latestResponse}
-			isTyping={isTyping}
-			onHide={handleBubbleHide}
-		/>
+			<!-- Speech Bubble (shows latest response, click to dismiss) -->
+			<SpeechBubble
+				message={latestResponse}
+				isTyping={isTyping}
+				onHide={handleBubbleHide}
+			/>
 
-		<!-- The image she's being shown, floated above her head while she considers it -->
-		<ThinkingImages images={thinkingImages} show={isTyping} />
+			<!-- The image she's being shown, floated above her head while she considers it -->
+			<ThinkingImages images={thinkingImages} show={isTyping} />
 
-		<!-- Bottom Chat Bar -->
-		<BottomChatBar
-			onSend={handleSend}
-			disabled={chatStore.isLoading}
-			{visionCapable}
-			providerLabel={imageProvider.label}
-			providerIsLocal={imageProvider.isLocal}
-		/>
+			<!-- Bottom Chat Bar -->
+			<BottomChatBar
+				onSend={handleSend}
+				disabled={chatStore.isLoading}
+				{visionCapable}
+				providerLabel={imageProvider.label}
+				providerIsLocal={imageProvider.isLocal}
+			/>
+		{:else}
+			<PhotoModeDock />
+		{/if}
 
 		<!-- Error toast for chat errors -->
 		{#if chatStore.error}
@@ -295,8 +303,8 @@
 			</div>
 		{/if}
 
-		<!-- Event Scene Overlay -->
-		{#if activeEvent?.scene}
+		<!-- Event Scene Overlay (deferred while posing; renders on exit) -->
+		{#if activeEvent?.scene && !photomodeStore.active}
 			<EventScene
 				scene={activeEvent?.scene}
 				eventName={activeEvent?.name}

--- a/static/poses/manifest.json
+++ b/static/poses/manifest.json
@@ -1,0 +1,8 @@
+[
+	{ "id": "pose-a", "name": "Pose A", "file": "/animations/VRMA_01.vrma" },
+	{ "id": "pose-b", "name": "Pose B", "file": "/animations/VRMA_02.vrma" },
+	{ "id": "pose-c", "name": "Pose C", "file": "/animations/VRMA_03.vrma" },
+	{ "id": "pose-d", "name": "Pose D", "file": "/animations/VRMA_04.vrma" },
+	{ "id": "rest", "name": "Rest", "file": "/animations/idle_3.vrma" },
+	{ "id": "sway", "name": "Sway", "file": "/animations/idle_5.vrma" }
+]


### PR DESCRIPTION
Mode state and entry, the pose pipeline, and the photo camera profile, with a working dock. A follow-up PR stacks A4-A7 (expressions, tap reactions, backgrounds, high-res capture) on this branch.

## What

- **Entry**: the top-left camera button enters Photo Mode (the old instant screenshot moves into the dock as quick-snap in the follow-up). Esc or the dock's X exits. Chat bar, stat indicators, speech bubble, and event overlays hide while active; an event triggered mid-pose is deferred and renders on exit.
- **Living poses**: entering pauses the idle-cycle scheduler and talking-animation swaps, but `vrm.update()` keeps running, so hair physics, blinking, and body settle stay alive while she holds a pose. Poses are single-frame VRMA holds: crossfade in over 0.3s, pause at frame zero.
- **Pose pipeline**: `/static/poses/manifest.json` + a cached loader service (`services/poses.ts`). Adding a pose is a data change. The launch manifest points at the bundled animation clips as placeholders until the Blender-exported pose set lands; swap the manifest entries and nothing else moves.
- **Load-race safety**: pose application reuses the model-generation guard plus a latest-wins token, so switching models mid-pose-load or tapping poses rapidly never applies a stale clip.
- **Photo camera**: damping, wider zoom range for close portraits through full body, polar clamp that keeps the camera above the floor. In photo mode FOV changes adjust the lens in place instead of snapping back to the fitted framing (the fitted-framing effect is suspended); Reset framing explicitly re-fits. Exit restores the chat camera profile.
- **Dock**: `components/photomode/PhotoModeDock.svelte`, pose carousel, lens slider, reset, exit. State lives in `stores/photomode.svelte.ts` per the persona-page decomposition pattern.

## Verification

- `pnpm check` 0 errors / 0 warnings; `pnpm test` 273/273.
- Live e2e on the dev build with a custom (non-bundled) VRM: entered photo mode, chat UI hid, dock rendered with all seven chips; applied multiple poses with visible held-stance changes and smooth transitions; lens slider moved without losing framing; Esc exited, chat UI returned, and the idle cycle resumed with a visible gesture. Zero console errors throughout.