### PR TITLE
docs: correct drifted facts across README and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@
 - **3D Speech Bubbles**: Chat responses appear as bubbles that track the model's head in 3D space
 - **Chat Interface**: Bottom-centered input bar with streaming responses
 - **Voice Input**: Speech-to-text via a local Whisper server (Speaches, faster-whisper-server, whisper.cpp), Groq (Whisper), or the browser's Web Speech API, with real-time audio visualization
-- **Show Her Photos**: Show your companion an image via the camera button or drag-and-drop. Vision-capable models (GPT-4o, Claude, Gemini, or local ones like LLaVA) actually see it and can remember the moment, and kept photos live on a scrapbook-style board. Images stay on your device and only ever reach vision-capable models
-- **LLM Integration**: Support for 7 LLM providers including OpenAI, Anthropic, Google, xAI, DeepSeek, Ollama, and LM Studio
+- **Show Her Photos**: Show your companion an image via the attach (paperclip) button in the chat bar or drag-and-drop. Vision-capable models (GPT-4o, Claude, Gemini, or local ones like LLaVA) actually see it and can remember the moment, and kept photos live on a scrapbook-style board. Images stay on your device and only ever reach vision-capable models
+- **LLM Integration**: Support for 8 LLM providers: OpenAI, Anthropic, Google, xAI, DeepSeek, Ollama, LM Studio, and any OpenAI-compatible endpoint (OpenRouter, Together, vLLM, ...)
 - **Local Model Discovery**: Ollama and LM Studio discover installed local models directly from your device
 - **Text-to-Speech**: Support for ElevenLabs and OpenAI TTS, plus local voices via any OpenAI-compatible server (Kokoro-FastAPI, openedai-speech)
 - **Fully Local Option**: Run the whole stack offline — local LLM (Ollama/LM Studio), local TTS, and local Whisper STT — so nothing leaves your device
@@ -284,6 +284,7 @@ utsuwa/
 
 ```bash
 pnpm dev          # Start web development server
+pnpm test         # Run the test suite (node --test)
 pnpm build        # Build web app for production
 pnpm preview      # Preview production build
 pnpm lint         # Type-check the project (svelte-check)
@@ -299,7 +300,7 @@ pnpm tauri build  # Build desktop app installer
 
 - [x] VRM model loading and display with orbit controls
 - [x] 3D speech bubbles tracking model head position
-- [x] Multi-provider LLM support (7 providers)
+- [x] Multi-provider LLM support (8 providers)
 - [x] Multi-provider TTS support (3 providers)
 - [x] Audio-driven lip-sync
 - [x] VRMA-based animations (idle, talking, blinking)
@@ -361,11 +362,6 @@ Utsuwa is built on the shoulders of these excellent projects:
 - **[Dexie.js](https://github.com/dexie/Dexie.js)** - IndexedDB wrapper for local storage
 - **[force-graph](https://github.com/vasturiano/force-graph)** - Force-directed graph visualization for memory graph
 - **[simple-icons](https://github.com/simple-icons/simple-icons)** - SVG icons for provider logos
-
-### 3D Effects
-
-- **[n8ao](https://github.com/N8python/n8ao)** - Ambient occlusion for Three.js
-- **[postprocessing](https://github.com/pmndrs/postprocessing)** - Post-processing effects
 
 ## License
 

--- a/src/content/docs/community/contributing.md
+++ b/src/content/docs/community/contributing.md
@@ -57,9 +57,10 @@ Feature requests are welcome. Create an issue with:
    git checkout -b feature/your-feature-name
    ```
 2. Make your changes
-3. Ensure your code follows the project's style:
+3. Run the quality gates; both must pass clean:
    ```bash
-   pnpm lint
+   pnpm test    # test suite (node --test)
+   pnpm check   # type checking (svelte-check)
    ```
 4. Test your changes thoroughly
 5. Commit your changes with a clear message

--- a/src/content/docs/guides/desktop-guide.md
+++ b/src/content/docs/guides/desktop-guide.md
@@ -86,7 +86,7 @@ Overlay mode detaches your companion into a transparent, always-on-top window:
 - **Always on Top**: The companion stays visible over all other windows
 - **Draggable**: Click and drag anywhere on the character to reposition
 - **Floating Chat**: Click the chat icon at the bottom to expand a chat input
