### PR TITLE
chore(ci): run pnpm build in the web job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Test
         run: pnpm test
 
+      # check and test don't resolve CSS side-effect imports or other
+      # build-only failures; a route can 500 in production with both green.
+      - name: Build
+        run: pnpm build
+
   tauri:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
check and test don't resolve CSS side-effect imports or other build-only failures, so a route can 500 in production while CI stays green. Caught during the PR #129 review where all three new settings pages failed to resolve a stylesheet import that both gates passed.

Verified pnpm build exits 0 on current main before adding the step.