### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0] - 2026-07-09
+
+### Added
+- **Photo Mode**: the camera button now opens a full photo mode instead of taking an instant screenshot. Pose her from a growing pose library, set her expression, pick a background, add a color filter, vignette, or a polaroid or film frame, drop draggable stickers on the shot, and capture at high resolution with a quick snap or a 3 second self-timer. A compact tabbed panel keeps every control in the corner, out of your shot, and everything you see in the preview is exactly what the saved photo looks like. Head tracking is in there too: toggle it on and she follows your camera with her eyes and chin while she holds a pose.
+- **Reminders and timers**: ask her to remind you of something ("remind me in 10 minutes to stretch") and she will schedule it, bring it up when it fires, and notice timers that came due while the app was closed. Pending and fired reminders live in a new alarm dropdown in the top bar. Works across the main app and the desktop overlay. Contributed by @dezihh.
+- **She reacts to touch**: tap her, in the regular view or in photo mode, and she responds with an expression and a little physics ripple through her hair and clothes. How she reacts depends on where you tap and how close the two of you are: early on she is easily flustered, and the warmer reactions are something you earn.
+- **Scene backgrounds**: the backdrop behind her is yours to change now, in the Controls panel. Pastel gradients like Sakura, Peach, and Lavender, and cute patterns like polka dots, hearts, sparkles, candy stripes, and gingham. Your pick sticks across restarts, and photos taken in Room mode capture it faithfully.
+- **Physics intensity**: a Movement slider in the Controls panel, from Subtle to Lively, scales how much her hair, skirt, and everything else the model author rigged responds to motion. Every model keeps its own tuning; the slider just turns the dial.
+
+### Fixed
+- Spring-bone physics no longer explodes after a tab refocus or a long window drag; the worst frame the physics ever sees is now a calm one.
+- Fired reminders no longer count as you interacting: they cannot advance the relationship, reset the away-time clock, or plant memories, and the "last time you talked" recap works again after every restart.
 
 ### Changed
 - **Reminder system is now multi-window aware**: the main app and desktop overlay coordinate fired timers via `BroadcastChannel`, so the alarm icon updates on every open surface. The LLM reaction still runs exactly once, handled by the window that atomically claims the reminder.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.9.2",
+	"version": "0.10.0",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.9.2"
+version = "0.10.0"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "pnpm build",


### PR DESCRIPTION
Version bump and changelog for the 0.10.0 release: Photo Mode, reminders and timers, touch reactions, scene backgrounds, and the physics slider. Details in CHANGELOG.md.