-- **Speech Bubbles**: Responses appear as speech bubbles near the character
+- **Speech Bubbles**: Responses appear in a docked dialog bubble above the bottom controls (the window moves around, so a head-tracking bubble would be unreadable)
 - **Status Indicator**: The mood/relationship status pill appears above the chat icon
 
 #### Controls
@@ -121,7 +121,7 @@ Some features are still being worked on:
 | Click-through transparency | ❌ Disabled (blocks UI) |
 | Global hotkeys | ✅ Available |
 | In-app auto-updates | ✅ Available |
-| Position persistence | ⏳ Planned |
+| Size and lock persistence | ✅ Available (window position across relaunch still planned) |
 | System tray | ⏳ Planned |
 
 ## Troubleshooting
@@ -155,7 +155,7 @@ The camera is locked in overlay mode. If the character appears rotated, exit ove
 
 ### Voice input not working
 
-The desktop app uses Tauri's webview, which does not support the browser's Web Speech API. For voice input on desktop, configure either a local Whisper server or a Groq API key in **Settings > Character** under the Voice Input (STT) section.
+The desktop app uses Tauri's webview, which does not support the browser's Web Speech API. For voice input on desktop, configure a local Whisper server, a Groq API key, or an OpenAI API key in **Settings > Character** under the Voice Input (STT) section.
 
 ### Can't interact with overlay UI
 

--- a/src/content/docs/guides/local-llm-setup.md
+++ b/src/content/docs/guides/local-llm-setup.md
@@ -49,9 +49,9 @@ This starts the Ollama API on `http://localhost:11434`.
 
 ### Connecting to Utsuwa
 
-1. Open **Settings** (gear icon)
-2. Navigate to the **Character** tab
-3. Enable the LLM toggle, then select **Ollama** from the provider dropdown
+1. Open the **Controls** panel (sliders icon, top right) and click **Settings** (gear)
+2. Navigate to the **Character** tab and open the **AI Services** section
+3. Enable the Chat (LLM) toggle, then select **Ollama** from the provider dropdown
 4. Leave the base URL as `http://localhost:11434` unless you changed Ollama's port
 5. Utsuwa will fetch models installed on your machine. Click the refresh icon if you just pulled a new model.
 6. Select an installed model from the dropdown
@@ -124,9 +124,9 @@ This starts an OpenAI-compatible API on `http://localhost:1234`.
 
 ### Connecting to Utsuwa
 
-1. Open **Settings** (gear icon)
-2. Navigate to the **Character** tab
-3. Enable the LLM toggle, then select **LM Studio** from the provider dropdown
+1. Open the **Controls** panel (sliders icon, top right) and click **Settings** (gear)
+2. Navigate to the **Character** tab and open the **AI Services** section
+3. Enable the Chat (LLM) toggle, then select **LM Studio** from the provider dropdown
 4. Leave the base URL as `http://localhost:1234/v1` unless you changed LM Studio's port
 5. Utsuwa will fetch models from the running LM Studio server. Click the refresh icon if you load a different model.
 6. Select the loaded model from the dropdown

--- a/src/content/docs/guides/local-stt-setup.md
+++ b/src/content/docs/guides/local-stt-setup.md
@@ -34,7 +34,7 @@ This serves the API at `http://localhost:8000/v1`.
 5. Set the **Model** field to a model your server exposes (e.g. `Systran/faster-whisper-large-v3`)
 6. Click the microphone button in the chat bar and speak
 
-A configured local server takes priority over Groq and the browser's Web Speech API automatically — there's no separate toggle.
+A configured local server takes priority over Groq, OpenAI, and the browser's Web Speech API automatically — there's no separate toggle.
 
 ### Models
 

--- a/src/content/docs/guides/local-tts-setup.md
+++ b/src/content/docs/guides/local-tts-setup.md
@@ -27,8 +27,8 @@ This serves the API at `http://localhost:8880/v1`.
 
 ### Connecting to Utsuwa
 
