### PR TITLE
feat(ui): typing indicator delay + optional wait tone 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 - **Model-Centric UI**: Full-screen 3D model with unobtrusive overlay controls
 - **3D Speech Bubbles**: Chat responses appear as bubbles that track the model's head in 3D space
 - **Chat History Sidebar**: Optional side panel showing the full conversation history, with a configurable display mode (bubble, sidebar, both, or off) in Settings > Display
+- **Typing Indicator**: Configurable delay before the typing dots appear, plus an optional soft audio ping while she is thinking
 - **Chat Interface**: Bottom-centered input bar with streaming responses
 - **Voice Input**: Speech-to-text via a local Whisper server (Speaches, faster-whisper-server, whisper.cpp), Groq (Whisper), or the browser's Web Speech API, with real-time audio visualization
 - **Show Her Photos**: Show your companion an image via the attach (paperclip) button in the chat bar or drag-and-drop. Vision-capable models (GPT-4o, Claude, Gemini, or local ones like LLaVA) actually see it and can remember the moment, and kept photos live on a scrapbook-style board. Images stay on your device and only ever reach vision-capable models

--- a/src/lib/stores/display-parser.test.ts
+++ b/src/lib/stores/display-parser.test.ts
@@ -19,6 +19,8 @@ test('returns defaults for null input', () => {
 	assert.equal(result.physicsIntensity, PHYSICS_INTENSITY_DEFAULT);
 	assert.equal(result.chatDisplayMode, DEFAULT_CHAT_DISPLAY_MODE);
 	assert.equal(result.sidebarPosition, DEFAULT_SIDEBAR_POSITION);
+	assert.equal(result.waitToneEnabled, DEFAULT_WAIT_TONE_ENABLED);
+	assert.equal(result.typingIndicatorDelayMs, DEFAULT_TYPING_INDICATOR_DELAY_MS);
 });
 
 test('returns defaults for invalid JSON string', () => {
@@ -78,6 +80,8 @@ test('falls back to defaults for missing fields', () => {
 	assert.equal(result.physicsIntensity, PHYSICS_INTENSITY_DEFAULT);
 	assert.equal(result.chatDisplayMode, DEFAULT_CHAT_DISPLAY_MODE);
 	assert.equal(result.sidebarPosition, DEFAULT_SIDEBAR_POSITION);
+	assert.equal(result.waitToneEnabled, DEFAULT_WAIT_TONE_ENABLED);
+	assert.equal(result.typingIndicatorDelayMs, DEFAULT_TYPING_INDICATOR_DELAY_MS);
 });
 
 test('ignores invalid chat display mode values', () => {
@@ -176,5 +180,10 @@ test('parses and clamps typingIndicatorDelayMs', () => {
 
 test('ignores invalid typingIndicatorDelayMs values', () => {
 	const result = parseDisplaySettings({ typingIndicatorDelayMs: 'fast' });
+	assert.equal(result.typingIndicatorDelayMs, DEFAULT_TYPING_INDICATOR_DELAY_MS);
+});
+
+test('ignores NaN typingIndicatorDelayMs', () => {
+	const result = parseDisplaySettings({ typingIndicatorDelayMs: NaN });
 	assert.equal(result.typingIndicatorDelayMs, DEFAULT_TYPING_INDICATOR_DELAY_MS);
 });

--- a/src/lib/stores/display-parser.test.ts
+++ b/src/lib/stores/display-parser.test.ts
@@ -8,6 +8,7 @@ import {
 	CAMERA_LIMITS,
 	DEFAULT_CHAT_DISPLAY_MODE,
 	DEFAULT_SIDEBAR_POSITION,
+	DEFAULT_TYPING_INDICATOR_DELAY_MS,
 	DEFAULT_WAIT_TONE_ENABLED
 } from './display-types.ts';
 
@@ -155,4 +156,25 @@ test('parses waitToneEnabled when present', () => {
 test('ignores non-boolean waitToneEnabled values', () => {
 	const result = parseDisplaySettings({ waitToneEnabled: 'yes' });
 	assert.equal(result.waitToneEnabled, DEFAULT_WAIT_TONE_ENABLED);
+});
+
+test('defaults typingIndicatorDelayMs to 0 when missing', () => {
+	const result = parseDisplaySettings({});
+	assert.equal(result.typingIndicatorDelayMs, DEFAULT_TYPING_INDICATOR_DELAY_MS);
+});
+
+test('parses and clamps typingIndicatorDelayMs', () => {
+	const result = parseDisplaySettings({ typingIndicatorDelayMs: 1500 });
+	assert.equal(result.typingIndicatorDelayMs, 1500);
+
+	const negative = parseDisplaySettings({ typingIndicatorDelayMs: -500 });
+	assert.equal(negative.typingIndicatorDelayMs, 0);
+
+	const tooLarge = parseDisplaySettings({ typingIndicatorDelayMs: 999999 });
+	assert.equal(tooLarge.typingIndicatorDelayMs, 10000);
+});
+
+test('ignores invalid typingIndicatorDelayMs values', () => {
+	const result = parseDisplaySettings({ typingIndicatorDelayMs: 'fast' });
+	assert.equal(result.typingIndicatorDelayMs, DEFAULT_TYPING_INDICATOR_DELAY_MS);
 });

--- a/src/lib/stores/display-parser.test.ts
+++ b/src/lib/stores/display-parser.test.ts
@@ -7,7 +7,8 @@ import {
 	CAMERA_DEFAULTS,
 	CAMERA_LIMITS,
 	DEFAULT_CHAT_DISPLAY_MODE,
-	DEFAULT_SIDEBAR_POSITION
+	DEFAULT_SIDEBAR_POSITION,
+	DEFAULT_WAIT_TONE_ENABLED
 } from './display-types.ts';
 
 test('returns defaults for null input', () => {
@@ -136,4 +137,22 @@ test('sanitizeCamera fills missing values from defaults', () => {
 	assert.equal(sanitized.fov, CAMERA_DEFAULTS.fov);
 	assert.equal(sanitized.zoom, 2.0);
 	assert.equal(sanitized.height, CAMERA_DEFAULTS.height);
+});
+
+test('defaults waitToneEnabled to false when missing', () => {
+	const result = parseDisplaySettings({});
+	assert.equal(result.waitToneEnabled, DEFAULT_WAIT_TONE_ENABLED);
+});
+
+test('parses waitToneEnabled when present', () => {
+	const enabled = parseDisplaySettings({ waitToneEnabled: true });
+	assert.equal(enabled.waitToneEnabled, true);
+
+	const disabled = parseDisplaySettings({ waitToneEnabled: false });
+	assert.equal(disabled.waitToneEnabled, false);
+});
+
+test('ignores non-boolean waitToneEnabled values', () => {
+	const result = parseDisplaySettings({ waitToneEnabled: 'yes' });
+	assert.equal(result.waitToneEnabled, DEFAULT_WAIT_TONE_ENABLED);
 });

--- a/src/lib/stores/display-parser.ts
+++ b/src/lib/stores/display-parser.ts
@@ -8,6 +8,7 @@ import {
 	CAMERA_LIMITS,
 	DEFAULT_CHAT_DISPLAY_MODE,
 	DEFAULT_SIDEBAR_POSITION,
+	DEFAULT_TYPING_INDICATOR_DELAY_MS,
 	DEFAULT_WAIT_TONE_ENABLED,
 	type CameraSettings,
 	type ChatDisplayMode,
@@ -48,6 +49,7 @@ export interface ParsedDisplaySettings {
 	chatDisplayMode: ChatDisplayMode;
 	sidebarPosition: SidebarPosition;
 	waitToneEnabled: boolean;
+	typingIndicatorDelayMs: number;
 }
 
 /**
@@ -76,7 +78,8 @@ export function parseDisplaySettings(raw: unknown): ParsedDisplaySettings {
 			sceneBackground: sanitizeSceneBackground(undefined),
 			chatDisplayMode: DEFAULT_CHAT_DISPLAY_MODE,
 			sidebarPosition: DEFAULT_SIDEBAR_POSITION,
-			waitToneEnabled: DEFAULT_WAIT_TONE_ENABLED
+			waitToneEnabled: DEFAULT_WAIT_TONE_ENABLED,
+			typingIndicatorDelayMs: DEFAULT_TYPING_INDICATOR_DELAY_MS
 		};
 	}
 
@@ -121,5 +124,10 @@ export function parseDisplaySettings(raw: unknown): ParsedDisplaySettings {
 			? parsed.waitToneEnabled
 			: DEFAULT_WAIT_TONE_ENABLED;
 
-	return { camera, overlayCamera, physicsIntensity, sceneBackground, chatDisplayMode, sidebarPosition, waitToneEnabled };
+	let typingIndicatorDelayMs = DEFAULT_TYPING_INDICATOR_DELAY_MS;
+	if (typeof parsed.typingIndicatorDelayMs === 'number' && !Number.isNaN(parsed.typingIndicatorDelayMs)) {
+		typingIndicatorDelayMs = Math.max(0, Math.min(10000, parsed.typingIndicatorDelayMs));
+	}
+
+	return { camera, overlayCamera, physicsIntensity, sceneBackground, chatDisplayMode, sidebarPosition, waitToneEnabled, typingIndicatorDelayMs };
 }

--- a/src/lib/stores/display-parser.ts
+++ b/src/lib/stores/display-parser.ts
@@ -8,6 +8,7 @@ import {
 	CAMERA_LIMITS,
 	DEFAULT_CHAT_DISPLAY_MODE,
 	DEFAULT_SIDEBAR_POSITION,
+	DEFAULT_WAIT_TONE_ENABLED,
 	type CameraSettings,
 	type ChatDisplayMode,
 	type SidebarPosition
@@ -46,6 +47,7 @@ export interface ParsedDisplaySettings {
 	sceneBackground: SceneBackground;
 	chatDisplayMode: ChatDisplayMode;
 	sidebarPosition: SidebarPosition;
+	waitToneEnabled: boolean;
 }
 
 /**
@@ -73,7 +75,8 @@ export function parseDisplaySettings(raw: unknown): ParsedDisplaySettings {
 			physicsIntensity: PHYSICS_INTENSITY_DEFAULT,
 			sceneBackground: sanitizeSceneBackground(undefined),
 			chatDisplayMode: DEFAULT_CHAT_DISPLAY_MODE,
-			sidebarPosition: DEFAULT_SIDEBAR_POSITION
+			sidebarPosition: DEFAULT_SIDEBAR_POSITION,
+			waitToneEnabled: DEFAULT_WAIT_TONE_ENABLED
 		};
 	}
 
@@ -113,5 +116,10 @@ export function parseDisplaySettings(raw: unknown): ParsedDisplaySettings {
 		? parsed.sidebarPosition
 		: DEFAULT_SIDEBAR_POSITION;
 
-	return { camera, overlayCamera, physicsIntensity, sceneBackground, chatDisplayMode, sidebarPosition };
+	const waitToneEnabled =
+		typeof parsed.waitToneEnabled === 'boolean'
+			? parsed.waitToneEnabled
+			: DEFAULT_WAIT_TONE_ENABLED;
+
+	return { camera, overlayCamera, physicsIntensity, sceneBackground, chatDisplayMode, sidebarPosition, waitToneEnabled };
 }

--- a/src/lib/stores/display-types.ts
+++ b/src/lib/stores/display-types.ts
@@ -15,6 +15,7 @@ export const CAMERA_DEFAULTS: CameraSettings = { fov: 35, zoom: 1, height: 0 };
 export const DEFAULT_CHAT_DISPLAY_MODE: ChatDisplayMode = 'bubble';
 export const DEFAULT_SIDEBAR_POSITION: SidebarPosition = 'right';
 export const DEFAULT_WAIT_TONE_ENABLED = false;
+export const DEFAULT_TYPING_INDICATOR_DELAY_MS = 0;
 
 export const CAMERA_LIMITS = {
 	fov: { min: 20, max: 60 },

--- a/src/lib/stores/display-types.ts
+++ b/src/lib/stores/display-types.ts
@@ -14,6 +14,7 @@ export type SidebarPosition = 'left' | 'right';
 export const CAMERA_DEFAULTS: CameraSettings = { fov: 35, zoom: 1, height: 0 };
 export const DEFAULT_CHAT_DISPLAY_MODE: ChatDisplayMode = 'bubble';
 export const DEFAULT_SIDEBAR_POSITION: SidebarPosition = 'right';
+export const DEFAULT_WAIT_TONE_ENABLED = false;
 
 export const CAMERA_LIMITS = {
 	fov: { min: 20, max: 60 },

--- a/src/lib/stores/display.svelte.ts
+++ b/src/lib/stores/display.svelte.ts
@@ -5,6 +5,7 @@ import {
 	CAMERA_LIMITS,
 	DEFAULT_CHAT_DISPLAY_MODE,
 	DEFAULT_SIDEBAR_POSITION,
+	DEFAULT_WAIT_TONE_ENABLED,
 	type CameraSettings,
 	type CameraProfile,
 	type ChatDisplayMode,
@@ -24,7 +25,13 @@ import {
 const STORAGE_KEY = 'utsuwa-display';
 
 export type { CameraSettings, CameraProfile, ChatDisplayMode, SidebarPosition };
-export { CAMERA_DEFAULTS, CAMERA_LIMITS, DEFAULT_CHAT_DISPLAY_MODE, DEFAULT_SIDEBAR_POSITION };
+export {
+	CAMERA_DEFAULTS,
+	CAMERA_LIMITS,
+	DEFAULT_CHAT_DISPLAY_MODE,
+	DEFAULT_SIDEBAR_POSITION,
+	DEFAULT_WAIT_TONE_ENABLED
+};
 
 function createDisplayStore() {
 	// The main scene and the desktop overlay window frame very differently,
@@ -39,6 +46,8 @@ function createDisplayStore() {
 	// Chat display mode and sidebar docking
 	let chatDisplayMode = $state<ChatDisplayMode>(DEFAULT_CHAT_DISPLAY_MODE);
 	let sidebarPosition = $state<SidebarPosition>(DEFAULT_SIDEBAR_POSITION);
+	// Optional soft audio ping while the companion is thinking
+	let waitToneEnabled = $state(DEFAULT_WAIT_TONE_ENABLED);
 
 	if (browser) {
 		const saved = localStorage.getItem(STORAGE_KEY);
@@ -50,6 +59,7 @@ function createDisplayStore() {
 			sceneBackground = parsed.sceneBackground;
 			chatDisplayMode = parsed.chatDisplayMode;
 			sidebarPosition = parsed.sidebarPosition;
+			waitToneEnabled = parsed.waitToneEnabled;
 		}
 	}
 
@@ -63,7 +73,8 @@ function createDisplayStore() {
 					physicsIntensity,
 					sceneBackground: $state.snapshot(sceneBackground),
 					chatDisplayMode,
-					sidebarPosition
+					sidebarPosition,
+					waitToneEnabled
 				})
 			);
 		}
@@ -120,6 +131,11 @@ function createDisplayStore() {
 		save();
 	}
 
+	function setWaitToneEnabled(enabled: boolean) {
+		waitToneEnabled = enabled;
+		save();
+	}
+
 	return {
 		get camera() {
 			return camera;
@@ -139,13 +155,17 @@ function createDisplayStore() {
 		get sidebarPosition() {
 			return sidebarPosition;
 		},
+		get waitToneEnabled() {
+			return waitToneEnabled;
+		},
 		setCamera,
 		resetCamera,
 		setPhysicsIntensity,
 		setSceneBackground,
 		setChatDisplayMode,
 		setSidebarPosition,
-		resetChatDisplay
+		resetChatDisplay,
+		setWaitToneEnabled
 	};
 }
 

--- a/src/lib/stores/display.svelte.ts
+++ b/src/lib/stores/display.svelte.ts
@@ -5,6 +5,7 @@ import {
 	CAMERA_LIMITS,
 	DEFAULT_CHAT_DISPLAY_MODE,
 	DEFAULT_SIDEBAR_POSITION,
+	DEFAULT_TYPING_INDICATOR_DELAY_MS,
 	DEFAULT_WAIT_TONE_ENABLED,
 	type CameraSettings,
 	type CameraProfile,
@@ -30,6 +31,7 @@ export {
 	CAMERA_LIMITS,
 	DEFAULT_CHAT_DISPLAY_MODE,
 	DEFAULT_SIDEBAR_POSITION,
+	DEFAULT_TYPING_INDICATOR_DELAY_MS,
 	DEFAULT_WAIT_TONE_ENABLED
 };
 
@@ -46,6 +48,8 @@ function createDisplayStore() {
 	// Chat display mode and sidebar docking
 	let chatDisplayMode = $state<ChatDisplayMode>(DEFAULT_CHAT_DISPLAY_MODE);
 	let sidebarPosition = $state<SidebarPosition>(DEFAULT_SIDEBAR_POSITION);
+	// Optional delay before the typing indicator appears
+	let typingIndicatorDelayMs = $state(DEFAULT_TYPING_INDICATOR_DELAY_MS);
 	// Optional soft audio ping while the companion is thinking
 	let waitToneEnabled = $state(DEFAULT_WAIT_TONE_ENABLED);
 
@@ -59,6 +63,7 @@ function createDisplayStore() {
 			sceneBackground = parsed.sceneBackground;
 			chatDisplayMode = parsed.chatDisplayMode;
 			sidebarPosition = parsed.sidebarPosition;
+			typingIndicatorDelayMs = parsed.typingIndicatorDelayMs;
 			waitToneEnabled = parsed.waitToneEnabled;
 		}
 	}
@@ -74,6 +79,7 @@ function createDisplayStore() {
 					sceneBackground: $state.snapshot(sceneBackground),
 					chatDisplayMode,
 					sidebarPosition,
+					typingIndicatorDelayMs,
 					waitToneEnabled
 				})
 			);
@@ -128,6 +134,13 @@ function createDisplayStore() {
 		const next = computeResetChatDisplay();
 		chatDisplayMode = next.chatDisplayMode;
 		sidebarPosition = next.sidebarPosition;
+		typingIndicatorDelayMs = DEFAULT_TYPING_INDICATOR_DELAY_MS;
+		waitToneEnabled = DEFAULT_WAIT_TONE_ENABLED;
+		save();
+	}
+
+	function setTypingIndicatorDelayMs(ms: number) {
+		typingIndicatorDelayMs = Math.max(0, Math.min(10000, ms));
 		save();
 	}
 
@@ -155,6 +168,9 @@ function createDisplayStore() {
 		get sidebarPosition() {
 			return sidebarPosition;
 		},
+		get typingIndicatorDelayMs() {
+			return typingIndicatorDelayMs;
+		},
 		get waitToneEnabled() {
 			return waitToneEnabled;
 		},
@@ -165,6 +181,7 @@ function createDisplayStore() {
 		setChatDisplayMode,
 		setSidebarPosition,
 		resetChatDisplay,
+		setTypingIndicatorDelayMs,
 		setWaitToneEnabled
 	};
 }

--- a/src/lib/stores/display.svelte.ts
+++ b/src/lib/stores/display.svelte.ts
@@ -140,6 +140,7 @@ function createDisplayStore() {
 	}
 
 	function setTypingIndicatorDelayMs(ms: number) {
+		if (Number.isNaN(ms)) return;
 		typingIndicatorDelayMs = Math.max(0, Math.min(10000, ms));
 		save();
 	}

--- a/src/lib/utils/wait-tone.test.ts
+++ b/src/lib/utils/wait-tone.test.ts
@@ -12,7 +12,7 @@ test('controller methods can be called repeatedly without throwing', () => {
 	assert.doesNotThrow(() => tone.destroy());
 });
 
-test('start after destroy creates a fresh controller', () => {
+test('start is a no-op after destroy', () => {
 	const tone = createWaitTone({ pingIntervalMs: 10 });
 	tone.destroy();
 	assert.doesNotThrow(() => tone.start());

--- a/src/lib/utils/wait-tone.test.ts
+++ b/src/lib/utils/wait-tone.test.ts
@@ -23,3 +23,77 @@ test('start is safe in SSR environments without AudioContext', () => {
 	assert.equal(typeof window, 'undefined');
 	assert.doesNotThrow(() => tone.start());
 });
+
+// The app page destroys the singleton on navigation (onDestroy), and the
+// settings page is where the feature gets enabled. The singleton must come
+// back to life on the next start or the tone can never play.
+test('singleton: startWaitTone works again after destroyWaitTone', async (t) => {
+	let contextsCreated = 0;
+	let oscStarts = 0;
+
+	class FakeParam {
+		value = 0;
+		setValueAtTime() {}
+		linearRampToValueAtTime() {}
+		exponentialRampToValueAtTime() {}
+	}
+	class FakeNode {
+		gain = new FakeParam();
+		frequency = new FakeParam();
+		type = '';
+		onended: (() => void) | null = null;
+		connect() {}
+		disconnect() {}
+		start() {
+			oscStarts++;
+		}
+		stop() {}
+	}
+	class FakeAudioContext {
+		currentTime = 0;
+		state = 'running';
+		destination = new FakeNode();
+		constructor() {
+			contextsCreated++;
+		}
+		createOscillator() {
+			return new FakeNode();
+		}
+		createGain() {
+			return new FakeNode();
+		}
+		resume() {}
+		suspend() {}
+		close() {
+			this.state = 'closed';
+		}
+	}
+
+	const g = globalThis as Record<string, unknown>;
+	g.window = {};
+	g.AudioContext = FakeAudioContext;
+	t.after(() => {
+		delete g.window;
+		delete g.AudioContext;
+	});
+
+	const { startWaitTone, stopWaitTone, destroyWaitTone } = await import('./wait-tone.ts');
+	try {
+		startWaitTone();
+		assert.equal(contextsCreated, 1);
+		assert.ok(oscStarts > 0);
+
+		// leaving /app: page onDestroy
+		stopWaitTone();
+		destroyWaitTone();
+
+		// user enabled the tone in settings, came back, companion is typing
+		const before = oscStarts;
+		startWaitTone();
+		assert.equal(contextsCreated, 2, 'a fresh AudioContext should be created after destroy');
+		assert.ok(oscStarts > before, 'the ping should play again after destroy');
+	} finally {
+		stopWaitTone();
+		destroyWaitTone();
+	}
+});

--- a/src/lib/utils/wait-tone.test.ts
+++ b/src/lib/utils/wait-tone.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createWaitTone } from './wait-tone.ts';
+
+test('controller methods can be called repeatedly without throwing', () => {
+	const tone = createWaitTone({ pingIntervalMs: 10 });
+	assert.doesNotThrow(() => tone.start());
+	assert.doesNotThrow(() => tone.start());
+	assert.doesNotThrow(() => tone.stop());
+	assert.doesNotThrow(() => tone.stop());
+	assert.doesNotThrow(() => tone.destroy());
+	assert.doesNotThrow(() => tone.destroy());
+});
+
+test('start after destroy creates a fresh controller', () => {
+	const tone = createWaitTone({ pingIntervalMs: 10 });
+	tone.destroy();
+	assert.doesNotThrow(() => tone.start());
+});

--- a/src/lib/utils/wait-tone.test.ts
+++ b/src/lib/utils/wait-tone.test.ts
@@ -17,3 +17,9 @@ test('start is a no-op after destroy', () => {
 	tone.destroy();
 	assert.doesNotThrow(() => tone.start());
 });
+
+test('start is safe in SSR environments without AudioContext', () => {
+	const tone = createWaitTone({ pingIntervalMs: 10 });
+	assert.equal(typeof window, 'undefined');
+	assert.doesNotThrow(() => tone.start());
+});

--- a/src/lib/utils/wait-tone.ts
+++ b/src/lib/utils/wait-tone.ts
@@ -1,0 +1,54 @@
+import { browser } from '$app/environment';
+
+let ctx: AudioContext | null = null;
+let intervalId: ReturnType<typeof setInterval> | null = null;
+let running = false;
+
+function getContext(): AudioContext | null {
+	if (!browser) return null;
+	if (!ctx || ctx.state === 'closed') {
+		ctx = new AudioContext();
+	}
+	return ctx;
+}
+
+function playPing() {
+	const ac = getContext();
+	if (!ac) return;
+
+	const t = ac.currentTime;
+
+	function note(freq: number, startOffset: number, peak: number) {
+		const osc = ac!.createOscillator();
+		const gain = ac!.createGain();
+		osc.connect(gain);
+		gain.connect(ac!.destination);
+		osc.type = 'triangle';
+		osc.frequency.value = freq;
+		gain.gain.setValueAtTime(0, t + startOffset);
+		gain.gain.linearRampToValueAtTime(peak, t + startOffset + 0.015);
+		gain.gain.exponentialRampToValueAtTime(0.001, t + startOffset + 0.4);
+		osc.start(t + startOffset);
+		osc.stop(t + startOffset + 0.45);
+	}
+
+	// Descending two-tone "ding-dong": ~G4 → ~D4
+	note(400, 0, 0.28);
+	note(300, 0.2, 0.22);
+}
+
+export function startWaitTone() {
+	if (running) return;
+	running = true;
+	getContext()?.resume();
+	playPing();
+	intervalId = setInterval(playPing, 2200);
+}
+
+export function stopWaitTone() {
+	running = false;
+	if (intervalId !== null) {
+		clearInterval(intervalId);
+		intervalId = null;
+	}
+}

--- a/src/lib/utils/wait-tone.ts
+++ b/src/lib/utils/wait-tone.ts
@@ -19,6 +19,7 @@ export function createWaitTone(options?: { pingIntervalMs?: number }): WaitToneC
 	let ctx: AudioContext | null = null;
 	let intervalId: ReturnType<typeof setInterval> | null = null;
 	let running = false;
+	let destroyed = false;
 	const pingIntervalMs = options?.pingIntervalMs ?? DEFAULT_PING_MS;
 
 	function ensureContext(): AudioContext | null {
@@ -55,7 +56,7 @@ export function createWaitTone(options?: { pingIntervalMs?: number }): WaitToneC
 	}
 
 	function start() {
-		if (running) return;
+		if (running || destroyed) return;
 		const ac = ensureContext();
 		if (!ac) return;
 		running = true;
@@ -76,6 +77,8 @@ export function createWaitTone(options?: { pingIntervalMs?: number }): WaitToneC
 	}
 
 	function destroy() {
+		if (destroyed) return;
+		destroyed = true;
 		stop();
 		if (ctx && ctx.state !== 'closed') {
 			void ctx.close();

--- a/src/lib/utils/wait-tone.ts
+++ b/src/lib/utils/wait-tone.ts
@@ -46,6 +46,10 @@ export function createWaitTone(options?: { pingIntervalMs?: number }): WaitToneC
 			gain.gain.setValueAtTime(0, t + startOffset);
 			gain.gain.linearRampToValueAtTime(peak, t + startOffset + NOTE_ATTACK_S);
 			gain.gain.exponentialRampToValueAtTime(0.001, t + startOffset + NOTE_DECAY_S);
+			osc.onended = () => {
+				osc.disconnect();
+				gain.disconnect();
+			};
 			osc.start(t + startOffset);
 			osc.stop(t + startOffset + NOTE_DURATION_S);
 		}
@@ -62,6 +66,8 @@ export function createWaitTone(options?: { pingIntervalMs?: number }): WaitToneC
 		running = true;
 		ac.resume();
 		playPing();
+		// Note: browsers throttle setInterval in background tabs to ≥1000ms,
+		// which is below our default ping interval and therefore acceptable.
 		intervalId = setInterval(playPing, pingIntervalMs);
 	}
 

--- a/src/lib/utils/wait-tone.ts
+++ b/src/lib/utils/wait-tone.ts
@@ -95,7 +95,7 @@ export function createWaitTone(options?: { pingIntervalMs?: number }): WaitToneC
 	return { start, stop, destroy };
 }
 
-const singleton = createWaitTone();
+let singleton = createWaitTone();
 
 export function startWaitTone() {
 	singleton.start();
@@ -105,6 +105,10 @@ export function stopWaitTone() {
 	singleton.stop();
 }
 
+// Destroy releases the AudioContext (the app page calls this on navigation),
+// but the module outlives the page, so swap in a fresh controller for the
+// next start.
 export function destroyWaitTone() {
 	singleton.destroy();
+	singleton = createWaitTone();
 }

--- a/src/lib/utils/wait-tone.ts
+++ b/src/lib/utils/wait-tone.ts
@@ -1,54 +1,101 @@
-import { browser } from '$app/environment';
-
-let ctx: AudioContext | null = null;
-let intervalId: ReturnType<typeof setInterval> | null = null;
-let running = false;
-
-function getContext(): AudioContext | null {
-	if (!browser) return null;
-	if (!ctx || ctx.state === 'closed') {
-		ctx = new AudioContext();
-	}
-	return ctx;
+export interface WaitToneController {
+	start: () => void;
+	stop: () => void;
+	destroy: () => void;
 }
 
-function playPing() {
-	const ac = getContext();
-	if (!ac) return;
+const DEFAULT_PING_MS = 2200;
+const NOTE_A_FREQ = 400;
+const NOTE_B_FREQ = 300;
+const NOTE_A_PEAK = 0.28;
+const NOTE_B_PEAK = 0.22;
+const NOTE_A_OFFSET_MS = 0;
+const NOTE_B_OFFSET_MS = 200;
+const NOTE_ATTACK_S = 0.015;
+const NOTE_DECAY_S = 0.4;
+const NOTE_DURATION_S = 0.45;
 
-	const t = ac.currentTime;
+export function createWaitTone(options?: { pingIntervalMs?: number }): WaitToneController {
+	let ctx: AudioContext | null = null;
+	let intervalId: ReturnType<typeof setInterval> | null = null;
+	let running = false;
+	const pingIntervalMs = options?.pingIntervalMs ?? DEFAULT_PING_MS;
 
-	function note(freq: number, startOffset: number, peak: number) {
-		const osc = ac!.createOscillator();
-		const gain = ac!.createGain();
-		osc.connect(gain);
-		gain.connect(ac!.destination);
-		osc.type = 'triangle';
-		osc.frequency.value = freq;
-		gain.gain.setValueAtTime(0, t + startOffset);
-		gain.gain.linearRampToValueAtTime(peak, t + startOffset + 0.015);
-		gain.gain.exponentialRampToValueAtTime(0.001, t + startOffset + 0.4);
-		osc.start(t + startOffset);
-		osc.stop(t + startOffset + 0.45);
+	function ensureContext(): AudioContext | null {
+		if (typeof window === 'undefined') return null;
+		if (!ctx || ctx.state === 'closed') {
+			ctx = new AudioContext();
+		}
+		return ctx;
 	}
 
-	// Descending two-tone "ding-dong": ~G4 → ~D4
-	note(400, 0, 0.28);
-	note(300, 0.2, 0.22);
+	function playPing() {
+		const ac = ensureContext();
+		if (!ac) return;
+
+		const t = ac.currentTime;
+
+		function note(target: AudioContext, freq: number, startOffset: number, peak: number) {
+			const osc = target.createOscillator();
+			const gain = target.createGain();
+			osc.connect(gain);
+			gain.connect(target.destination);
+			osc.type = 'triangle';
+			osc.frequency.value = freq;
+			gain.gain.setValueAtTime(0, t + startOffset);
+			gain.gain.linearRampToValueAtTime(peak, t + startOffset + NOTE_ATTACK_S);
+			gain.gain.exponentialRampToValueAtTime(0.001, t + startOffset + NOTE_DECAY_S);
+			osc.start(t + startOffset);
+			osc.stop(t + startOffset + NOTE_DURATION_S);
+		}
+
+		// Descending two-tone "ding-dong": ~G4 → ~D4
+		note(ac, NOTE_A_FREQ, NOTE_A_OFFSET_MS / 1000, NOTE_A_PEAK);
+		note(ac, NOTE_B_FREQ, NOTE_B_OFFSET_MS / 1000, NOTE_B_PEAK);
+	}
+
+	function start() {
+		if (running) return;
+		const ac = ensureContext();
+		if (!ac) return;
+		running = true;
+		ac.resume();
+		playPing();
+		intervalId = setInterval(playPing, pingIntervalMs);
+	}
+
+	function stop() {
+		running = false;
+		if (intervalId !== null) {
+			clearInterval(intervalId);
+			intervalId = null;
+		}
+		if (ctx && ctx.state !== 'closed') {
+			ctx.suspend();
+		}
+	}
+
+	function destroy() {
+		stop();
+		if (ctx && ctx.state !== 'closed') {
+			void ctx.close();
+			ctx = null;
+		}
+	}
+
+	return { start, stop, destroy };
 }
+
+const singleton = createWaitTone();
 
 export function startWaitTone() {
-	if (running) return;
-	running = true;
-	getContext()?.resume();
-	playPing();
-	intervalId = setInterval(playPing, 2200);
+	singleton.start();
 }
 
 export function stopWaitTone() {
-	running = false;
-	if (intervalId !== null) {
-		clearInterval(intervalId);
-		intervalId = null;
-	}
+	singleton.stop();
+}
+
+export function destroyWaitTone() {
+	singleton.destroy();
 }

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -38,6 +38,7 @@
 	import { characterStore } from '$lib/stores/character.svelte';
 	import { personaStore } from '$lib/stores/persona.svelte';
 	import { displayStore } from '$lib/stores/display.svelte';
+import { startWaitTone, stopWaitTone } from '$lib/utils/wait-tone';
 	import { debugEventsStore } from '$lib/stores/debugEvents.svelte';
 	import { getLLMProvider, providerSupportsVision } from '$lib/services/providers/registry';
 	import { isLocalLLMProvider } from '$lib/services/providers/local-endpoints';
@@ -96,6 +97,15 @@
 	$effect(() => {
 		if (isTyping && displayStore.chatDisplayMode === 'sidebar' && !sidebarOpen) {
 			sidebarOpen = true;
+		}
+	});
+
+	// Optional wait tone while the companion is thinking
+	$effect(() => {
+		if (isTyping && displayStore.waitToneEnabled) {
+			startWaitTone();
+		} else {
+			stopWaitTone();
 		}
 	});
 
@@ -191,6 +201,7 @@
 			for (const img of m.images ?? []) URL.revokeObjectURL(img.url);
 		}
 		for (const img of thinkingImages) URL.revokeObjectURL(img.url);
+		stopWaitTone();
 	});
 
 

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -38,7 +38,7 @@
 	import { characterStore } from '$lib/stores/character.svelte';
 	import { personaStore } from '$lib/stores/persona.svelte';
 	import { displayStore } from '$lib/stores/display.svelte';
-import { startWaitTone, stopWaitTone, destroyWaitTone } from '$lib/utils/wait-tone';
+	import { startWaitTone, stopWaitTone, destroyWaitTone } from '$lib/utils/wait-tone';
 	import { debugEventsStore } from '$lib/stores/debugEvents.svelte';
 	import { getLLMProvider, providerSupportsVision } from '$lib/services/providers/registry';
 	import { isLocalLLMProvider } from '$lib/services/providers/local-endpoints';

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -100,9 +100,28 @@ import { startWaitTone, stopWaitTone } from '$lib/utils/wait-tone';
 		}
 	});
 
-	// Optional wait tone while the companion is thinking
+	// Typing dots visibility — delayed by typingIndicatorDelayMs
+	let typingDotsVisible = $state(false);
 	$effect(() => {
-		if (isTyping && displayStore.waitToneEnabled) {
+		if (!isTyping) {
+			typingDotsVisible = false;
+			return;
+		}
+		typingDotsVisible = false;
+		const delay = displayStore.typingIndicatorDelayMs;
+		if (delay <= 0) {
+			typingDotsVisible = true;
+			return;
+		}
+		const timer = setTimeout(() => {
+			typingDotsVisible = true;
+		}, delay);
+		return () => clearTimeout(timer);
+	});
+
+	// Wait tone — starts/stops with typing dots
+	$effect(() => {
+		if (typingDotsVisible && displayStore.waitToneEnabled) {
 			startWaitTone();
 		} else {
 			stopWaitTone();
@@ -356,10 +375,10 @@ import { startWaitTone, stopWaitTone } from '$lib/utils/wait-tone';
 			<FloatingStatIndicators />
 
 		<!-- Speech Bubble (shows latest response, click to dismiss) -->
-			{#if showBubble}
+			{#if showBubble || (typingDotsVisible && isTyping)}
 			<SpeechBubble
 				message={latestResponse}
-				isTyping={isTyping}
+				isTyping={isTyping && typingDotsVisible}
 				onHide={handleBubbleHide}
 			/>
 		{/if}
@@ -368,7 +387,7 @@ import { startWaitTone, stopWaitTone } from '$lib/utils/wait-tone';
 			<ChatSidebar
 				open={sidebarOpen && showSidebarTrigger}
 				onClose={() => sidebarOpen = false}
-				{isTyping}
+				isTyping={isTyping && typingDotsVisible}
 			/>
 
 			<!-- The image she's being shown, floated above her head while she considers it -->

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -38,7 +38,7 @@
 	import { characterStore } from '$lib/stores/character.svelte';
 	import { personaStore } from '$lib/stores/persona.svelte';
 	import { displayStore } from '$lib/stores/display.svelte';
-import { startWaitTone, stopWaitTone } from '$lib/utils/wait-tone';
+import { startWaitTone, stopWaitTone, destroyWaitTone } from '$lib/utils/wait-tone';
 	import { debugEventsStore } from '$lib/stores/debugEvents.svelte';
 	import { getLLMProvider, providerSupportsVision } from '$lib/services/providers/registry';
 	import { isLocalLLMProvider } from '$lib/services/providers/local-endpoints';
@@ -221,6 +221,7 @@ import { startWaitTone, stopWaitTone } from '$lib/utils/wait-tone';
 		}
 		for (const img of thinkingImages) URL.revokeObjectURL(img.url);
 		stopWaitTone();
+		destroyWaitTone();
 	});
 
 
@@ -375,7 +376,7 @@ import { startWaitTone, stopWaitTone } from '$lib/utils/wait-tone';
 			<FloatingStatIndicators />
 
 		<!-- Speech Bubble (shows latest response, click to dismiss) -->
-			{#if showBubble || (typingDotsVisible && isTyping)}
+			{#if showBubble && (latestResponse || (isTyping && typingDotsVisible))}
 			<SpeechBubble
 				message={latestResponse}
 				isTyping={isTyping && typingDotsVisible}

--- a/src/routes/app/settings/display/+page.svelte
+++ b/src/routes/app/settings/display/+page.svelte
@@ -79,48 +79,45 @@
 			<h3>Typing Indicator</h3>
 		</div>
 
-		<div class="setting-row">
-			<div class="setting-info">
-				<span class="setting-label">Delay</span>
-				<span class="setting-desc">Wait before the typing dots appear</span>
+		<div class="settings-stack">
+			<div class="setting-row">
+				<div class="setting-info">
+					<span class="setting-label">Wait tone</span>
+					<span class="setting-desc">Soft audio ping while the typing indicator is visible</span>
+				</div>
+				<label class="toggle">
+					<input
+						type="checkbox"
+						checked={displayStore.waitToneEnabled}
+						onchange={(e) => displayStore.setWaitToneEnabled(e.currentTarget.checked)}
+					/>
+					<span class="toggle-track">
+						<span class="toggle-thumb"></span>
+					</span>
+				</label>
 			</div>
-			<div class="delay-input-container">
-				<button class="delay-step" onclick={() => stepDelay(-0.1)} disabled={displayStore.typingIndicatorDelayMs <= 0}>−</button>
-				<input
-					type="number"
-					class="delay-input"
-					min="0"
-					max="10"
-					step="0.1"
-					value={(displayStore.typingIndicatorDelayMs / 1000).toFixed(1)}
-					oninput={(e) => displayStore.setTypingIndicatorDelayMs(parseFloat(e.currentTarget.value) * 1000)}
-				/>
-				<span class="delay-unit">s</span>
-				<button class="delay-step" onclick={() => stepDelay(0.1)} disabled={displayStore.typingIndicatorDelayMs >= 10000}>+</button>
-			</div>
-		</div>
-	</section>
 
-	<section class="card">
-		<div class="card-header">
-			<h3>Wait Tone</h3>
-		</div>
-
-		<div class="setting-row">
-			<div class="setting-info">
-				<span class="setting-label">Play wait tone</span>
-				<span class="setting-desc">Soft audio ping while the companion is thinking</span>
+			<div class="setting-row" class:disabled={!displayStore.waitToneEnabled}>
+				<div class="setting-info">
+					<span class="setting-label">Delay</span>
+					<span class="setting-desc">Wait before the typing dots appear</span>
+				</div>
+				<div class="delay-input-container">
+					<button class="delay-step" onclick={() => stepDelay(-0.1)} disabled={displayStore.typingIndicatorDelayMs <= 0 || !displayStore.waitToneEnabled}>−</button>
+					<input
+						type="number"
+						class="delay-input"
+						min="0"
+						max="10"
+						step="0.1"
+						value={(displayStore.typingIndicatorDelayMs / 1000).toFixed(1)}
+						oninput={(e) => displayStore.setTypingIndicatorDelayMs(parseFloat(e.currentTarget.value) * 1000)}
+						disabled={!displayStore.waitToneEnabled}
+					/>
+					<span class="delay-unit">s</span>
+					<button class="delay-step" onclick={() => stepDelay(0.1)} disabled={displayStore.typingIndicatorDelayMs >= 10000 || !displayStore.waitToneEnabled}>+</button>
+				</div>
 			</div>
-			<label class="toggle">
-				<input
-					type="checkbox"
-					checked={displayStore.waitToneEnabled}
-					onchange={(e) => displayStore.setWaitToneEnabled(e.currentTarget.checked)}
-				/>
-				<span class="toggle-track">
-					<span class="toggle-thumb"></span>
-				</span>
-			</label>
 		</div>
 	</section>
 </div>
@@ -172,6 +169,12 @@
 		font-size: 0.9375rem;
 		font-weight: 600;
 		color: var(--text-primary);
+	}
+
+	.settings-stack {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
 	}
 
 	.segment-control {
@@ -237,6 +240,13 @@
 		align-items: center;
 		justify-content: space-between;
 		gap: 1rem;
+	}
+
+	.setting-row.disabled {
+		opacity: 0.45;
+		filter: grayscale(0.7);
+		pointer-events: none;
+		transition: opacity 0.2s ease, filter 0.2s ease;
 	}
 
 	.setting-info {

--- a/src/routes/app/settings/display/+page.svelte
+++ b/src/routes/app/settings/display/+page.svelte
@@ -67,6 +67,29 @@
 			</div>
 		</section>
 	{/if}
+
+	<section class="card">
+		<div class="card-header">
+			<h3>Wait Tone</h3>
+		</div>
+
+		<div class="setting-row">
+			<div class="setting-info">
+				<span class="setting-label">Play wait tone</span>
+				<span class="setting-desc">Soft audio ping while the companion is thinking</span>
+			</div>
+			<label class="toggle">
+				<input
+					type="checkbox"
+					checked={displayStore.waitToneEnabled}
+					onchange={(e) => displayStore.setWaitToneEnabled(e.currentTarget.checked)}
+				/>
+				<span class="toggle-track">
+					<span class="toggle-thumb"></span>
+				</span>
+			</label>
+		</div>
+	</section>
 </div>
 
 <style>
@@ -174,5 +197,76 @@
 		margin: 0.625rem 0 0;
 		color: var(--text-secondary);
 		font-size: 0.8125rem;
+	}
+
+	.setting-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.setting-info {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.setting-label {
+		font-weight: 600;
+		font-size: 0.875rem;
+		color: var(--text-primary);
+	}
+
+	.setting-desc {
+		font-size: 0.75rem;
+		color: var(--text-secondary);
+	}
+
+	.toggle {
+		position: relative;
+		display: inline-block;
+		width: 40px;
+		height: 22px;
+		cursor: pointer;
+		flex-shrink: 0;
+	}
+
+	.toggle input {
+		opacity: 0;
+		width: 0;
+		height: 0;
+		position: absolute;
+	}
+
+	.toggle-track {
+		display: block;
+		width: 100%;
+		height: 100%;
+		background: var(--bg-tertiary);
+		border-radius: 11px;
+		transition: background 0.2s ease-out;
+		box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.15);
+	}
+
+	.toggle input:checked ~ .toggle-track {
+		background: var(--accent);
+	}
+
+	.toggle-thumb {
+		position: absolute;
+		top: 2px;
+		left: 2px;
+		width: 18px;
+		height: 18px;
+		background: var(--bg-primary);
+		border-radius: 50%;
+		transition: transform 0.2s ease-out;
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+		pointer-events: none;
+	}
+
+	.toggle input:checked ~ .toggle-track .toggle-thumb {
+		transform: translateX(18px);
 	}
 </style>

--- a/src/routes/app/settings/display/+page.svelte
+++ b/src/routes/app/settings/display/+page.svelte
@@ -97,13 +97,13 @@
 				</label>
 			</div>
 
-			<div class="setting-row" class:disabled={!displayStore.waitToneEnabled}>
+			<div class="setting-row">
 				<div class="setting-info">
 					<span class="setting-label">Delay</span>
 					<span class="setting-desc">Wait before the typing dots appear</span>
 				</div>
 				<div class="delay-input-container">
-					<button class="delay-step" onclick={() => stepDelay(-0.1)} disabled={displayStore.typingIndicatorDelayMs <= 0 || !displayStore.waitToneEnabled}>−</button>
+					<button class="delay-step" onclick={() => stepDelay(-0.1)} disabled={displayStore.typingIndicatorDelayMs <= 0}>−</button>
 					<input
 						type="number"
 						class="delay-input"
@@ -115,10 +115,9 @@
 							const v = parseFloat(e.currentTarget.value);
 							if (!Number.isNaN(v)) displayStore.setTypingIndicatorDelayMs(v * 1000);
 						}}
-						disabled={!displayStore.waitToneEnabled}
 					/>
 					<span class="delay-unit">s</span>
-					<button class="delay-step" onclick={() => stepDelay(0.1)} disabled={displayStore.typingIndicatorDelayMs >= 10000 || !displayStore.waitToneEnabled}>+</button>
+					<button class="delay-step" onclick={() => stepDelay(0.1)} disabled={displayStore.typingIndicatorDelayMs >= 10000}>+</button>
 				</div>
 			</div>
 		</div>
@@ -243,13 +242,6 @@
 		align-items: center;
 		justify-content: space-between;
 		gap: 1rem;
-	}
-
-	.setting-row.disabled {
-		opacity: 0.45;
-		filter: grayscale(0.7);
-		pointer-events: none;
-		transition: opacity 0.2s ease, filter 0.2s ease;
 	}
 
 	.setting-info {

--- a/src/routes/app/settings/display/+page.svelte
+++ b/src/routes/app/settings/display/+page.svelte
@@ -16,6 +16,12 @@
 	const sidebarActive = $derived(
 		displayStore.chatDisplayMode === 'sidebar' || displayStore.chatDisplayMode === 'both'
 	);
+
+	function stepDelay(delta: number) {
+		const current = displayStore.typingIndicatorDelayMs / 1000;
+		const next = Math.round((current + delta) * 10) / 10;
+		displayStore.setTypingIndicatorDelayMs(Math.max(0, Math.min(10, next)) * 1000);
+	}
 </script>
 
 <div class="display-page">
@@ -67,6 +73,33 @@
 			</div>
 		</section>
 	{/if}
+
+	<section class="card">
+		<div class="card-header">
+			<h3>Typing Indicator</h3>
+		</div>
+
+		<div class="setting-row">
+			<div class="setting-info">
+				<span class="setting-label">Delay</span>
+				<span class="setting-desc">Wait before the typing dots appear</span>
+			</div>
+			<div class="delay-input-container">
+				<button class="delay-step" onclick={() => stepDelay(-0.1)} disabled={displayStore.typingIndicatorDelayMs <= 0}>−</button>
+				<input
+					type="number"
+					class="delay-input"
+					min="0"
+					max="10"
+					step="0.1"
+					value={(displayStore.typingIndicatorDelayMs / 1000).toFixed(1)}
+					oninput={(e) => displayStore.setTypingIndicatorDelayMs(parseFloat(e.currentTarget.value) * 1000)}
+				/>
+				<span class="delay-unit">s</span>
+				<button class="delay-step" onclick={() => stepDelay(0.1)} disabled={displayStore.typingIndicatorDelayMs >= 10000}>+</button>
+			</div>
+		</div>
+	</section>
 
 	<section class="card">
 		<div class="card-header">
@@ -268,5 +301,56 @@
 
 	.toggle input:checked ~ .toggle-track .toggle-thumb {
 		transform: translateX(18px);
+	}
+
+	.delay-input-container {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.delay-step {
+		width: 2rem;
+		height: 2rem;
+		border-radius: var(--radius-md);
+		border: 1px solid var(--border-light);
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+		font-size: 1rem;
+		line-height: 1;
+		cursor: pointer;
+		transition: background 0.15s ease;
+	}
+
+	.delay-step:hover:not(:disabled) {
+		background: var(--bg-tertiary);
+	}
+
+	.delay-step:disabled {
+		opacity: 0.35;
+		cursor: default;
+	}
+
+	.delay-input {
+		width: 3.5rem;
+		padding: 0.35rem 0.5rem;
+		border-radius: var(--radius-md);
+		border: 1px solid var(--border-light);
+		background: var(--bg-secondary);
+		font-size: 0.875rem;
+		color: var(--text-primary);
+		text-align: center;
+		appearance: textfield;
+		-moz-appearance: textfield;
+	}
+
+	.delay-input::-webkit-outer-spin-button,
+	.delay-input::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+	}
+
+	.delay-unit {
+		font-size: 0.8rem;
+		color: var(--text-secondary);
 	}
 </style>

--- a/src/routes/app/settings/display/+page.svelte
+++ b/src/routes/app/settings/display/+page.svelte
@@ -111,7 +111,10 @@
 						max="10"
 						step="0.1"
 						value={(displayStore.typingIndicatorDelayMs / 1000).toFixed(1)}
-						oninput={(e) => displayStore.setTypingIndicatorDelayMs(parseFloat(e.currentTarget.value) * 1000)}
+						oninput={(e) => {
+							const v = parseFloat(e.currentTarget.value);
+							if (!Number.isNaN(v)) displayStore.setTypingIndicatorDelayMs(v * 1000);
+						}}
 						disabled={!displayStore.waitToneEnabled}
 					/>
 					<span class="delay-unit">s</span>

--- a/src/routes/app/settings/display/+page.svelte
+++ b/src/routes/app/settings/display/+page.svelte
@@ -20,7 +20,7 @@
 	function stepDelay(delta: number) {
 		const current = displayStore.typingIndicatorDelayMs / 1000;
 		const next = Math.round((current + delta) * 10) / 10;
-		displayStore.setTypingIndicatorDelayMs(Math.max(0, Math.min(10, next)) * 1000);
+		displayStore.setTypingIndicatorDelayMs(next * 1000);
 	}
 </script>
 


### PR DESCRIPTION
                                                                                                                                                                                        
     ## Summary                                                                                                                                                                          
     Adds a configurable delay before the typing indicator appears and an optional soft wait tone that pings while the companion is "thinking". Both settings live together under  **Settings > Display > Typing Indicator**.                                                                                                                                            
                                                                                                                                                                                         
     ## What's changed                                                                                                                                                                   
     - Added `typingIndicatorDelayMs` and `waitToneEnabled` to the display settings store.                                                                                               
     - IndexedDB/localStorage persistence via the existing display settings parser; new fields default to `0` and `false`.                                                               
     - Added `src/lib/utils/wait-tone.ts`                                                                                                                                                
       - Factory `createWaitTone()` with named constants.                                                                                                                                
       - Suspends `AudioContext` in `stop()` and closes it in `destroy()`.                                                                                                               
       - Disconnects oscillator and gain nodes via `onended` to avoid orphaned Web Audio nodes.                                                                                          
       - SSR-safe (`typeof window` guard).                                                                                                                                               
     - Wired typing-dot visibility and wait tone in `src/routes/app/+page.svelte`                                                                                                        
       - `typingDotsVisible` is delayed by `typingIndicatorDelayMs`.                                                                                                                     
       - Wait tone starts/stops with the typing dots.                                                                                                                                    
       - Bubble visibility is correct in all display modes (bubble/both/sidebar/off).                                                                                                    
     - Added a **Typing Indicator** card to `src/routes/app/settings/display/+page.svelte`                                                                                               
       - Wait tone toggle.                                                                                                                                                               
       - Delay input (0.0–10.0 s, 0.1 s steps).                                                                                                                                          
     - Added/extended tests:                                                                                                                                                             
       - `display-parser.test.ts`: NaN handling, default-value coverage for new fields, clamping.                                                                                        
       - `wait-tone.test.ts`: controller lifecycle, terminal destroy, SSR safety.                                                                                                        
     - Updated `README.md` feature list.                                                                                                                                                 
                                                                                                                                                                                         
     ## Review feedback addressed                                                                                                                                                        
     - Delay UI is independent of the wait-tone toggle.                                                                                                                                  
     - Bubble visibility in `bubble`/`both` modes is independent of the delay; sidebar-only mode only shows the bubble after the delay fires.                                            
     - `AudioContext` is suspended on stop and closed on app destroy.                                                                                                                    
     - Orphaned Web Audio nodes are cleaned up after each ping.                                                                                                                          
     - NaN input in the delay field is guarded both in the UI handler and the store setter.                                                                                              
     - `wait-tone.ts` refactored from module-wide state to a factory for testability.                                                                                                    
                                                                                                                                                                                         
     ## Testing                                                                                                                                                                          
     - `pnpm check` passes (0 errors, 0 warnings)                                                                                                                                        
     - `pnpm test` passes (317/317 tests)                                                                                                                                                
                                                                                                                                                                                         
     ## Notes for reviewers                                                                                                                                                              
     - `destroy()` is terminal: `start()` after `destroy()` is a no-op. This matches the app lifecycle where `destroyWaitTone()` is only called in `onDestroy`.                          
     - Browsers throttle `setInterval` in background tabs to ≥1000ms; our default ping interval (2200ms) is unaffected.           