### PR TITLE
refactor(tts): streaming pipeline with VoiceOrchestrator and queue tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 - **Show Her Photos**: Show your companion an image via the attach (paperclip) button in the chat bar or drag-and-drop. Vision-capable models (GPT-4o, Claude, Gemini, or local ones like LLaVA) actually see it and can remember the moment, and kept photos live on a scrapbook-style board. Images stay on your device and only ever reach vision-capable models
 - **LLM Integration**: Support for 8 LLM providers: OpenAI, Anthropic, Google, xAI, DeepSeek, Ollama, LM Studio, and any OpenAI-compatible endpoint (OpenRouter, Together, vLLM, ...)
 - **Local Model Discovery**: Ollama and LM Studio discover installed local models directly from your device
-- **Text-to-Speech**: Support for ElevenLabs and OpenAI TTS, plus local voices via any OpenAI-compatible server (Kokoro-FastAPI, openedai-speech)
+- **Text-to-Speech**: Support for ElevenLabs and OpenAI TTS, plus local voices via any OpenAI-compatible server (Kokoro-FastAPI, openedai-speech). Sentences are fetched in parallel with playback so gaps between sentences stay short
 - **Fully Local Option**: Run the whole stack offline — local LLM (Ollama/LM Studio), local TTS, and local Whisper STT — so nothing leaves your device
 - **Lip-sync**: Audio-driven mouth animation synced to TTS playback
 - **Animations**: VRMA-based idle and talking animations with automatic blinking

--- a/src/lib/services/tts/elevenlabs.test.ts
+++ b/src/lib/services/tts/elevenlabs.test.ts
@@ -1,0 +1,129 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+class MockAudioBufferSourceNode {
+	buffer: AudioBuffer | null = null;
+	onended: (() => void) | null = null;
+	playbackRate = { value: 1 };
+	start() {
+		setImmediate(() => this.onended?.());
+	}
+	stop() {}
+	connect() {
+		return this;
+	}
+	disconnect() {}
+}
+
+class MockAnalyserNode {
+	fftSize = 256;
+	connect() {
+		return this;
+	}
+	disconnect() {}
+	getByteFrequencyData() {}
+}
+
+class MockAudioContext {
+	state = 'running';
+	currentTime = 0;
+	destination = {};
+	createBufferSource() {
+		return new MockAudioBufferSourceNode() as unknown as AudioBufferSourceNode;
+	}
+	createAnalyser() {
+		return new MockAnalyserNode() as unknown as AnalyserNode;
+	}
+	createBuffer(numChannels: number, length: number, sampleRate: number) {
+		return {
+			duration: length / sampleRate,
+			getChannelData: () => new Float32Array(length),
+			numberOfChannels: numChannels,
+			sampleRate,
+			length
+		} as unknown as AudioBuffer;
+	}
+	async decodeAudioData() {
+		return this.createBuffer(1, 480, 48000);
+	}
+	resume() {
+		return Promise.resolve();
+	}
+}
+
+// @ts-expect-error globalThis.AudioContext is not available in Node test environment
+globalThis.AudioContext = MockAudioContext;
+
+import { ElevenLabsTTS } from './elevenlabs.ts';
+
+function parseBody(init?: RequestInit): Record<string, unknown> {
+	if (!init?.body) return {};
+	try {
+		return JSON.parse(init.body as string) as Record<string, unknown>;
+	} catch {
+		return {};
+	}
+}
+
+function mockFetchResponse() {
+	return Promise.resolve({
+		ok: true,
+		status: 200,
+		arrayBuffer: () => Promise.resolve(new ArrayBuffer(8))
+	} as Response);
+}
+
+test('fetchAudioBuffer sends the correct request shape', async () => {
+	const requests: { url: string; body: Record<string, unknown> }[] = [];
+	// @ts-expect-error global fetch mock
+	globalThis.fetch = (url: string, init: RequestInit) => {
+		requests.push({ url, body: parseBody(init) });
+		return mockFetchResponse();
+	};
+
+	const tts = new ElevenLabsTTS({
+		provider: 'elevenlabs',
+		apiKey: 'test-key',
+		voiceId: 'test-voice',
+		model: 'eleven_turbo_v2_5',
+		speed: 1.2
+	});
+
+	await tts.fetchAudioBuffer('Hello world.');
+
+	assert.equal(requests.length, 1);
+	assert.ok(requests[0].url.includes('/text-to-speech/test-voice/stream'));
+	assert.equal(requests[0].body.text, 'Hello world.');
+	assert.equal(requests[0].body.model_id, 'eleven_turbo_v2_5');
+	assert.equal((requests[0].body.voice_settings as Record<string, unknown>).stability, 0.5);
+	assert.equal(
+		(requests[0].body.voice_settings as Record<string, unknown>).similarity_boost,
+		0.75
+	);
+});
+
+test('speak returns a source and analyser', async () => {
+	globalThis.fetch = () => mockFetchResponse();
+
+	const tts = new ElevenLabsTTS({
+		provider: 'elevenlabs',
+		apiKey: 'test-key'
+	});
+
+	const result = await tts.speak('Hello world.');
+	assert.ok(result.source);
+	assert.ok(result.analyser);
+});
+
+test('speak applies client-side speed via playbackRate', async () => {
+	globalThis.fetch = () => mockFetchResponse();
+
+	const tts = new ElevenLabsTTS({
+		provider: 'elevenlabs',
+		apiKey: 'test-key',
+		speed: 1.3
+	});
+
+	const result = await tts.speak('Hello world.');
+	assert.equal((result.source as unknown as { playbackRate: { value: number } }).playbackRate.value, 1.3);
+});

--- a/src/lib/services/tts/elevenlabs.ts
+++ b/src/lib/services/tts/elevenlabs.ts
@@ -1,5 +1,11 @@
-import { getSharedAudioContext, type ITTSProvider, type TTSOptions, type TTSSpeakResult } from './index';
-import { providerErrorMessage } from './provider-utils';
+import {
+	getSharedAudioContext,
+	type ITTSProvider,
+	type TTSOptions,
+	type TTSSpeakResult,
+	type StreamOptions
+} from './index.ts';
+import { providerErrorMessage } from './provider-utils.ts';
 
 function ensureTrailingSlash(url: string): string {
 	return url.endsWith('/') ? url : url + '/';
@@ -11,6 +17,13 @@ export class ElevenLabsTTS implements ITTSProvider {
 	private model: string;
 	private speed: number;
 	private baseUrl: string;
+
+	readonly capabilities = {
+		streaming: false,
+		emotion: false,
+		multilingual: true,
+		clientSideSpeed: true
+	};
 
 	constructor(options: TTSOptions) {
 		this.apiKey = options.apiKey || '';
@@ -25,6 +38,11 @@ export class ElevenLabsTTS implements ITTSProvider {
 	}
 
 	async speak(text: string): Promise<TTSSpeakResult> {
+		const audioBuffer = await this.fetchAudioBuffer(text);
+		return this.playAudioBuffer(audioBuffer);
+	}
+
+	async fetchAudioBuffer(text: string, options?: StreamOptions): Promise<AudioBuffer> {
 		const response = await fetch(
 			`${this.baseUrl}text-to-speech/${this.voiceId}/stream`,
 			{
@@ -40,7 +58,8 @@ export class ElevenLabsTTS implements ITTSProvider {
 						stability: 0.5,
 						similarity_boost: 0.75
 					}
-				})
+				}),
+				signal: options?.signal
 			}
 		);
 
@@ -64,22 +83,22 @@ export class ElevenLabsTTS implements ITTSProvider {
 			await audioContext.resume();
 		}
 
-		const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+		return audioContext.decodeAudioData(arrayBuffer);
+	}
 