-1. Open **Settings** (gear icon)
-2. Navigate to the **Character** tab
+1. Open the **Controls** panel (sliders icon, top right) and click **Settings** (gear)
+2. Navigate to the **Character** tab and open the **AI Services** section
 3. Enable the **Speech (TTS)** toggle, then select **Local TTS** from the provider dropdown
 4. Leave the base URL as `http://localhost:8880/v1/` unless you changed the port
 5. Pick a **voice** (start typing in the voice field to see suggestions like `af_bella`)

--- a/src/content/docs/guides/troubleshooting.md
+++ b/src/content/docs/guides/troubleshooting.md
@@ -155,7 +155,7 @@ If the mic button shows an error in the browser:
 
 1. **Check browser support** - Web Speech API works in Chrome, Edge, and Safari. Firefox has limited support.
 2. **Allow microphone access** - Your browser may be blocking the microphone permission.
-3. **Use a local Whisper server or Groq** - For better quality or broader browser support, configure Local STT (a self-hosted OpenAI-compatible Whisper server) or add a Groq API key in **Settings > Character** under Voice Input (STT). A configured local server takes top priority, then Groq, then Web Speech API.
+3. **Use a local Whisper server or Groq** - For better quality or broader browser support, configure Local STT (a self-hosted OpenAI-compatible Whisper server) or add a Groq API key in **Settings > Character** under Voice Input (STT). A configured local server takes top priority, then Groq, then OpenAI, then Web Speech API.
 
 ### "Microphone access denied"
 
@@ -190,7 +190,7 @@ On the desktop app, most local providers need only that the server is running. T
 
 1. **System audio** - Check your OS volume and that Utsuwa isn't muted in the system mixer
 2. **TTS configured** - Confirm a TTS provider is set up and a voice is selected (see Text-to-Speech Issues above)
