### PR TITLE
docs: document the 0.8 to 0.10 feature wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@
 - **VRM Model Viewer**: Load and display VRM 3D avatar models with orbit controls, automatic camera framing per model, and live camera settings (zoom, height, field of view)
 - **Developer Tools**: Test VRM facial expressions and animations, or upload a temporary `.vrm` file for a non-persistent preview that reverts when you leave the page
 - **AR Mode**: On WebXR-capable devices (Android Chrome, headset browsers), place your companion on your real floor, drag her around, and pinch to resize
+- **Photo Mode**: Pose her from a pose library, set her expression, pick a background, add a color filter, vignette, or frame, drop draggable stickers on the shot, and capture in high resolution with a quick snap or self-timer. Head tracking keeps her eyes on your camera while she holds the pose
+- **Touch Reactions**: Tap her and she reacts with an expression and a physics ripple through hair and clothes. Reactions depend on where you tap and how close the two of you are
+- **Scene Backgrounds**: Swap the backdrop behind her for pastel gradients or cute patterns (dots, hearts, sparkles, stripes, gingham) right from the Controls panel; your pick persists
+- **Physics Intensity**: A Movement slider from Subtle to Lively scales how much her hair and outfit respond to motion, respecting each model's own rig tuning
 - **Model-Centric UI**: Full-screen 3D model with unobtrusive overlay controls
 - **3D Speech Bubbles**: Chat responses appear as bubbles that track the model's head in 3D space
 - **Chat Interface**: Bottom-centered input bar with streaming responses
@@ -317,6 +321,14 @@ pnpm tauri build  # Build desktop app installer
 - [x] In-app auto-updates for the desktop app
 - [x] Show companion images (multimodal vision) with a keepsake photo board
 - [x] Custom OpenAI-compatible LLM endpoint (OpenRouter, Together, Mistral, vLLM, LiteLLM, ...)
+- [x] AR mode on WebXR-capable devices
+- [x] Live camera settings (zoom, height, field of view) with per-overlay profiles
+- [x] Context window control with memory scaling and history truncation
+- [x] Reminders and timers with an alarm dropdown, multi-window aware
+- [x] Photo mode: poses, expressions, backgrounds, filters, frames, stickers, head tracking, high-res capture
+- [x] Relationship-staged touch reactions
+- [x] Persistent scene backgrounds (pastel gradients and patterns)
+- [x] Spring-bone physics intensity slider
 
 ### In Progress / Planned
 

--- a/src/content/docs/guides/desktop-guide.md
+++ b/src/content/docs/guides/desktop-guide.md
@@ -88,6 +88,9 @@ Overlay mode detaches your companion into a transparent, always-on-top window:
 - **Floating Chat**: Click the chat icon at the bottom to expand a chat input
 - **Speech Bubbles**: Responses appear in a docked dialog bubble above the bottom controls (the window moves around, so a head-tracking bubble would be unreadable)
 - **Status Indicator**: The mood/relationship status pill appears above the chat icon
+- **Resizable**: Drag the top-left corner tab to resize the overlay; the size is remembered across launches
+- **Lockable**: The lock button in the hover controls pins the overlay in place so clicks cannot drag it
+- **Overlay Camera**: The hover controls include a camera panel with zoom, height, and field-of-view sliders independent from the main window's framing
 
 #### Controls
 

--- a/src/content/docs/guides/web-guide.md
+++ b/src/content/docs/guides/web-guide.md
@@ -72,6 +72,38 @@ Selection is automatic by priority: a configured local server wins, then Groq, t
 
 See [Local STT Setup](/docs/guides/local-stt-setup) for running a local Whisper server.
 