-		// Create source node
+	private playAudioBuffer(audioBuffer: AudioBuffer): TTSSpeakResult {
+		const audioContext = this.getAudioContext();
+
 		const source = audioContext.createBufferSource();
 		source.buffer = audioBuffer;
 		source.playbackRate.value = this.speed;
 
-		// Create analyser for lip-sync
 		const analyser = audioContext.createAnalyser();
 		analyser.fftSize = 256;
 
-		// Connect nodes
 		source.connect(analyser);
 		analyser.connect(audioContext.destination);
 
-		// Start playback
 		source.start(0);
 
 		return { source, analyser };

--- a/src/lib/services/tts/index.ts
+++ b/src/lib/services/tts/index.ts
@@ -10,6 +10,12 @@ export interface TTSOptions {
 	speed?: number;
 	pitch?: number;
 	volume?: number;
+	/** Primary language for multilingual TTS. */
+	language?: string;
+	/** Alternative language that triggers the alternative voice. */
+	altLanguage?: string;
+	/** Voice ID used when the alternative language is active. */
+	altVoiceId?: string;
 }
 
 // Result from TTS speak method
@@ -18,10 +24,49 @@ export interface TTSSpeakResult {
 	analyser: AnalyserNode;
 }
 
+// Per-request options that can override session-level TTS options for a single
+// segment (e.g. alternative language/voice or emotion-specific tuning).
+export interface StreamOptions {
+	voiceId?: string;
+	language?: string;
+	emotion?: string;
+	exaggeration?: number;
+	cfgWeight?: number;
+	temperature?: number;
+	speed?: number;
+	pitch?: number;
+	volume?: number;
+	signal?: AbortSignal;
+}
+
+// Chunk yielded by streaming TTS providers. `done` marks the end of the stream.
+export interface AudioChunk {
+	data: ArrayBuffer;
+	done: boolean;
+}
+
+// Capability flags advertised by a TTS provider.
+export interface TTSCapabilities {
+	streaming?: boolean;
+	emotion?: boolean;
+	multilingual?: boolean;
+	// Maximum number of concurrent synthesis requests; Infinity if unspecified.
+	maxConcurrentSynthesis?: number;
+	// True if this provider ignores the speed parameter server-side and the
+	// orchestrator must apply it via AudioBufferSourceNode.playbackRate.
+	clientSideSpeed?: boolean;
+}
+
 // Base TTS provider interface
 export interface ITTSProvider {
 	speak(text: string): Promise<TTSSpeakResult>;
+	/** Fetch a full AudioBuffer for non-streaming pipelining. */
+	fetchAudioBuffer?(text: string, options?: StreamOptions): Promise<AudioBuffer>;
+	/** Optional true streaming: yields audio chunks as they arrive. */
+	speakStreaming?(text: string, options?: StreamOptions): AsyncGenerator<AudioChunk>;
 	getAudioContext(): AudioContext;
+	/** Capability flags used by the orchestrator to choose the right path. */
+	capabilities?: TTSCapabilities;
 }
 
 // Shared audio context for all providers
@@ -35,8 +80,8 @@ export function getSharedAudioContext(): AudioContext {
 }
 
 // Import individual providers
-import { ElevenLabsTTS } from './elevenlabs';
-import { OpenAITTS } from './openai-tts';
+import { ElevenLabsTTS } from './elevenlabs.ts';
+import { OpenAITTS } from './openai-tts.ts';
 
 // Provider factory
 let currentProvider: ITTSProvider | null = null;

--- a/src/lib/services/tts/openai-tts.ts
+++ b/src/lib/services/tts/openai-tts.ts
@@ -1,10 +1,16 @@
-import { getSharedAudioContext, type ITTSProvider, type TTSOptions, type TTSSpeakResult } from './index';
+import {
+	getSharedAudioContext,
+	type ITTSProvider,
+	type TTSOptions,
+	type TTSSpeakResult,
+	type StreamOptions
+} from './index.ts';
 import {
 	getTTSBaseUrl,
 	getLocalTTSConnectionHint,
 	isLocalTTSProvider
-} from '$lib/services/providers/local-endpoints';
-import { providerErrorMessage } from './provider-utils';
+} from '../providers/local-endpoints.ts';
+import { providerErrorMessage } from './provider-utils.ts';
 
 function ensureTrailingSlash(url: string): string {
 	return url.endsWith('/') ? url : url + '/';
@@ -25,6 +31,12 @@ export class OpenAITTS implements ITTSProvider {
 	private baseUrl: string;
 	private isLocal: boolean;
 
+	readonly capabilities = {
+		streaming: false,
+		emotion: false,
+		multilingual: false
+	};
+
 	constructor(options: TTSOptions) {
 		this.apiKey = options.apiKey || '';
 		this.voiceId = options.voiceId || 'alloy';
@@ -41,6 +53,11 @@ export class OpenAITTS implements ITTSProvider {
 	}
 
 	async speak(text: string): Promise<TTSSpeakResult> {
+		const audioBuffer = await this.fetchAudioBuffer(text);
+		return this.playAudioBuffer(audioBuffer);
+	}
+
+	async fetchAudioBuffer(text: string, options?: StreamOptions): Promise<AudioBuffer> {
 		const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 		// Local servers don't need a key; only send auth when we actually have one.
 		if (this.apiKey) {
@@ -56,9 +73,10 @@ export class OpenAITTS implements ITTSProvider {
 					model: this.model,
 					input: text,
 					voice: this.voiceId,
-					speed: this.speed,
+					speed: options?.speed ?? this.speed,
 					response_format: 'mp3'
-				})
+				}),
+				signal: options?.signal
 			});
 		} catch (err) {
 			// A thrown fetch is usually a refused connection or a CORS block, which
@@ -91,7 +109,11 @@ export class OpenAITTS implements ITTSProvider {
 			await audioContext.resume();
 		}
 
-		const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+		return audioContext.decodeAudioData(arrayBuffer);
+	}
+
+	private playAudioBuffer(audioBuffer: AudioBuffer): TTSSpeakResult {
+		const audioContext = this.getAudioContext();
 
 		const source = audioContext.createBufferSource();
 		source.buffer = audioBuffer;

--- a/src/lib/services/tts/streaming-speech-buffer.test.ts
+++ b/src/lib/services/tts/streaming-speech-buffer.test.ts
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { StreamingSpeechBuffer } from './streaming-speech-buffer.ts';
+
+function createBuffer() {
+	const segments: { text: string; language?: string }[] = [];
+	const buffer = new StreamingSpeechBuffer({
+		defaultLanguage: 'en',
+		onSegment: (seg) => segments.push(seg)
+	});
+	return { buffer, segments };
+}
+
+test('emits a complete sentence immediately', () => {
+	const { buffer, segments } = createBuffer();
+	buffer.feed('Hello world.');
+	assert.equal(segments.length, 1);
+	assert.equal(segments[0].text, 'Hello world.');
+});
+
+test('emits multiple sentences from one chunk', () => {
+	const { buffer, segments } = createBuffer();
+	buffer.feed('First sentence. Second sentence.');
+	assert.equal(segments.length, 2);
+	assert.equal(segments[0].text, 'First sentence.');
+	assert.equal(segments[1].text, 'Second sentence.');
+});
+
+test('buffers partial sentences until a terminator arrives', () => {
+	const { buffer, segments } = createBuffer();
+	buffer.feed('Hello ');
+	assert.equal(segments.length, 0);
+	buffer.feed('world.');
+	assert.equal(segments.length, 1);
+	assert.equal(segments[0].text, 'Hello world.');
+});
+
+test('flushes remaining text without a terminator', () => {
+	const { buffer, segments } = createBuffer();
+	buffer.feed('No terminator here');
+	assert.equal(segments.length, 0);
+	buffer.flush();
+	assert.equal(segments.length, 1);
+	assert.equal(segments[0].text, 'No terminator here');
+});
+
+test('splits at paragraph breaks', () => {
+	const { buffer, segments } = createBuffer();
+	buffer.feed('Paragraph one.\n\nParagraph two.');
+	assert.equal(segments.length, 2);
+	assert.equal(segments[0].text, 'Paragraph one.');
+	assert.equal(segments[1].text, 'Paragraph two.');
+});
+
+test('does not emit while inside an open JSON block', () => {
+	const { buffer, segments } = createBuffer();
+	buffer.feed('Hello. {"mood_change":');
+	assert.equal(segments.length, 1);
+	assert.equal(segments[0].text, 'Hello.');
+	buffer.feed('{"emotion":"happy"}} Goodbye.');
+	assert.equal(segments.length, 2);
+	assert.equal(segments[1].text, 'Goodbye.');
+});
+
+test('reset clears pending text', () => {
+	const { buffer, segments } = createBuffer();
+	buffer.feed('Pending');
+	buffer.reset();
+	buffer.flush();
+	assert.equal(segments.length, 0);
+});
+
+test('skips segments containing only punctuation and whitespace', () => {
+	const { buffer, segments } = createBuffer();
+	buffer.feed('   ');
+	buffer.flush();
+	assert.equal(segments.length, 0);
+});

--- a/src/lib/services/tts/streaming-speech-buffer.ts
+++ b/src/lib/services/tts/streaming-speech-buffer.ts
@@ -1,0 +1,156 @@
+import type { SpeechSegment } from '../voice-orchestrator.ts';
+import { splitIntoSegments, stripSpeechArtifacts, stripForSpeech } from '../../utils/sentences.ts';
+
+export interface StreamingSpeechBufferOptions {
+	defaultLanguage?: string;
+	streaming?: boolean;
+	onSegment: (segment: SpeechSegment) => void;
+}
+
+/**
+ * Buffers streaming LLM text and emits SpeechSegments as soon as complete
+ * sentences are available. A flush timer ensures trailing text without a
+ * sentence terminator is still emitted after a short timeout.
+ */
+export class StreamingSpeechBuffer {
+	private buffer = '';
+	private emittedLength = 0;
+	// Tracks depth of curly braces so JSON state-update blocks that span
+	// multiple streaming chunks are held back from TTS until fully received.
+	private jsonDepth = 0;
+	private flushTimer: ReturnType<typeof setTimeout> | null = null;
+	private readonly FLUSH_TIMEOUT_MS = 1500;
+	private readonly options: StreamingSpeechBufferOptions;
+
+	constructor(options: StreamingSpeechBufferOptions) {
+		this.options = options;
+	}
+
+	feed(chunk: string): void {
+		// Track curly-brace depth across chunks so we never emit text that is
+		// inside an open JSON state-update block.
+		for (const ch of chunk) {
+			if (ch === '{') this.jsonDepth++;
+			else if (ch === '}') this.jsonDepth--;
+		}
+		this.buffer += chunk;
+		this.tryEmit();
+		this.armFlushTimer();
+	}
+
+	flush(): void {
+		let remaining = this.buffer.slice(this.emittedLength).trim();
+		if (!remaining) return;
+
+		const { cleaned } = stripForSpeech(remaining);
+		remaining = cleaned.trim();
+		if (!remaining) {
+			this.emittedLength = this.buffer.length;
+			this.jsonDepth = 0;
+			return;
+		}
+
+		for (const seg of splitIntoSegments(remaining, this.options.defaultLanguage)) {
+			this.options.onSegment(seg);
+		}
+		this.emittedLength = this.buffer.length;
+		this.jsonDepth = 0;
+	}
+
+	reset(): void {
+		this.buffer = '';
+		this.emittedLength = 0;
+		this.jsonDepth = 0;
+		this.clearFlushTimer();
+	}
+
+	private tryEmit(): void {
+		this.clearFlushTimer();
+
+		let unprocessed = this.buffer.slice(this.emittedLength);
+		while (unprocessed.length > 0) {
+			const before = this.emittedLength;
+			this.tryEmitBlock(unprocessed);
+			if (this.emittedLength === before) break; // no sentence boundary found
+			unprocessed = this.buffer.slice(this.emittedLength);
+		}
+
+		if (this.emittedLength < this.buffer.length) {
+			this.armFlushTimer();
+		}
+	}
+
+	private armFlushTimer(): void {
+		if (this.flushTimer) return;
+		this.flushTimer = setTimeout(() => {
+			this.flushTimer = null;
+			this.flush();
+		}, this.FLUSH_TIMEOUT_MS);
+	}
+
+	private clearFlushTimer(): void {
+		if (this.flushTimer) {
+			clearTimeout(this.flushTimer);
+			this.flushTimer = null;
+		}
+	}
+
+	private emit(block: string): void {
+		const { cleaned } = stripForSpeech(block);
+		for (const seg of splitIntoSegments(cleaned, this.options.defaultLanguage)) {
+			this.options.onSegment(seg);
+		}
+	}
+
+	private tryEmitBlock(text: string): void {
+		// While we are inside an open JSON state-update block, do not emit anything
+		// that follows the opening brace. Content before the brace is still safe to
+		// emit (e.g. a completed sentence before a state-update block starts).
+		if (this.jsonDepth > 0) {
+			const braceIndex = text.indexOf('{');
+			if (braceIndex <= 0) return;
+			text = text.slice(0, braceIndex);
+		}
+
+		// Strip any completed JSON state-update block(s) from the current tail.
+		// Use the non-trimming variant so trailing whitespace is preserved for the
+		// next streaming chunk.
+		const { cleaned } = stripSpeechArtifacts(text);
+		if (cleaned !== text) {
+			this.buffer = this.buffer.slice(0, this.emittedLength) + cleaned;
+			text = cleaned;
+		}
+
+		const paraBreak = text.indexOf('\n\n');
+		if (paraBreak > 0) {
+			const block = text.slice(0, paraBreak);
+			if (block.trim()) {
+				this.emit(block);
+				this.emittedLength += paraBreak + 2;
+			}
+			return;
+		}
+
+		const singleBreak = text.indexOf('\n');
+		if (singleBreak > 0) {
+			const block = text.slice(0, singleBreak);
+			if (block.trim()) {
+				this.emit(block);
+				this.emittedLength += singleBreak + 1;
+			}
+			return;
+		}
+
+		// Emit up to the first sentence boundary so TTS can start immediately.
+		const sentenceEnd = /([.!?…])(\s+|$)/;
+		const m = sentenceEnd.exec(text);
+		if (!m) return;
+
+		const firstEnd = m.index + m[0].length;
+		const block = text.slice(0, firstEnd);
+		if (block.trim()) {
+			this.emit(block);
+			this.emittedLength += firstEnd;
+		}
+	}
+}

--- a/src/lib/services/voice-orchestrator.test.ts
+++ b/src/lib/services/voice-orchestrator.test.ts
@@ -1,0 +1,146 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Mock the browser AudioContext before importing the orchestrator.
+class MockAudioBufferSourceNode {
+	buffer: AudioBuffer | null = null;
+	onended: (() => void) | null = null;
+	start() {
+		// Simulate immediate playback completion on the next tick.
+		setImmediate(() => this.onended?.());
+	}
+	stop() {}
+	connect() {
+		return this;
+	}
+	disconnect() {}
+}
+
+class MockAnalyserNode {
+	fftSize = 256;
+	connect() {
+		return this;
+	}
+	disconnect() {}
+	getByteFrequencyData() {}
+}
+
+class MockAudioContext {
+	state = 'running';
+	currentTime = 0;
+	destination = {};
+	createBufferSource() {
+		return new MockAudioBufferSourceNode() as unknown as AudioBufferSourceNode;
+	}
+	createAnalyser() {
+		return new MockAnalyserNode() as unknown as AnalyserNode;
+	}
+	createBuffer(numChannels: number, length: number, sampleRate: number) {
+		return {
+			duration: length / sampleRate,
+			getChannelData: () => new Float32Array(length),
+			numberOfChannels: numChannels,
+			sampleRate,
+			length
+		} as unknown as AudioBuffer;
+	}
+	async decodeAudioData(buffer: ArrayBuffer) {
+		return this.createBuffer(1, 480, 48000);
+	}
+	resume() {
+		return Promise.resolve();
+	}
+}
+
+// @ts-expect-error globalThis.AudioContext is not available in Node test environment
+globalThis.AudioContext = MockAudioContext;
+
+import { VoiceOrchestrator, type SpeechSegment } from './voice-orchestrator.ts';
+import type { TTSOptions } from './tts/index.ts';
+
+const baseOptions: TTSOptions = { provider: 'openai-tts', apiKey: 'test-key' };
+
+function mockFetchResponse() {
+	return Promise.resolve({
+		ok: true,
+		status: 200,
+		arrayBuffer: () => Promise.resolve(new ArrayBuffer(8))
+	} as Response);
+}
+
+function parseBody(init?: RequestInit): Record<string, unknown> {
+	if (!init?.body) return {};
+	try {
+		return JSON.parse(init.body as string) as Record<string, unknown>;
+	} catch {
+		return {};
+	}
+}
+
+test('speakSegments plays all segments and fires onSegmentStart for each', async () => {
+	const fetchCalls: { url: string; body: Record<string, unknown> }[] = [];
+	// @ts-expect-error global fetch mock
+	globalThis.fetch = (url: string, init: RequestInit) => {
+		fetchCalls.push({ url, body: parseBody(init) });
+		return mockFetchResponse();
+	};
+
+	const orchestrator = new VoiceOrchestrator();
+	const starts: string[] = [];
+	const segments: SpeechSegment[] = [
+		{ text: 'First sentence.' },
+		{ text: 'Second sentence.' }
+	];
+
+	let complete = false;
+	await orchestrator.speakSegments(segments, baseOptions, {
+		onSegmentStart: (seg) => starts.push(seg.text),
+		onComplete: () => {
+			complete = true;
+		}
+	});
+
+	assert.equal(fetchCalls.length, 2);
+	assert.equal(fetchCalls[0].body.input, 'First sentence.');
+	assert.equal(fetchCalls[1].body.input, 'Second sentence.');
+	assert.deepEqual(starts, ['First sentence.', 'Second sentence.']);
+	assert.equal(complete, true);
+});
+
+test('skips empty or punctuation-only segments', async () => {
+	globalThis.fetch = () => mockFetchResponse();
+
+	const orchestrator = new VoiceOrchestrator();
+	const starts: string[] = [];
+	const segments: SpeechSegment[] = [
+		{ text: 'Hello.' },
+		{ text: '   ' },
+		{ text: '!!!' },
+		{ text: 'Goodbye.' }
+	];
+
+	await orchestrator.speakSegments(segments, baseOptions, {
+		onSegmentStart: (seg) => starts.push(seg.text)
+	});
+
+	assert.deepEqual(starts, ['Hello.', 'Goodbye.']);
+});
+
+test('interrupt stops playback and onComplete fires', async () => {
+	globalThis.fetch = () => mockFetchResponse();
+
+	const orchestrator = new VoiceOrchestrator();
+	let complete = false;
+
+	orchestrator.beginSession(baseOptions, {
+		onComplete: () => {
+			complete = true;
+		}
+	});
+	orchestrator.pushSegment({ text: 'A long sentence that gets interrupted.' });
+	orchestrator.interrupt();
+
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(complete, true);
+	assert.equal(orchestrator.getIsPlaying(), false);
+});

--- a/src/lib/services/voice-orchestrator.test.ts
+++ b/src/lib/services/voice-orchestrator.test.ts
@@ -126,6 +126,64 @@ test('skips empty or punctuation-only segments', async () => {
 	assert.deepEqual(starts, ['Hello.', 'Goodbye.']);
 });
 
+test('caps parallel synthesis when the provider declares no limit', async () => {
+	let inFlight = 0;
+	let maxInFlight = 0;
+	globalThis.fetch = async () => {
+		inFlight++;
+		maxInFlight = Math.max(maxInFlight, inFlight);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		inFlight--;
+		return {
+			ok: true,
+			status: 200,
+			arrayBuffer: () => Promise.resolve(new ArrayBuffer(8))
+		} as Response;
+	};
+
+	const orchestrator = new VoiceOrchestrator();
+	const segments: SpeechSegment[] = Array.from({ length: 6 }, (_, i) => ({
+		text: `Sentence number ${i + 1}.`
+	}));
+
+	await orchestrator.speakSegments(segments, baseOptions, {});
+
+	// Cloud providers enforce per-plan concurrency caps (ElevenLabs Free allows 2),
+	// so an uncapped fan-out turns an ordinary reply into a 429 storm.
+	assert.ok(
+		maxInFlight <= 2,
+		`expected at most 2 parallel synthesis requests, saw ${maxInFlight}`
+	);
+});
+
+test('speakSegments rejects when a segment fails so the store can surface it', async () => {
+	let call = 0;
+	globalThis.fetch = () => {
+		call++;
+		if (call === 2) {
+			return Promise.resolve({
+				ok: false,
+				status: 429,
+				json: () => Promise.reject(new Error('no body'))
+			} as unknown as Response);
+		}
+		return mockFetchResponse();
+	};
+
+	const orchestrator = new VoiceOrchestrator();
+	const starts: string[] = [];
+	const segments: SpeechSegment[] = [{ text: 'One.' }, { text: 'Two.' }, { text: 'Three.' }];
+
+	await assert.rejects(
+		orchestrator.speakSegments(segments, baseOptions, {
+			onSegmentStart: (seg) => starts.push(seg.text)
+		}),
+		/429/
+	);
+	// The surviving segments still play; the failure is reported, not swallowed.
+	assert.deepEqual(starts, ['One.', 'Three.']);
+});
+
 test('interrupt stops playback and onComplete fires', async () => {
 	globalThis.fetch = () => mockFetchResponse();
 

--- a/src/lib/services/voice-orchestrator.ts
+++ b/src/lib/services/voice-orchestrator.ts
@@ -44,6 +44,11 @@ export interface OrchestratorCallbacks {
 	onAction?: (action: string) => void;
 }
 
+// Cloud TTS plans commonly cap concurrent synthesis (ElevenLabs Free allows 2),
+// and the pipeline only needs to stay one segment ahead of playback anyway.
+// Providers that tolerate more can raise this via capabilities.maxConcurrentSynthesis.
+const DEFAULT_MAX_CONCURRENT_SYNTHESIS = 2;
+
 // ---------------------------------------------------------------------------
 // Simple counting semaphore for limiting parallel TTS synthesis requests
 // ---------------------------------------------------------------------------
@@ -161,8 +166,10 @@ export class VoiceOrchestrator {
 	private inferredPrimaryLang: string | undefined = undefined;
 	private lastSegmentLang: string | undefined = undefined;
 	private pipelineDoneResolve: (() => void) | null = null;
+	private pipelineDoneReject: ((err: unknown) => void) | null = null;
 	private pipelineDone: Promise<void> = Promise.resolve();
 	private pipelineDoneResolved = true;
+	private pipelineErrors: unknown[] = [];
 
 	// Limits parallel TTS synthesis requests (important for single-GPU diffusion models)
 	private synthesisLimiter = new Semaphore(Infinity);
@@ -212,11 +219,13 @@ export class VoiceOrchestrator {
 
 		// Apply provider-specific concurrency limit (e.g. OmniVoice = 2)
 		const provider = getTTSProvider(options);
-		const limit = provider.capabilities?.maxConcurrentSynthesis ?? Infinity;
+		const limit = provider.capabilities?.maxConcurrentSynthesis ?? DEFAULT_MAX_CONCURRENT_SYNTHESIS;
 		this.synthesisLimiter.drainAndReset(limit);
+		this.pipelineErrors = [];
 		this.pipelineDoneResolved = false;
-		this.pipelineDone = new Promise<void>((resolve) => {
+		this.pipelineDone = new Promise<void>((resolve, reject) => {
 			this.pipelineDoneResolve = resolve;
+			this.pipelineDoneReject = reject;
 		});
 
 		// Start the async pipeline runner (fire-and-forget; resolves pipelineDone)
@@ -276,6 +285,9 @@ export class VoiceOrchestrator {
 
 		// Non-streaming providers: batch path (prefetch while previous segment plays)
 		const bufferPromise = this.fetchBuffer(provider, segment, signal);
+		// runPipeline awaits this later; the no-op catch just keeps a fast rejection
+		// from surfacing as an unhandled-rejection warning in the meantime.
+		bufferPromise.catch(() => {});
 		this.channel.push({ segment, index, bufferPromise });
 	}
 
@@ -338,6 +350,16 @@ export class VoiceOrchestrator {
 			this.pipelineDoneResolved = true;
 			this.pipelineDoneResolve?.();
 			this.pipelineDoneResolve = null;
+			this.pipelineDoneReject = null;
+		}
+	}
+
+	private rejectPipeline(err: unknown): void {
+		if (!this.pipelineDoneResolved) {
+			this.pipelineDoneResolved = true;
+			this.pipelineDoneReject?.(err);
+			this.pipelineDoneResolve = null;
+			this.pipelineDoneReject = null;
 		}
 	}
 
@@ -372,7 +394,10 @@ export class VoiceOrchestrator {
 						item.segment.text,
 						err
 					);
-					continue; // skip this segment
+					// Keep playing the remaining segments, but remember the failure so
+					// the session promise rejects and the store can show its toast.
+					this.pipelineErrors.push(err);
+					continue;
 				}
 
 				if (!buffer || this.pipelineAbort?.signal.aborted) continue;
@@ -390,7 +415,14 @@ export class VoiceOrchestrator {
 			this.currentAnalyser = null;
 			callbacks?.onEmotionChange?.(null);
 			callbacks?.onComplete?.();
-			this.resolvePipeline();
+			const firstError = this.pipelineErrors[0];
+			if (firstError !== undefined && !this.pipelineAbort?.signal.aborted) {
+				this.rejectPipeline(
+					firstError instanceof Error ? firstError : new Error(String(firstError))
+				);
+			} else {
+				this.resolvePipeline();
+			}
 		}
 	}
 
@@ -480,6 +512,11 @@ export class VoiceOrchestrator {
 			source.onended = () => resolve();
 			source.start(0);
 		});
+
+		// One analyser is created per segment; leaving them connected to the
+		// destination accumulates nodes on the shared context over a session.
+		source.disconnect();
+		analyser.disconnect();
 	}
 
 	/**

--- a/src/lib/services/voice-orchestrator.ts
+++ b/src/lib/services/voice-orchestrator.ts
@@ -1,0 +1,697 @@
+import {
+	getTTSProvider,
+	getSharedAudioContext,
+	type TTSOptions,
+	type StreamOptions,
+	type ITTSProvider
+} from './tts/index.ts';
+
+/**
+ * Metadata attached to each speech segment by the response parser.
+ * Fields beyond `text` are optional and only used by capable providers.
+ */
+export interface SpeechSegment {
+	text: string;
+	/** Emotion style hint forwarded to TTS (e.g. 'happy', 'sad') */
+	emotion?: string;
+	/** Emotion intensity 0.0-1.0 */
+	exaggeration?: number;
+	/** ISO 639-1 language code for multilingual switching */
+	language?: string;
+	/** VRM body action to trigger (e.g. wave, nod, jump) */
+	action?: string;
+	/** Optional speech speed override */
+	speed?: number;
+	/** Optional pitch override (formant shift multiplier) */
+	pitch?: number;
+	/** Optional volume override (gain multiplier) */
+	volume?: number;
+	/** Voice selector: 'default' | 'alt' | literal voice ID. Resolved by orchestrator. */
+	voiceId?: string;
+}
+
+/** Callbacks the orchestrator fires so the UI can react synchronously. */
+export interface OrchestratorCallbacks {
+	/** Fired when a segment starts playing - for speech bubble sync */
+	onSegmentStart?: (segment: SpeechSegment, index: number) => void;
+	/** Fired when all segments have finished */
+	onComplete?: () => void;
+	/** Fired continuously with analyser data for lip-sync */
+	onAnalyserUpdate?: (analyser: AnalyserNode) => void;
+	/** Fired when a segment with an emotion tag starts */
+	onEmotionChange?: (emotion: string | null) => void;
+	/** Fired when a segment has an [action:xxx] tag */
+	onAction?: (action: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Simple counting semaphore for limiting parallel TTS synthesis requests
+// ---------------------------------------------------------------------------
+
+class Semaphore {
+	private slots: number;
+	private queue: (() => void)[] = [];
+
+	constructor(limit: number) {
+		this.slots = limit;
+	}
+
+	acquire(): Promise<void> {
+		if (this.slots > 0) {
+			this.slots--;
+			return Promise.resolve();
+		}
+		return new Promise<void>((resolve) => this.queue.push(resolve));
+	}
+
+	release(): void {
+		const next = this.queue.shift();
+		if (next) {
+			next();
+		} else {
+			this.slots++;
+		}
+	}
+
+	/** Drain pending waiters (e.g. on interrupt) so they can check abort state. */
+	drainAndReset(limit: number): void {
+		this.slots = limit;
+		const pending = this.queue.splice(0);
+		for (const w of pending) w();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal async producer-consumer queue for the pipeline
+// ---------------------------------------------------------------------------
+
+interface PipelineItem {
+	segment: SpeechSegment;
+	index: number;
+	/** Batch path: resolves to the decoded AudioBuffer once synthesis is complete */
+	bufferPromise?: Promise<AudioBuffer | null>;
+	/** Streaming path: called when the runner is ready to play this segment */
+	streamPlay?: (callbacks?: OrchestratorCallbacks) => Promise<void>;
+}
+
+/**
+ * Lightweight single-consumer async queue.
+ * push() adds items; close() signals the end of the stream.
+ * next() returns the next item or null when the queue is closed and drained.
+ */
+class PipelineQueue {
+	private queue: PipelineItem[] = [];
+	private waiter: ((item: PipelineItem | null) => void) | null = null;
+	private closed = false;
+
+	push(item: PipelineItem): void {
+		if (this.waiter) {
+			const w = this.waiter;
+			this.waiter = null;
+			w(item);
+		} else {
+			this.queue.push(item);
+		}
+	}
+
+	close(): void {
+		this.closed = true;
+		if (this.waiter) {
+			const w = this.waiter;
+			this.waiter = null;
+			w(null);
+		}
+	}
+
+	next(): Promise<PipelineItem | null> {
+		if (this.queue.length > 0) return Promise.resolve(this.queue.shift()!);
+		if (this.closed) return Promise.resolve(null);
+		return new Promise((resolve) => {
+			this.waiter = resolve;
+		});
+	}
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * VoiceOrchestrator — central layer between LLM output and TTS/VRM.
+ *
+ * Pipeline mode (preferred):
+ *   beginSession() → pushSegment() × N → endSession() → await result
+ *
+ * Legacy batch mode (still supported):
+ *   speakSegments(allSegments, …)
+ *
+ * Key property: synthesis of segment N+1 starts as soon as pushSegment() is
+ * called, overlapping with playback of segment N. This eliminates the
+ * inter-sentence gap caused by sequential fetch → play → fetch → play.
+ */
+export class VoiceOrchestrator {
+	private bufferedStreamingSegments: SpeechSegment[] = [];
+	private currentSource: AudioBufferSourceNode | null = null;
+	private currentAnalyser: AnalyserNode | null = null;
+	private isPlaying = false;
+
+	// Pipeline state
+	private channel: PipelineQueue | null = null;
+	private pipelineAbort: AbortController | null = null;
+	private sessionOptions: TTSOptions | null = null;
+	private pipelineIndex = 0;
+	private inferredPrimaryLang: string | undefined = undefined;
+	private lastSegmentLang: string | undefined = undefined;
+	private pipelineDoneResolve: (() => void) | null = null;
+	private pipelineDone: Promise<void> = Promise.resolve();
+	private pipelineDoneResolved = true;
+
+	// Limits parallel TTS synthesis requests (important for single-GPU diffusion models)
+	private synthesisLimiter = new Semaphore(Infinity);
+
+	getAnalyser(): AnalyserNode | null {
+		return this.currentAnalyser;
+	}
+
+	getIsPlaying(): boolean {
+		return this.isPlaying;
+	}
+
+	// -------------------------------------------------------------------------
+	// Legacy batch API — keeps backward compatibility
+	// -------------------------------------------------------------------------
+
+	async speakSegments(
+		segments: SpeechSegment[],
+		options: TTSOptions,
+		callbacks?: OrchestratorCallbacks
+	): Promise<void> {
+		this.beginSession(options, callbacks);
+		for (const seg of segments) {
+			this.pushSegment(seg);
+		}
+		return this.endSession();
+	}
+
+	// -------------------------------------------------------------------------
+	// Pipeline API — preferred for streaming LLM output
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Start a new speech session.
+	 * Any in-progress session is interrupted first.
+	 */
+	beginSession(options: TTSOptions, callbacks?: OrchestratorCallbacks): void {
+		this.interrupt();
+
+		this.sessionOptions = options;
+		this.pipelineAbort = new AbortController();
+		this.pipelineIndex = 0;
+		this.inferredPrimaryLang = undefined;
+		this.lastSegmentLang = undefined;
+		this.bufferedStreamingSegments = [];
+		this.channel = new PipelineQueue();
+
+		// Apply provider-specific concurrency limit (e.g. OmniVoice = 2)
+		const provider = getTTSProvider(options);
+		const limit = provider.capabilities?.maxConcurrentSynthesis ?? Infinity;
+		this.synthesisLimiter.drainAndReset(limit);
+		this.pipelineDoneResolved = false;
+		this.pipelineDone = new Promise<void>((resolve) => {
+			this.pipelineDoneResolve = resolve;
+		});
+
+		// Start the async pipeline runner (fire-and-forget; resolves pipelineDone)
+		this.runPipeline(callbacks).catch((err) => {
+			if ((err as Error).name !== 'AbortError') {
+				console.error('[VoiceOrchestrator] Pipeline error:', err);
+			}
+		});
+	}
+
+	/**
+	 * Push a segment into the pipeline.
+	 * Synthesis starts immediately in the background.
+	 */
+	pushSegment(segment: SpeechSegment): void {
+		if (!this.channel || !this.sessionOptions || this.pipelineAbort?.signal.aborted) return;
+
+		// Skip segments that contain only emoji, whitespace, or punctuation — these produce
+		// no meaningful speech but still incur full TTS generation overhead.
+		const textContent = segment.text.replace(
+			/[\p{Emoji_Presentation}\p{Extended_Pictographic}\s\p{P}]/gu,
+			''
+		);
+		if (!textContent.trim()) return;
+
+		// Auto-assign alt voice when language differs from the configured primary language.
+		// Requires sessionOptions.language or at least one segment to provide a language hint.
+		if (!segment.voiceId && this.sessionOptions.altVoiceId && segment.language) {
+			if (this.inferredPrimaryLang === undefined) {
+				this.inferredPrimaryLang = segment.language;
+				this.lastSegmentLang = segment.language;
+			}
+			const primaryLang = this.sessionOptions.language || this.inferredPrimaryLang;
+			const altLang = this.sessionOptions.altLanguage;
+			const shouldUseAlt = altLang
+				? segment.language === altLang
+				: segment.language !== primaryLang;
+			if (shouldUseAlt) {
+				segment = { ...segment, voiceId: 'alt' };
+			}
+		}
+		this.lastSegmentLang = segment.language !== undefined ? segment.language : this.lastSegmentLang;
+
+		const provider = getTTSProvider(this.sessionOptions);
+		const abort = this.pipelineAbort;
+		if (!abort) return;
+		const signal = abort.signal;
+		const index = this.pipelineIndex++;
+
+		// For streaming providers (Chatterbox): buffer segments and combine into one
+		// request in endSession. This enables sentence_pipelining=true which drops
+		// RTF and allows gapless progressive playback.
+		if (provider.capabilities?.streaming && provider.speakStreaming) {
+			this.bufferedStreamingSegments.push(segment);
+			return;
+		}
+
+		// Non-streaming providers: batch path (prefetch while previous segment plays)
+		const bufferPromise = this.fetchBuffer(provider, segment, signal);
+		this.channel.push({ segment, index, bufferPromise });
+	}
+
+	/**
+	 * Signal that no more segments will be pushed.
+	 * Returns a promise that resolves when all audio has finished playing.
+	 */
+	endSession(): Promise<void> {
+		// Flush buffered streaming segments as one combined streaming call.
+		if (
+			this.bufferedStreamingSegments.length > 0 &&
+			this.channel &&
+			this.sessionOptions &&
+			this.pipelineAbort
+		) {
+			const segments = [...this.bufferedStreamingSegments];
+			this.bufferedStreamingSegments = [];
+			const provider = getTTSProvider(this.sessionOptions);
+			const signal = this.pipelineAbort.signal;
+			const index = this.pipelineIndex++;
+			this.channel.push({
+				segment: segments[0],
+				index,
+				streamPlay: (cb) => this.playAllAsOneStream(provider, segments, index, signal, cb)
+			});
+		}
+		this.channel?.close();
+		return this.pipelineDone;
+	}
+
+	interrupt(): void {
+		this.pipelineAbort?.abort();
+		this.pipelineAbort = null;
+
+		this.synthesisLimiter.drainAndReset(Infinity);
+
+		this.channel?.close();
+		this.channel = null;
+
+		if (this.currentSource) {
+			try {
+				this.currentSource.stop();
+			} catch {
+				// Already stopped
+			}
+			this.currentSource = null;
+		}
+
+		this.currentAnalyser = null;
+		this.isPlaying = false;
+		this.resolvePipeline();
+	}
+
+	// -------------------------------------------------------------------------
+	// Private helpers
+	// -------------------------------------------------------------------------
+
+	private resolvePipeline(): void {
+		if (!this.pipelineDoneResolved) {
+			this.pipelineDoneResolved = true;
+			this.pipelineDoneResolve?.();
+			this.pipelineDoneResolve = null;
+		}
+	}
+
+	private async runPipeline(callbacks?: OrchestratorCallbacks): Promise<void> {
+		this.isPlaying = true;
+		const provider = this.sessionOptions ? getTTSProvider(this.sessionOptions) : null;
+		const clientSideSpeed = provider?.capabilities?.clientSideSpeed ?? false;
+
+		try {
+			while (true) {
+				if (this.pipelineAbort?.signal.aborted) break;
+
+				const item = await (this.channel?.next() ?? Promise.resolve(null));
+				if (item === null) break; // channel closed (endSession called)
+
+				if (this.pipelineAbort?.signal.aborted) break;
+
+				// Streaming path: synthesis and playback happen together
+				if (item.streamPlay) {
+					await item.streamPlay(callbacks);
+					continue;
+				}
+
+				// Batch path: wait for synthesis to finish (may already be done)
+				let buffer: AudioBuffer | null = null;
+				try {
+					buffer = await item.bufferPromise!;
+				} catch (err) {
+					if ((err as Error).name === 'AbortError') break;
+					console.error(
+						'[VoiceOrchestrator] Synthesis failed for segment:',
+						item.segment.text,
+						err
+					);
+					continue; // skip this segment
+				}
+
+				if (!buffer || this.pipelineAbort?.signal.aborted) continue;
+
+				if (item.segment.action) callbacks?.onAction?.(item.segment.action);
+
+				const playbackRate = clientSideSpeed
+					? (item.segment.speed ?? this.sessionOptions?.speed ?? 1)
+					: undefined;
+				await this.playBuffer(buffer, item.segment, item.index, callbacks, playbackRate);
+			}
+		} finally {
+			this.isPlaying = false;
+			this.currentSource = null;
+			this.currentAnalyser = null;
+			callbacks?.onEmotionChange?.(null);
+			callbacks?.onComplete?.();
+			this.resolvePipeline();
+		}
+	}
+
+	/**
+	 * Fetch and decode audio to an AudioBuffer (without starting playback).
+	 * Synthesis runs in the background while the previous segment plays.
+	 */
+	private resolveVoiceId(tag: string | undefined): string | undefined {
+		if (!tag || tag === 'default') return undefined;
+		if (tag === 'alt') return this.sessionOptions?.altVoiceId || undefined;
+		return tag;
+	}
+
+	private async fetchBuffer(
+		provider: ITTSProvider,
+		segment: SpeechSegment,
+		signal: AbortSignal
+	): Promise<AudioBuffer | null> {
+		const streamOpts: StreamOptions = {
+			emotion: segment.emotion,
+			exaggeration: segment.exaggeration,
+			language: segment.language,
+			speed: segment.speed ?? this.sessionOptions?.speed,
+			pitch: segment.pitch,
+			volume: segment.volume,
+			voiceId: this.resolveVoiceId(segment.voiceId),
+			signal
+		};
+
+		if (signal.aborted) return null;
+
+		// Acquire a synthesis slot — limits parallel requests to the provider's
+		// maxConcurrentSynthesis cap (e.g. 2 for OmniVoice). This prevents all
+		// segments from being synthesised in one GPU batch, which would delay the
+		// first segment by the full batch duration instead of just one segment.
+		await this.synthesisLimiter.acquire();
+		if (signal.aborted) {
+			this.synthesisLimiter.release();
+			return null;
+		}
+
+		try {
+			// Preferred path: provider implements fetchAudioBuffer
+			if (provider.fetchAudioBuffer) {
+				return await provider.fetchAudioBuffer(segment.text, streamOpts);
+			}
+
+			// Fallback: use speak() and extract the decoded buffer from the source.
+			const result = await provider.speak(segment.text);
+			return result.source.buffer;
+		} finally {
+			this.synthesisLimiter.release();
+		}
+	}
+
+	private async playBuffer(
+		buffer: AudioBuffer,
+		segment: SpeechSegment,
+		index: number,
+		callbacks?: OrchestratorCallbacks,
+		playbackRate?: number
+	): Promise<void> {
+		const audioContext = getSharedAudioContext();
+		if (audioContext.state === 'suspended') {
+			await audioContext.resume();
+		}
+
+		const source = audioContext.createBufferSource();
+		source.buffer = buffer;
+		if (playbackRate !== undefined && playbackRate > 0 && playbackRate !== 1) {
+			source.playbackRate.value = playbackRate;
+		}
+
+		const analyser = audioContext.createAnalyser();
+		analyser.fftSize = 256;
+
+		source.connect(analyser);
+		analyser.connect(audioContext.destination);
+
+		this.currentSource = source;
+		this.currentAnalyser = analyser;
+
+		callbacks?.onSegmentStart?.(segment, index);
+		callbacks?.onAnalyserUpdate?.(analyser);
+
+		await new Promise<void>((resolve) => {
+			source.onended = () => resolve();
+			source.start(0);
+		});
+	}
+
+	/**
+	 * Stream all segments as ONE request with sentence_pipelining=true.
+	 *
+	 * Each streamed binary chunk is decoded and scheduled with precise Web Audio
+	 * timestamps: source.start(nextPlayTime); nextPlayTime += buffer.duration.
+	 * SCHEDULE_AHEAD_S seconds of "pre-roll" means the first chunk starts playing
+	 * slightly in the future, giving subsequent chunks time to arrive before their
+	 * scheduled start — gapless even at RTF ~1.0.
+	 */
+	private async playAllAsOneStream(
+		provider: ITTSProvider,
+		segments: SpeechSegment[],
+		index: number,
+		signal: AbortSignal,
+		callbacks?: OrchestratorCallbacks
+	): Promise<void> {
+		const SCHEDULE_AHEAD_S = 1.5;
+
+		const audioContext = getSharedAudioContext();
+		if (audioContext.state === 'suspended') {
+			await audioContext.resume();
+		}
+
+		const analyser = audioContext.createAnalyser();
+		analyser.fftSize = 256;
+		analyser.connect(audioContext.destination);
+		this.currentAnalyser = analyser;
+
+		try {
+			const firstSeg = segments[0];
+			if (firstSeg.action) callbacks?.onAction?.(firstSeg.action);
+			callbacks?.onSegmentStart?.(firstSeg, index);
+			callbacks?.onAnalyserUpdate?.(analyser);
+
+			// Estimate per-sentence timings and fire onSegmentStart for subsequent
+			// segments so the speech bubble advances sentence-by-sentence.
+			const segmentTimers: ReturnType<typeof setTimeout>[] = [];
+			const CHARS_PER_SECOND = 13;
+			let accumulatedMs = 0;
+			for (let i = 1; i < segments.length; i++) {
+				accumulatedMs += (segments[i - 1].text.length / CHARS_PER_SECOND) * 1000;
+				const seg = segments[i];
+				const segIndex = index + i;
+				const fireAt = accumulatedMs;
+				segmentTimers.push(
+					setTimeout(() => {
+						if (signal.aborted) return;
+						callbacks?.onSegmentStart?.(seg, segIndex);
+					}, fireAt)
+				);
+			}
+			signal.addEventListener(
+				'abort',
+				() => {
+					for (const t of segmentTimers) clearTimeout(t);
+				},
+				{ once: true }
+			);
+
+			const combinedText = segments
+				.map((s, i) => {
+					const t = s.text.trim();
+					if (i < segments.length - 1 && !/[.!?…。！？]$/.test(t)) return t + '.';
+					return t;
+				})
+				.join(' ');
+
+			const streamOpts: StreamOptions = {
+				emotion: firstSeg.emotion,
+				exaggeration: firstSeg.exaggeration,
+				language: firstSeg.language,
+				speed: firstSeg.speed,
+				signal
+			};
+
+			const PCM_HEADER_SIZE = 44;
+			let headerParsed = false;
+			let audioFormat = 3; // default: IEEE float32
+			let numChannels = 1;
+			let sampleRate = 24000;
+			let bytesPerSample = 4;
+
+			let remainder: Uint8Array = new Uint8Array(0);
+			let nextPlayTime = 0;
+			let firstChunk = true;
+			let lastSourceEndTime = 0;
+			const sources: AudioBufferSourceNode[] = [];
+
+			const abortHandler = () => {
+				for (const src of sources) {
+					try {
+						src.stop();
+					} catch {
+						/* already stopped */
+					}
+				}
+			};
+			signal.addEventListener('abort', abortHandler, { once: true });
+
+			try {
+				const generator = provider.speakStreaming!(combinedText, streamOpts);
+
+				for await (const chunk of generator) {
+					if (signal.aborted) break;
+					if (chunk.done) break;
+					if (chunk.data.byteLength === 0) continue;
+
+					const incoming = new Uint8Array(chunk.data);
+					let raw: Uint8Array;
+					if (remainder.byteLength > 0) {
+						raw = new Uint8Array(remainder.byteLength + incoming.byteLength);
+						raw.set(remainder);
+						raw.set(incoming, remainder.byteLength);
+						remainder = new Uint8Array(0);
+					} else {
+						raw = incoming;
+					}
+
+					let pcmBytes: Uint8Array;
+
+					if (!headerParsed) {
+						if (raw.byteLength < PCM_HEADER_SIZE) {
+							remainder = raw;
+							continue;
+						}
+						const hdv = new DataView(raw.buffer, raw.byteOffset, raw.byteLength);
+						audioFormat = hdv.getUint16(20, true);
+						numChannels = hdv.getUint16(22, true);
+						sampleRate = hdv.getUint32(24, true);
+						const bps = hdv.getUint16(34, true);
+						bytesPerSample = bps / 8;
+						headerParsed = true;
+						pcmBytes = raw.slice(PCM_HEADER_SIZE);
+					} else {
+						pcmBytes = raw;
+					}
+
+					if (pcmBytes.byteLength === 0) continue;
+
+					const frameSize = bytesPerSample * numChannels;
+					const alignedBytes = Math.floor(pcmBytes.byteLength / frameSize) * frameSize;
+					if (alignedBytes === 0) {
+						remainder = pcmBytes;
+						continue;
+					}
+					remainder = pcmBytes.slice(alignedBytes);
+
+					const numSamples = alignedBytes / bytesPerSample;
+					const samplesPerChannel = numSamples / numChannels;
+					const float32 = new Float32Array(numSamples);
+					const pdv = new DataView(pcmBytes.buffer, pcmBytes.byteOffset, alignedBytes);
+					if (audioFormat === 3) {
+						for (let i = 0; i < numSamples; i++) float32[i] = pdv.getFloat32(i * 4, true);
+					} else {
+						for (let i = 0; i < numSamples; i++) float32[i] = pdv.getInt16(i * 2, true) / 32768.0;
+					}
+
+					const audioBuffer = audioContext.createBuffer(
+						numChannels,
+						samplesPerChannel,
+						sampleRate
+					);
+					if (numChannels === 1) {
+						audioBuffer.getChannelData(0).set(float32);
+					} else {
+						for (let ch = 0; ch < numChannels; ch++) {
+							const chData = audioBuffer.getChannelData(ch);
+							for (let i = 0; i < samplesPerChannel; i++) {
+								chData[i] = float32[i * numChannels + ch];
+							}
+						}
+					}
+
+					if (firstChunk) {
+						nextPlayTime = audioContext.currentTime + SCHEDULE_AHEAD_S;
+						firstChunk = false;
+					}
+
+					const src = audioContext.createBufferSource();
+					src.buffer = audioBuffer;
+					src.connect(analyser);
+					this.currentSource = src;
+					sources.push(src);
+					src.start(nextPlayTime);
+					lastSourceEndTime = nextPlayTime + audioBuffer.duration;
+					nextPlayTime = lastSourceEndTime;
+				}
+			} catch (err) {
+				if ((err as Error).name !== 'AbortError' && !signal.aborted) {
+					console.error('[VoiceOrchestrator] playAllAsOneStream error:', err);
+				}
+			} finally {
+				signal.removeEventListener('abort', abortHandler);
+			}
+
+			if (signal.aborted) return;
+
+			// Wait until all scheduled audio has finished playing.
+			const remainingMs = (lastSourceEndTime - audioContext.currentTime) * 1000;
+			if (remainingMs > 0) {
+				await new Promise<void>((resolve) => {
+					const id = setTimeout(resolve, remainingMs + 150);
+					signal.addEventListener('abort', () => {
+						clearTimeout(id);
+						resolve();
+					}, { once: true });
+				});
+			}
+		} finally {
+			analyser.disconnect();
+		}
+	}
+}

--- a/src/lib/stores/tts-store-logic.test.ts
+++ b/src/lib/stores/tts-store-logic.test.ts
@@ -1,0 +1,207 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+	canSpeak,
+	enqueue,
+	beginNext,
+	finishCurrent,
+	clearQueue,
+	runQueue,
+	type QueueSnapshot,
+	type QueueEngine
+} from './tts-store-logic.ts';
+
+function makeEngine(initial: QueueSnapshot): QueueEngine {
+	let snapshot = initial;
+	return {
+		get snapshot() {
+			return snapshot;
+		},
+		set snapshot(value) {
+			snapshot = value;
+		},
+		play: async () => {
+			throw new Error('play() must be provided by the test');
+		}
+	};
+}
+
+const empty: QueueSnapshot = { isSpeaking: false, queue: [] };
+
+const cloudOptions = { provider: 'elevenlabs' as const, apiKey: 'secret' };
+const cloudNoKey = { provider: 'elevenlabs' as const };
+const localOptions = { provider: 'local-tts' as const };
+
+test('canSpeak requires a key for cloud providers', () => {
+	assert.equal(canSpeak(cloudNoKey), false);
+	assert.equal(canSpeak(cloudOptions), true);
+});
+
+test('canSpeak allows local providers without a key', () => {
+	assert.equal(canSpeak(localOptions), true);
+});
+
+test('canSpeak allows any provider when a key is present', () => {
+	assert.equal(canSpeak({ ...localOptions, apiKey: 'secret' }), true);
+});
+
+test('enqueue appends an item preserving options', () => {
+	const first = enqueue('hello', cloudOptions, empty);
+	assert.equal(first.queue.length, 1);
+	assert.equal(first.queue[0].text, 'hello');
+	assert.equal(first.queue[0].options, cloudOptions);
+
+	const second = enqueue('world', localOptions, first);
+	assert.equal(second.queue.length, 2);
+	assert.equal(second.queue[1].options, localOptions);
+	assert.equal(second.isSpeaking, false);
+});
+
+test('beginNext returns null while already speaking', () => {
+	const speaking: QueueSnapshot = {
+		isSpeaking: true,
+		queue: [{ text: 'a', options: cloudOptions }]
+	};
+	const result = beginNext(speaking);
+	assert.equal(result.item, null);
+	assert.equal(result.snapshot.isSpeaking, true);
+	assert.equal(result.snapshot.queue.length, 1);
+});
+
+test('beginNext returns null for an empty queue', () => {
+	const result = beginNext(empty);
+	assert.equal(result.item, null);
+});
+
+test('beginNext claims the next item and marks playback active', () => {
+	const snapshot = enqueue('second', localOptions, enqueue('first', cloudOptions, empty));
+	const result = beginNext(snapshot);
+
+	assert.notEqual(result.item, null);
+	assert.equal(result.item!.text, 'first');
+	assert.equal(result.snapshot.isSpeaking, true);
+	assert.equal(result.snapshot.queue.length, 1);
+	assert.equal(result.snapshot.queue[0].text, 'second');
+});
+
+test('finishCurrent releases the speaking flag while keeping remaining queue', () => {
+	const snapshot: QueueSnapshot = {
+		isSpeaking: true,
+		queue: [{ text: 'next', options: cloudOptions }]
+	};
+	const finished = finishCurrent(snapshot);
+	assert.equal(finished.isSpeaking, false);
+	assert.equal(finished.queue.length, 1);
+});
+
+test('clearQueue stops speaking and drops pending items', () => {
+	const snapshot: QueueSnapshot = {
+		isSpeaking: true,
+		queue: [
+			{ text: 'a', options: cloudOptions },
+			{ text: 'b', options: localOptions }
+		]
+	};
+	const cleared = clearQueue(snapshot);
+	assert.equal(cleared.isSpeaking, false);
+	assert.equal(cleared.queue.length, 0);
+});
+
+test('sequential beginNext/finishCurrent simulates processing multiple items', () => {
+	let snapshot = enqueue(
+		'three',
+		cloudOptions,
+		enqueue('two', localOptions, enqueue('one', cloudOptions, empty))
+	);
+
+	const first = beginNext(snapshot);
+	assert.equal(first.item?.text, 'one');
+	snapshot = finishCurrent(first.snapshot);
+
+	const second = beginNext(snapshot);
+	assert.equal(second.item?.text, 'two');
+	assert.equal(second.snapshot.queue.length, 1);
+
+	snapshot = finishCurrent(second.snapshot);
+	const third = beginNext(snapshot);
+	assert.equal(third.item?.text, 'three');
+
+	snapshot = finishCurrent(third.snapshot);
+	assert.equal(beginNext(snapshot).item, null);
+});
+
+test('runQueue plays all queued items in order', async () => {
+	const played: string[] = [];
+	const engine = makeEngine(
+		enqueue('c', cloudOptions, enqueue('b', localOptions, enqueue('a', cloudOptions, empty)))
+	);
+	engine.play = async (item) => {
+		played.push(item.text);
+	};
+
+	await runQueue(engine);
+
+	assert.deepEqual(played, ['a', 'b', 'c']);
+	assert.equal(engine.snapshot.isSpeaking, false);
+	assert.equal(engine.snapshot.queue.length, 0);
+});
+
+test('runQueue does nothing when already speaking', async () => {
+	let calls = 0;
+	const engine = makeEngine({ isSpeaking: true, queue: [{ text: 'a', options: cloudOptions }] });
+	engine.play = async () => {
+		calls += 1;
+	};
+
+	await runQueue(engine);
+
+	assert.equal(calls, 0);
+	assert.equal(engine.snapshot.isSpeaking, true);
+	assert.equal(engine.snapshot.queue.length, 1);
+});
+
+test('runQueue continues after a play error', async () => {
+	const played: string[] = [];
+	const errors: unknown[] = [];
+	const engine = makeEngine(
+		enqueue('b', localOptions, enqueue('a', cloudOptions, empty))
+	);
+	engine.play = async (item) => {
+		if (item.text === 'a') {
+			throw new Error('synthesis failed');
+		}
+		played.push(item.text);
+	};
+	engine.onError = (error) => errors.push(error);
+
+	await runQueue(engine);
+
+	assert.deepEqual(played, ['b']);
+	assert.equal(errors.length, 1);
+	assert.ok(errors[0] instanceof Error);
+	assert.equal((errors[0] as Error).message, 'synthesis failed');
+	assert.equal(engine.snapshot.isSpeaking, false);
+	assert.equal(engine.snapshot.queue.length, 0);
+});
+
+test('runQueue stops processing when the queue is cleared during playback', async () => {
+	const played: string[] = [];
+	const finished: number[] = [];
+	const engine = makeEngine(
+		enqueue('b', localOptions, enqueue('a', cloudOptions, empty))
+	);
+	engine.play = async (item) => {
+		played.push(item.text);
+		// Simulate stop() clearing the queue while the first item is playing.
+		engine.snapshot = clearQueue(engine.snapshot);
+	};
+	engine.onFinished = () => finished.push(1);
+
+	await runQueue(engine);
+
+	assert.deepEqual(played, ['a']);
+	assert.equal(finished.length, 1);
+	assert.equal(engine.snapshot.isSpeaking, false);
+	assert.equal(engine.snapshot.queue.length, 0);
+});

--- a/src/lib/stores/tts-store-logic.ts
+++ b/src/lib/stores/tts-store-logic.ts
@@ -1,0 +1,85 @@
+// NOTE: relative imports use .ts extensions because this file is loaded directly
+// by the Node test runner (`node --test --experimental-strip-types`).
+import { isLocalTTSProvider } from '../services/providers/local-endpoints.ts';
+import type { TTSOptions } from '../services/tts/index.ts';
+
+export interface QueueItem {
+	text: string;
+	options: TTSOptions;
+}
+
+export interface QueueSnapshot {
+	isSpeaking: boolean;
+	queue: QueueItem[];
+}
+
+export interface QueueEngine {
+	get snapshot(): QueueSnapshot;
+	set snapshot(value: QueueSnapshot);
+	play(item: QueueItem): Promise<void>;
+	onError?(error: unknown): void;
+	onFinished?(): void;
+}
+
+/** Cloud providers need an API key; local endpoints (e.g. Kokoro) don't. */
+export function canSpeak(options: TTSOptions): boolean {
+	if (options.apiKey) return true;
+	return isLocalTTSProvider(options.provider);
+}
+
+/** Append a new utterance to the queue without starting playback. */
+export function enqueue(
+	text: string,
+	options: TTSOptions,
+	snapshot: QueueSnapshot
+): QueueSnapshot {
+	return { ...snapshot, queue: [...snapshot.queue, { text, options }] };
+}
+
+/**
+ * Claim the next queue item for playback.
+ * Returns `null` when playback is already active or the queue is empty.
+ */
+export function beginNext(
+	snapshot: QueueSnapshot
+): { snapshot: QueueSnapshot; item: QueueItem | null } {
+	if (snapshot.isSpeaking || snapshot.queue.length === 0) {
+		return { snapshot, item: null };
+	}
+	return {
+		snapshot: { ...snapshot, isSpeaking: true, queue: snapshot.queue.slice(1) },
+		item: snapshot.queue[0]
+	};
+}
+
+/** Mark the current utterance as finished so the next one can start. */
+export function finishCurrent(snapshot: QueueSnapshot): QueueSnapshot {
+	return { ...snapshot, isSpeaking: false };
+}
+
+/** Stop playback and drop all pending utterances. */
+export function clearQueue(snapshot: QueueSnapshot): QueueSnapshot {
+	return { ...snapshot, isSpeaking: false, queue: [] };
+}
+
+/**
+ * Drive the queue until it is empty.
+ * The engine's `snapshot` is read and written through getters/setters so the
+ * caller can wire it to Svelte runes or plain state.
+ */
+export async function runQueue(engine: QueueEngine): Promise<void> {
+	const claim = beginNext(engine.snapshot);
+	if (!claim.item) return;
+
+	engine.snapshot = claim.snapshot;
+
+	try {
+		await engine.play(claim.item);
+	} catch (error) {
+		engine.onError?.(error);
+	} finally {
+		engine.snapshot = finishCurrent(engine.snapshot);
+		engine.onFinished?.();
+		await runQueue(engine);
+	}
+}

--- a/src/lib/stores/tts.svelte.ts
+++ b/src/lib/stores/tts.svelte.ts
@@ -1,16 +1,26 @@
-import { getTTSProvider, type TTSOptions } from '$lib/services/tts';
-import { isLocalTTSProvider } from '$lib/services/providers/local-endpoints';
+import { type TTSOptions } from '$lib/services/tts';
+import { VoiceOrchestrator, type SpeechSegment } from '$lib/services/voice-orchestrator';
+import { splitIntoSentences } from '$lib/utils/sentences';
+import {
+	canSpeak,
+	clearQueue,
+	enqueue,
+	runQueue,
+	type QueueEngine,
+	type QueueItem
+} from './tts-store-logic';
 
 function createTTSStore() {
 	let isSpeaking = $state(false);
 	let currentAnalyser = $state<AnalyserNode | null>(null);
-	let currentSource = $state<AudioBufferSourceNode | null>(null);
-	let queue = $state<string[]>([]);
+	let queue = $state<QueueItem[]>([]);
 	// Last playback failure, surfaced by the UI as a toast. Silent failures made
 	// misconfigurations (like a stale voice id from another provider) look like
 	// the companion just chose not to speak.
 	let lastError = $state<string | null>(null);
 	let errorTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const orchestrator = new VoiceOrchestrator();
 
 	function reportError(error: unknown) {
 		lastError = error instanceof Error ? error.message : 'Voice playback failed';
@@ -18,65 +28,63 @@ function createTTSStore() {
 		errorTimer = setTimeout(() => (lastError = null), 8000);
 	}
 
+	function buildCallbacks(): {
+		onAnalyserUpdate: (analyser: AnalyserNode) => void;
+	} {
+		return {
+			onAnalyserUpdate: (analyser: AnalyserNode) => {
+				currentAnalyser = analyser;
+			}
+		};
+	}
+
+	const engine: QueueEngine = {
+		get snapshot() {
+			return { isSpeaking, queue };
+		},
+		set snapshot(value) {
+			isSpeaking = value.isSpeaking;
+			queue = value.queue;
+		},
+		play: async (item) => {
+			const sentences = splitIntoSentences(item.text);
+			const segments: SpeechSegment[] = sentences.map((sentence) => ({ text: sentence }));
+
+			await orchestrator.speakSegments(segments, item.options, buildCallbacks());
+		},
+		onError: (error) => {
+			console.error('TTS error:', error);
+			reportError(error);
+		},
+		onFinished: () => {
+			currentAnalyser = null;
+		}
+	};
+
 	async function speak(text: string, options: TTSOptions) {
 		// Cloud providers need a key; local servers (e.g. Kokoro) don't.
-		if (!options.apiKey && !isLocalTTSProvider(options.provider)) {
+		if (!canSpeak(options)) {
 			console.warn('TTS not configured - missing API key');
 			return;
 		}
 
-		// Add to queue
-		queue = [...queue, text];
-
-		// If already speaking, the queue will be processed
-		if (isSpeaking) return;
-
-		await processQueue(options);
+		const next = enqueue(text, options, { isSpeaking, queue });
+		queue = next.queue;
+		await processQueue();
 	}
 
-	async function processQueue(options: TTSOptions) {
-		if (queue.length === 0) {
-			isSpeaking = false;
-			currentAnalyser = null;
-			return;
-		}
-
-		isSpeaking = true;
-		const text = queue[0];
-		queue = queue.slice(1);
-
-		try {
-			const tts = getTTSProvider(options);
-			const { source, analyser } = await tts.speak(text);
-
-			currentSource = source;
-			currentAnalyser = analyser;
-
-			// Wait for playback to complete
-			await new Promise<void>((resolve) => {
-				source.onended = () => resolve();
-			});
-		} catch (error) {
-			console.error('TTS error:', error);
-			reportError(error);
-		}
-
-		// Process next in queue
-		await processQueue(options);
+	async function processQueue() {
+		await runQueue(engine);
 	}
 
 	function stop() {
-		if (currentSource) {
-			try {
-				currentSource.stop();
-			} catch {
-				// Already stopped
-			}
-		}
-		queue = [];
-		isSpeaking = false;
+		orchestrator.interrupt();
+		// clearQueue resets the queue snapshot only; currentAnalyser is store-level
+		// state and is cleared separately below.
+		const cleared = clearQueue({ isSpeaking, queue });
+		isSpeaking = cleared.isSpeaking;
+		queue = cleared.queue;
 		currentAnalyser = null;
-		currentSource = null;
 	}
 
 	return {

--- a/src/lib/utils/sentences.test.ts
+++ b/src/lib/utils/sentences.test.ts
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { splitIntoSentences, stripForSpeech, splitIntoSegments } from './sentences.ts';
+
+// --- splitIntoSentences ---
+
+test('splits text at sentence-ending punctuation', () => {
+	const text = 'Hello world. How are you? I am fine.';
+	const result = splitIntoSentences(text);
+	assert.deepEqual(result, ['Hello world.', 'How are you?', 'I am fine.']);
+});
+
+test('returns the whole text as one sentence when no boundary exists', () => {
+	const text = 'Just one long sentence without terminator';
+	const result = splitIntoSentences(text);
+	assert.deepEqual(result, [text]);
+});
+
+test('returns empty array for whitespace-only input', () => {
+	assert.deepEqual(splitIntoSentences('   '), []);
+	assert.deepEqual(splitIntoSentences(''), []);
+});
+
+// --- stripForSpeech ---
+
+test('strips fenced JSON blocks', () => {
+	const text = 'Hello. ```json\n{"mood_change":{}}\n``` Goodbye.';
+	const { cleaned } = stripForSpeech(text);
+	assert.equal(cleaned, 'Hello. Goodbye.');
+});
+
+test('strips inline JSON state-update blocks', () => {
+	const text = 'Hello. {"mood_change":{"emotion":"happy"}} Goodbye.';
+	const { cleaned } = stripForSpeech(text);
+	assert.equal(cleaned, 'Hello. Goodbye.');
+});
+
+test('removes markdown asterisks and arrows', () => {
+	const text = 'This is *bold* and → there.';
+	const { cleaned } = stripForSpeech(text);
+	assert.equal(cleaned, 'This is bold and there.');
+});
+
+// --- splitIntoSegments ---
+
+test('creates segments with default language', () => {
+	const text = 'First sentence. Second sentence.';
+	const segments = splitIntoSegments(text, 'de');
+	assert.equal(segments.length, 2);
+	assert.equal(segments[0].text, 'First sentence.');
+	assert.equal(segments[0].language, 'de');
+	assert.equal(segments[1].text, 'Second sentence.');
+	assert.equal(segments[1].language, 'de');
+});
+
+test('returns empty array for empty text', () => {
+	assert.deepEqual(splitIntoSegments('', 'en'), []);
+});

--- a/src/lib/utils/sentences.ts
+++ b/src/lib/utils/sentences.ts
@@ -1,0 +1,140 @@
+import type { SpeechSegment } from '$lib/services/voice-orchestrator';
+
+/**
+ * Split text into sentence-like chunks using punctuation followed by whitespace
+ * or end-of-string. Falls back to the whole trimmed text if no boundary is found.
+ */
+export function splitIntoSentences(text: string): string[] {
+	if (!text.trim()) return [];
+	const parts = text
+		.split(/(?<=[.!?…])\s+/)
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+	return parts.length > 0 ? parts : [text.trim()];
+}
+
+/**
+ * Remove JSON state-update blocks and other artifacts that should never be
+ * spoken. Collapses multiple spaces but preserves leading/trailing whitespace
+ * so it is safe to use while text is still being streamed.
+ */
+export function stripSpeechArtifacts(text: string): { cleaned: string; removed: string[] } {
+	const removed: string[] = [];
+
+	// Remove fenced JSON blocks
+	let cleaned = text.replace(/```json\s*([\s\S]*?)\s*```/gi, (_match, content) => {
+		removed.push('```json' + (content ? ' ' + content.slice(0, 200) : '') + '```');
+		return '';
+	});
+
+	// Remove inline JSON state-update blocks with brace balancing.
+	cleaned = stripStateUpdateBlocks(cleaned, removed);
+
+	// Remove Markdown asterisks that TTS would read aloud.
+	cleaned = cleaned.replace(/\*+/g, ' ');
+
+	// Remove arrows and other symbols that TTS engines read aloud as text.
+	cleaned = cleaned.replace(/[→←↑↓⇒⇐⇑⇓]/g, ' ');
+
+	// Ensure a space after sentence/clause punctuation when followed by a letter.
+	cleaned = cleaned.replace(/([.,;:!?])([a-zA-ZäöüÄÖÜß])/g, '$1 $2');
+
+	// Collapse multiple spaces but keep leading/trailing whitespace for streaming.
+	cleaned = cleaned.replace(/  +/g, ' ');
+
+	return { cleaned, removed: removed.filter((r) => r.trim().length > 0) };
+}
+
+/**
+ * Final cleanup of text for speech. Same as stripSpeechArtifacts but trims
+ * leading/trailing whitespace for finished output.
+ */
+export function stripForSpeech(text: string): { cleaned: string; removed: string[] } {
+	const result = stripSpeechArtifacts(text);
+	return { cleaned: result.cleaned.trim(), removed: result.removed };
+}
+
+const STATE_UPDATE_KEYS = [
+	'mood_change',
+	'affection_delta',
+	'trust_delta',
+	'intimacy_delta',
+	'comfort_delta',
+	'respect_delta',
+	'energy_delta',
+	'new_memory',
+	'triggered_event',
+	'structured_fact_seen'
+];
+
+function stripStateUpdateBlocks(text: string, removed: string[]): string {
+	const keyPattern = new RegExp(`"(?:${STATE_UPDATE_KEYS.join('|')})"`);
+	let result = '';
+	let i = 0;
+
+	while (i < text.length) {
+		const ch = text[i];
+		if (ch !== '{') {
+			result += ch;
+			i++;
+			continue;
+		}
+
+		const rest = text.slice(i);
+		const keyMatch = keyPattern.exec(rest);
+		if (!keyMatch || keyMatch.index > 200) {
+			result += ch;
+			i++;
+			continue;
+		}
+
+		let depth = 1;
+		let inString = false;
+		let escape = false;
+		let j = i + 1;
+		for (; j < text.length && depth > 0; j++) {
+			const c = text[j];
+			if (escape) {
+				escape = false;
+				continue;
+			}
+			if (c === '\\') {
+				escape = true;
+				continue;
+			}
+			if (c === '"') {
+				inString = !inString;
+				continue;
+			}
+			if (inString) continue;
+			if (c === '{') depth++;
+			else if (c === '}') depth--;
+		}
+
+		if (depth === 0) {
+			const block = text.slice(i, j);
+			removed.push(block.slice(0, 500));
+			i = j;
+		} else {
+			result += ch;
+			i++;
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Split text into speech segments. For Phase 1 this is a simple wrapper around
+ * sentence splitting; language/emotion tags are added in later phases.
+ */
+export function splitIntoSegments(
+	text: string,
+	defaultLanguage?: string
+): SpeechSegment[] {
+	if (!text.trim()) return [];
+	return splitIntoSentences(text).map((sentence) => ({
+		text: sentence,
+		language: defaultLanguage
+	}));
+}


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                            
                                                                                                                                                                                                                                           
     Replaces the ad-hoc TTS playback queue with a `VoiceOrchestrator` that can                                                                                                                                                            
     pipeline both streaming and buffered TTS providers, and introduces a                                                                                                                                                                  
     sentence-aware `StreamingSpeechBuffer` for chunking long LLM replies.                                                                                                                                                                 
                                                                                                                                                                                                                                           
     This is **Phase 1** of the streaming-TTS roadmap. It lays the foundation for                                                                                                                                                          
     providers such as **Chatterbox-NG** and **OmniVoice** without adding new                                                                                                                                                              
     endpoints or breaking existing ElevenLabs / OpenAI / local providers.                                                                                                                                                                 
                                                                                                                                                                                                                                           
     ## What's changed                                                                                                                                                                                                                     
                                                                                                                                                                                                                                           
     - Added `src/lib/services/voice-orchestrator.ts`                                                                                                                                                                                      
       - `speakSegments()` for playing a list of speech segments sequentially.                                                                                                                                                             
       - `interrupt()` to stop playback cleanly.                                                                                                                                                                                           
       - `beginSession()` / `pushSegment()` / `endSession()` API for future                                                                                                                                                                
         streaming providers.                                                                                                                                                                                                              
       - `clientSideSpeed` capability handling so ElevenLabs speed works via                                                                                                                                                               
         `AudioBufferSourceNode.playbackRate`.                                                                                                                                                                                             
                                                                                                                                                                                                                                           
     - Added `src/lib/services/tts/streaming-speech-buffer.ts`                                                                                                                                                                             
       - Sentence-aware text chunking.                                                                                                                                                                                                     
       - Emits complete sentences as soon as a terminator is seen.                                                                                                                                                                         
       - Flushes remaining text at the end of a stream.                                                                                                                                                                                    
       - Skips open JSON blocks and punctuation-only segments.                                                                                                                                                                             
                                                                                                                                                                                                                                           
     - Added `src/lib/utils/sentences.ts`                                                                                                                                                                                                  
       - `splitIntoSentences()` helper used by both the buffer and the store.                                                                                                                                                              
                                                                                                                                                                                                                                           
     - Refactored `src/lib/stores/tts.svelte.ts`                                                                                                                                                                                           
       - Extracted pure queue logic into `src/lib/stores/tts-store-logic.ts`.                                                                                                                                                              
       - Store now drives the queue through a `QueueEngine` abstraction.                                                                                                                                                                   
       - Queue semantics preserved: `speak()` while playing appends instead of                                                                                                                                                             
         interrupting.                                                                                                                                                                                                                     
       - Removed dead code (`getTTSProvider` import, `getAnalyserData`).                                                                                                                                                                   
                                                                                                                                                                                                                                           
     - Extended `ITTSProvider` in `src/lib/services/tts/index.ts`                                                                                                                                                                          
       - Added optional `speakStreaming()` method.                                                                                                                                                                                         
       - Added `TTSCapabilities` flags (`streaming`, `emotion`, `multilingual`,                                                                                                                                                            
         `maxConcurrentSynthesis`, `clientSideSpeed`).                                                                                                                                                                                     
                                                                                                                                                                                                                                           
     - Updated existing providers                                                                                                                                                                                                          
       - `elevenlabs.ts`: advertises `clientSideSpeed: true`.                                                                                                                                                                              
       - `openai-tts.ts`: advertises `clientSideSpeed: false`.                                                                                                                                                                             
                                                                                                                                                                                                                                           
     - Added tests                                                                                                                                                                                                                         
       - `src/lib/services/voice-orchestrator.test.ts`                                                                                                                                                                                     
       - `src/lib/services/tts/streaming-speech-buffer.test.ts`                                                                                                                                                                            
       - `src/lib/stores/tts-store-logic.test.ts`                                                                                                                                                                                          
       - `src/lib/utils/sentences.test.ts`                                                                                                                                                                                                 
       - `src/lib/services/tts/elevenlabs.test.ts`                                                                                                                                                                                         
                                                                                                                                                                                                                                           
     ## Testing                                                                                                                                                                                                                            
                                                                                                                                                                                                                                           
     - `pnpm check` passes (0 errors, 0 warnings)                                                                                                                                                                                          
     - `pnpm test` passes (343/343 tests)                                                                                                                                                                                                  
                                                                                                                                                                                                                                           
     ## Notes for reviewers                                                                                                                                                                                                                
                                                                                                                                                                                                                                           
     - No new API endpoints are introduced in this PR.                                                                                                                                                                                     
     - Existing non-streaming providers continue to use `fetchAudioBuffer()` and                                                                                                                                                           
       the legacy path.                                                                                                                                                                                                                    
     - The `QueueEngine` getter/setter pattern keeps the pure queue logic                                                                                                                                                                  
       testable in Node while still wiring into Svelte 5 runes.                                                                                                                                                                            
     - Provider-specific endpoints (e.g. `/api/tts/chatterbox/stream`,                                                                                                                                                                     
       `/api/tts/omnivoice/stream`) will follow in separate PRs.       