-3. **Microphone/voice input** - The desktop webview has no Web Speech API, so the mic needs a Groq key; see [Mic button not responding (desktop)](#mic-button-not-responding-desktop)
+3. **Microphone/voice input** - The desktop webview has no Web Speech API, so the mic needs a Groq or OpenAI key; see [Mic button not responding (desktop)](#mic-button-not-responding-desktop)
 
 ### Updates not installing
 

--- a/src/content/docs/guides/web-guide.md
+++ b/src/content/docs/guides/web-guide.md
@@ -32,9 +32,9 @@ The app will be available at `http://localhost:5173`.
 
 Your companion needs an LLM to generate responses.
 
-1. Open **Settings** (gear icon in the sidebar)
-2. Navigate to the **Character** tab
-3. Enable the LLM toggle, then select a provider from the dropdown and enter your API key
+1. Open the **Controls** panel (sliders icon, top right) and click the **Settings** (gear) button
+2. Navigate to the **Character** tab and open the **AI Services** section
+3. Enable the Chat (LLM) toggle, then select a provider from the dropdown and enter your API key
 4. Alternatively, use a local server like Ollama or LM Studio (no API key needed)
 
 All API keys are stored locally on your device and never sent anywhere except the respective provider's API.
@@ -44,16 +44,15 @@ All API keys are stored locally on your device and never sent anywhere except th
 Utsuwa comes with a default avatar, but you can load your own:
 
 1. Go to **Settings > Character**
-2. Click **Load VRM** to select a local `.vrm` file
-3. Or enter a URL to load a VRM model from the web
+2. Click **Add Custom** in the Avatar section and select a local `.vrm` file (drag-and-drop works too)
 
 ### 3. Configure Text-to-Speech (Optional)
 
 To have your companion speak responses aloud:
 
-1. Go to **Settings > Character**
-2. Enable the TTS toggle, then select a provider (ElevenLabs or OpenAI TTS)
-3. Enter your API key and configure voice settings
+1. Go to **Settings > Character** and open the **AI Services** section
+2. Enable the Speech (TTS) toggle, then select a provider (ElevenLabs, OpenAI TTS, or Local TTS)
+3. Enter your API key (cloud providers) and configure voice settings
 
 ## Using the Chat
 
@@ -69,7 +68,7 @@ Click the microphone button in the chat bar to use speech-to-text. Three options
 - **Groq or OpenAI Whisper** — Higher-quality cloud transcription via Groq's or OpenAI's Whisper API. Requires the respective API key, added in the same Voice Input (STT) section.
 - **Web Speech API** — Built into your browser (Chrome, Edge, Safari). No API key required. The default in the browser when nothing else is configured.
 
-Selection is automatic by priority: a configured local server wins, then Groq, then Web Speech. On the desktop app the Web Speech API is unavailable, so configure either a local Whisper server or a Groq key for voice input.
+Selection is automatic by priority: a configured local server wins, then Groq, then OpenAI, then Web Speech. On the desktop app the Web Speech API is unavailable, so configure either a local Whisper server or a Groq key for voice input.
 
 See [Local STT Setup](/docs/guides/local-stt-setup) for running a local Whisper server.
 
@@ -83,4 +82,4 @@ All data is stored locally on your device.
 
 ## Themes
 
-Utsuwa supports light and dark modes with automatic system preference detection. Go to **Settings > Display** to change your appearance mode.
+Utsuwa supports light and dark modes with automatic system preference detection. Open the **Controls** panel (sliders icon, top right) and click the theme button to cycle System, Light, and Dark.

--- a/src/content/docs/overview/introduction.md
+++ b/src/content/docs/overview/introduction.md
@@ -19,7 +19,7 @@ Most AI companions today are either text-only chat interfaces or locked behind p
 
 Utsuwa takes a different approach. It gives you a 3D avatar that speaks, remembers your conversations, and develops a relationship with you over time. No accounts, no subscriptions. Your data stays on your device.
 
-Connect any LLM provider you want — OpenAI, Anthropic, Google, DeepSeek, xAI, or a local model through Ollama or LM Studio. Add voice with ElevenLabs, OpenAI TTS, or a local TTS server. For voice input, use a local Whisper server, Groq, or your browser's built-in speech recognition. Load any VRM model as your companion's body. Everything is modular and swappable — and can run entirely on your own machine.
+Connect any LLM provider you want — OpenAI, Anthropic, Google, DeepSeek, xAI, any OpenAI-compatible endpoint (OpenRouter, Together, vLLM), or a local model through Ollama or LM Studio. Add voice with ElevenLabs, OpenAI TTS, or a local TTS server. For voice input, use a local Whisper server, Groq, OpenAI, or your browser's built-in speech recognition. Load any VRM model as your companion's body. Everything is modular and swappable — and can run entirely on your own machine.
 
 "Utsuwa" means "vessel" in Japanese — a container for AI to inhabit visually. The app is the vessel; you choose what goes inside.
 

--- a/src/content/docs/technology/architecture.md
+++ b/src/content/docs/technology/architecture.md
@@ -163,7 +163,7 @@ Text-to-speech converts LLM responses to audio with lip-sync.
 
 ### Speech-to-Text (STT)
 
-Voice input converts microphone audio to text through one of three providers, chosen automatically by priority.
+Voice input converts microphone audio to text through one of four providers, chosen automatically by priority.
 
 **Key files:**
 - `src/lib/services/stt/openai-stt.ts` — OpenAI-compatible transcription client (Groq and local Whisper servers via `/v1/audio/transcriptions`)
@@ -173,9 +173,10 @@ Voice input converts microphone audio to text through one of three providers, ch
 **Supported providers (priority order):**
 - **Local STT** — any OpenAI-compatible Whisper server (Speaches, faster-whisper-server, whisper.cpp). No key; defaults to `http://localhost:8000/v1`
 - **Groq (Whisper)** — cloud transcription, requires an API key
+- **OpenAI (Whisper)** — cloud transcription via the OpenAI API, requires an API key
 - **Web Speech API** — browser built-in, no key, unavailable in the desktop webview
 
-Selection: a configured local server wins, then Groq, then Web Speech.
+Selection: a configured local server wins, then Groq, then OpenAI, then Web Speech.
 
 ### Memory System
 
@@ -192,7 +193,7 @@ Three-tier memory architecture for context and recall.
 3. **Sessions** — Conversation summaries for long-term context
 
 **Semantic search:**
-Uses `@xenova/transformers` to run the `all-MiniLM-L6-v2` embedding model locally on the user's device. Facts are embedded as 384-dimensional vectors and can be retrieved by cosine similarity to the current conversation.
+Uses `@xenova/transformers` to run the multilingual `paraphrase-multilingual-MiniLM-L12-v2` embedding model locally on the user's device. Facts are embedded as 384-dimensional vectors and can be retrieved by cosine similarity to the current conversation.
 
 See [Companion System](/docs/technology/companion-system) and [Memory Graph](/docs/technology/memory-graph) for detailed memory documentation.
 
@@ -232,6 +233,7 @@ All data persists client-side via IndexedDB using Dexie.js.
 - `sessions` — Conversation session summaries
 - `conversationTurns` — Conversation history
 - `completedEvents` — Milestone events that have fired
+- `reminders` — Scheduled tasks and timers with their fired/dismissed state
 
 **Key file:** `src/lib/db/index.ts`
 
@@ -252,12 +254,14 @@ src/
 │   │   ├── docs/          # Documentation site components
 │   │   ├── events/        # Event scene and choice UI
 │   │   ├── icons/         # Icon components
-│   │   ├── layout/        # App layout components
+│   │   ├── marketing/     # Landing page components
 │   │   ├── memory/        # Memory graph visualization
 │   │   ├── onboarding/    # First-run setup
 │   │   ├── overlay/       # Desktop overlay UI
+│   │   ├── photomode/     # Photo mode panel, stickers, frame preview
 │   │   ├── settings/      # Settings page components
 │   │   ├── ui/            # Shared UI primitives
+│   │   ├── updater/       # Desktop auto-update UI
 │   │   └── vrm/           # 3D scene and model
 │   ├── config/            # App and docs configuration
 │   ├── data/              # Static data (event definitions)

--- a/src/content/docs/technology/companion-system.md
+++ b/src/content/docs/technology/companion-system.md
@@ -139,7 +139,7 @@ type RelationshipStage =
 Facts are indexed using vector embeddings for semantic similarity search. Instead of keyword matching, the system finds facts by meaning — "outdoor activities" can retrieve memories about hiking even without shared words.
 
 **How it works:**
-- Uses Transformers.js with the `all-MiniLM-L6-v2` model (~23MB, runs locally)
+- Uses Transformers.js with the multilingual `paraphrase-multilingual-MiniLM-L12-v2` model (runs locally; works across languages, not just English)
 - Embeddings are 384-dimensional vectors stored alongside facts in IndexedDB
 - On query, the user message is embedded and compared using cosine similarity
 - Results ranked by blending semantic similarity (70%) with importance score (30%), minimum similarity 0.3

--- a/src/content/docs/technology/memory-graph.md
+++ b/src/content/docs/technology/memory-graph.md
@@ -49,7 +49,7 @@ Click "Reset View" to zoom out and see the full graph, clearing any selection.
 
 ## Technical Details
 
-The Memory Graph uses **384-dimensional embeddings** (via Transformers.js with the all-MiniLM-L6-v2 model) to compute semantic relationships between memories. Memories with a **cosine similarity >= 0.5** are connected.
+The Memory Graph uses **384-dimensional embeddings** (via Transformers.js with the multilingual paraphrase-multilingual-MiniLM-L12-v2 model) to compute semantic relationships between memories. Memories with a **cosine similarity >= 0.5** are connected.
 
 **Reference Count** tracks how many times a memory has been retrieved during conversations — higher counts indicate memories that frequently inform responses.
 

--- a/src/lib/services/providers/registry.ts
+++ b/src/lib/services/providers/registry.ts
@@ -24,7 +24,7 @@ export interface ProviderMetadata {
 }
 
 // ============================================
-// LLM PROVIDERS (7 total)
+// LLM PROVIDERS (8 total)
 // ============================================
 
 export const LLM_PROVIDERS: ProviderMetadata[] = [


### PR DESCRIPTION
Accuracy-only pass over the README and docs site after 0.10.0. Fixes wrong instructions (camera button vs attach button, settings navigation, removed VRM-by-URL and Settings > Display which no longer exist), corrects the embedding model name in three places, the STT priority order in five, the LLM provider count, stale acknowledgments, and the project structure tree. No new content; feature documentation for the 0.8-0.10 wave lands in a follow-up PR.