+## Photo Mode
+
+Click the **camera button** (top left) to open Photo Mode. A compact tabbed panel appears in the corner:
+
+- **Camera** — lens (field of view) slider, a head-tracking toggle so she looks at your camera, a rule-of-thirds grid, and framing reset. Orbit, pan, and zoom freely while posing
+- **Pose** — hold a pose from the pose library, or Natural for her regular stance
+- **Face** — pick from the expressions your model actually ships
+- **Scene** — background presets (including transparent for stickers), color filters, a vignette, and polaroid or film frames
+- **Sticker** — drop stickers on the shot, drag to move, scroll to resize, double-click or use the list to remove
+
+Capture at high resolution, take a quick snap, or use the 3 second self-timer. What you see in the preview is exactly what the file contains. Captures download on the web app; they are kept out of the photoboard, which stays reserved for images you have shown her. Press Escape or the X to exit.
+
+## Reminders and Timers
+
+Ask her in chat: "remind me in 10 minutes to stretch." She schedules it, brings it up herself when it fires, and notices timers that came due while the app was closed. The alarm bell (top right) shows pending tasks and fired or missed reminders; dismissals persist. Reminders stay in sync between the main app and the desktop overlay.
+
+## Touch
+
+Tap her and she reacts: an expression and a small ripple through her hair and clothes. Where you tap matters, and so does your relationship stage; early on she is easily flustered, and warmer reactions come with closeness. A quick tap reacts; dragging orbits the camera and never triggers her.
+
+## Scene Controls
+
+The **Controls** panel (sliders icon, top right, then the camera icon) holds the scene:
+
+- **Camera** — zoom, height, and field of view sliders with a reset
+- **Background** — persistent scene backdrops: solids, pastel gradients (Sakura, Peach, Lavender, and more), and patterns (dots, hearts, sparkles, candy stripes, gingham)
+- **Physics** — a Movement intensity slider from Subtle to Lively that scales spring-bone motion (hair, skirts, ribbons) while respecting each model's own tuning
+
+## AR Mode
+
+On WebXR-capable devices (Android Chrome, headset browsers), the cube icon in the Controls cluster places your companion in your real space: put her on your floor, drag her around, and pinch to resize. Entering Photo Mode ends an AR session first; photos always compose against the regular scene.
+
 ## Data Management
 
 All data is stored locally on your device.

--- a/src/content/docs/technology/architecture.md
+++ b/src/content/docs/technology/architecture.md
@@ -223,6 +223,38 @@ $effect(() => {
 });
 ```
 
+### Photo Mode
+
+A studio inside the scene: poses, expressions, backgrounds, filters, frames, stickers, head tracking, and high-resolution capture.
+
+**Key files:**
+- `src/lib/stores/photomode.svelte.ts` — mode state, session-only lens override, capture options
+- `src/lib/services/poses.ts` — pose manifest loading (`/static/poses/manifest.json`) with cached VRMA animations; adding a pose is a data change
+- `src/lib/services/scene-backgrounds.ts` — shared background preset library: gradients as CSS values, patterns as procedurally drawn canvas tiles reused for the live preview and capture compositing
+- `src/lib/services/photo-capture.ts` — capture composite helpers (backgrounds, frames, vignette, stickers)
+- `src/lib/components/photomode/` — the tabbed panel, draggable sticker layer, and frame preview
+
+Captures render one supersampled frame in place (the canvas keeps its drawing buffer), then composite the background, filter, vignette, frame, and stickers on a 2D canvas so the saved PNG matches the preview exactly. Photo captures are stored under a separate keepsake kind and never appear on the photoboard.
+
+### Tap Reactions and Physics
+
+- `src/lib/services/photo-touch.ts` — buckets a raycast tap into a coarse touch zone by nearest humanoid bone
+- `src/lib/engine/photo-reactions.ts` — the data-driven reaction table keyed on zone and relationship tier; repeat taps escalate and cool down. This file is the single knob for tone tuning
+- `src/lib/engine/spring-physics.ts` — the physics intensity mapping (multipliers over each rig's authored spring values, clamped to stable ranges) and the frame-delta clamp that prevents spring-bone blowups after tab refocus
+
+Reactions work in the chat view and photo mode alike: an expression flash plus a decaying bone nudge that only the spring physics inherits.
+
+### Reminders and Scheduling
+
+Companion-scheduled tasks and timers, multi-window aware.
+
+**Key files:**
+- `src/lib/utils/reminders.ts` — reminder tag parsing (`[reminder:5min]...[/reminder]`), natural-language fallback extraction, and pure policy helpers
+- `src/lib/stores/reminders.svelte.ts` — the poll loop: fires due reminders, reports missed ones, coordinates across windows via `BroadcastChannel` with an atomic claim so the LLM reacts exactly once
+- `src/lib/services/chat/reminder-chat.ts` — delivers fired reminders through the chat pipeline as system events
+
+Fired reminders enter the prompt as an `<event>` layer rather than a user turn and skip all relationship-state mutation. See the Companion System doc for the systemEvent turn path.
+
 ### Storage Layer
 
 All data persists client-side via IndexedDB using Dexie.js.

--- a/src/content/docs/technology/companion-system.md
+++ b/src/content/docs/technology/companion-system.md
@@ -63,6 +63,7 @@ interface CharacterState {
   savedDatingSimStage?: RelationshipStage;
   personality: PersonalityProfile;
   lastInteraction: Date | null;
+  lastDecayAt?: Date | null;   // decay applies once per absence, not per reload
   firstMet: Date;
   daysKnown: number;
   totalInteractions: number;
@@ -166,6 +167,7 @@ interface Fact {
   createdAt: Date;
   lastAccessed?: Date;
   embedding?: number[];     // 384-dim vector
+  embeddingModel?: string;  // which model produced it; drives re-embedding on upgrades
 }
 ```
 
@@ -307,13 +309,21 @@ Events are organized by type (`milestone`, `random`, `scheduled`, `conditional`,
 
 ## Prompt Architecture
 
-The system prompt is built from 5 layers:
+The system prompt is built from up to 7 layers:
 
 1. **System** — Rules, output format, current time
 2. **Character** — Name, personality, background, speech patterns
 3. **Current State** — Mood, energy, relationship stage and stats, days known
 4. **Memory** — Recent conversation turns, relevant facts, session context
-5. **Instructions** — Stage-specific behavior guidance, JSON output format
+5. **Being Shown** *(optional)* — Present only when the user shows an image: frames the photo as something she is being shown in the moment, not a file attachment
+6. **Event** *(optional)* — Present only for system events such as a fired reminder: the trigger text arrives in an `<event>` block instead of a user turn
+7. **Instructions** — Stage-specific behavior guidance, JSON output format
+
+### System Events and Reminders
+
+Not every turn starts with the user. The companion can schedule reminders and timers, either by emitting a `[reminder:5min]content[/reminder]` tag in her reply or from natural phrasing like "remind me in 10 minutes" via a client-side fallback. Reminders persist in the `reminders` table, fire from a poll loop that survives reloads, and timers missed while the app was closed surface on the next launch.
+
+A fired reminder is delivered as a **system event**: the trigger text enters the prompt through the `<event>` layer instead of a fake user message, and the turn deliberately skips everything that would pretend the user spoke. Sentiment heuristics, baseline stat updates, streak and interaction counting, fact extraction, and event checks are all bypassed; her reply is still parsed, spoken through TTS, and can chain further reminders. Machine-generated turns can never advance the relationship or reset the away-time clock.
 
 ### Context Window and Memory Budget
 
@@ -453,6 +463,18 @@ db.version(3).stores({
   sessions: '++id, startedAt',
   conversationTurns: '++id, sessionId, createdAt',
   completedEvents: '++id, eventId, completedAt'
+});
+
+// v4: Reminders table for scheduled tasks and timers
+// v5: Compound index [executed+triggerAt] for efficient due/upcoming queries
+// v6: dismissed flag so fired reminders survive reloads until dismissed
+db.version(6).stores({
+  characterStates: '++id, updatedAt',
+  facts: '++id, category, importance, createdAt',
+  sessions: '++id, startedAt',
+  conversationTurns: '++id, sessionId, createdAt',
+  completedEvents: '++id, eventId, completedAt',
+  reminders: '++id, sessionId, triggerAt, executed, dismissed, [executed+triggerAt]'
 });
 ```
 


### PR DESCRIPTION
Follow-up to #120. That one fixed what the docs got wrong; this one adds what they were missing: Photo Mode, reminders, touch reactions, scene backgrounds, and the physics slider across the README, web guide, desktop guide, and both technology docs. The companion-system doc also gains the systemEvent turn path and the current v6 database schema.