### PR TITLE
feat(chat): chat UX overhaul with docked window input, shimmer status, and text reveal

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@
 - **Scene Backgrounds**: Swap the backdrop behind her for pastel gradients or cute patterns (dots, hearts, sparkles, stripes, gingham) right from the Controls panel; your pick persists
 - **Physics Intensity**: A Movement slider from Subtle to Lively scales how much her hair and outfit respond to motion, respecting each model's own rig tuning
 - **Model-Centric UI**: Full-screen 3D model with unobtrusive overlay controls
-- **3D Speech Bubbles**: Chat responses appear as bubbles that track the model's head in 3D space
-- **Chat History Sidebar**: Optional side panel showing the full conversation history, with a configurable display mode (bubble, sidebar, both, or off) in Settings > Display
-- **Typing Indicator**: Configurable delay before the typing dots appear, plus an optional soft audio ping while she is thinking
-- **Chat Interface**: Bottom-centered input bar with streaming responses
+- **3D Speech Bubbles**: Chat responses appear as bubbles that track the model's head in 3D space, revealed word by word at a configurable speed
+- **Chat Window**: Optional messenger-style floating window with the full conversation history and the input docked inside; drag it anywhere, resize from any edge, snap it left or right. Display modes (Immersive, Chat window, Both, Off) live in Settings > Display
+- **Thinking Status**: A shimmer label narrates what she is actually doing (Remembering, Looking at your photo, Thinking), with a configurable delay and an optional soft audio ping
+- **Chat Interface**: Floating input bar (left, center, or right aligned) with streaming responses
 - **Voice Input**: Speech-to-text via a local Whisper server (Speaches, faster-whisper-server, whisper.cpp), Groq (Whisper), or the browser's Web Speech API, with real-time audio visualization
 - **Show Her Photos**: Show your companion an image via the attach (paperclip) button in the chat bar or drag-and-drop. Vision-capable models (GPT-4o, Claude, Gemini, or local ones like LLaVA) actually see it and can remember the moment, and kept photos live on a scrapbook-style board. Images stay on your device and only ever reach vision-capable models
 - **LLM Integration**: Support for 8 LLM providers: OpenAI, Anthropic, Google, xAI, DeepSeek, Ollama, LM Studio, and any OpenAI-compatible endpoint (OpenRouter, Together, vLLM, ...)

--- a/docs/superpowers/plans/2026-07-18-chat-ux-overhaul.md
+++ b/docs/superpowers/plans/2026-07-18-chat-ux-overhaul.md
@@ -1,0 +1,162 @@
+# Chat UX Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dock the chat input into the chat window when open, restyle chat surfaces gray, add phase-aware shimmer thinking labels and word-by-word reply reveal, fix window resize, and expand Display settings with placement controls.
+
+**Architecture:** Extract the input core from BottomChatBar into a shared ChatInput component backed by a chat-draft store so the draft survives surface switches. Two new UI primitives (ShimmerLabel, StreamingText) implemented from scratch. ChatSidebar becomes ChatWindow with custom edge-resize. Pipeline gains an optional setPhase hook. Display store gains textRevealSpeed, chatBarAlignment, and a window-reset token.
+
+**Tech Stack:** Svelte 5 runes, TypeScript, node --test, Dexie-free (localStorage persistence only).
+
+## Global Constraints
+
+- Node 22: `export PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH"`
+- Relative imports in files under test need `.ts` extensions (node --test).
+- No `any`, no `@ts-ignore` without justification.
+- No AI attribution in commits. Conventional commit format. No em dashes or emojis anywhere.
+- Stored ChatDisplayMode values stay `bubble | sidebar | both | off`; only labels change.
+- `pnpm test` and `pnpm check` must be clean before the PR; live e2e (utsuwa-e2e) before claiming done.
+
+---
+
+### Task 1: Display store fields (textRevealSpeed, chatBarAlignment, reset token)
+
+**Files:**
+- Modify: `src/lib/stores/display-types.ts`
+- Modify: `src/lib/stores/display-parser.ts`
+- Test: `src/lib/stores/display-parser.test.ts`
+- Modify: `src/lib/stores/display.svelte.ts`
+
+**Interfaces:**
+- Produces: `type TextRevealSpeed = 'off' | 'slow' | 'normal' | 'fast'`;
+  `type ChatBarAlignment = 'left' | 'center' | 'right'`;
+  `REVEAL_SPEED_MS: Record<TextRevealSpeed, number>` = off 0, slow 110, normal 60, fast 30;
+  defaults `DEFAULT_TEXT_REVEAL_SPEED = 'normal'`, `DEFAULT_CHAT_BAR_ALIGNMENT = 'center'`;
+  displayStore getters `textRevealSpeed`, `chatBarAlignment`, `chatWindowResetToken` and setters `setTextRevealSpeed(v)`, `setChatBarAlignment(v)`, `requestChatWindowReset()`.
+
+- [ ] Step 1: Add failing parser tests to `display-parser.test.ts`: valid values round-trip, unknown strings and non-strings fall back to defaults, absent fields fall back to defaults.
+- [ ] Step 2: `node --test src/lib/stores/display-parser.test.ts` fails on the new assertions.
+- [ ] Step 3: Add the types, defaults, and `REVEAL_SPEED_MS` to display-types; sanitize both fields in `parseDisplaySettings` with allow-list checks mirroring the existing chatDisplayMode handling.
+- [ ] Step 4: Tests pass.
+- [ ] Step 5: Extend `display.svelte.ts`: state, persistence in `save()`, hydration, setters, and `chatWindowResetToken` (session-only counter, not persisted; `requestChatWindowReset()` increments it). `resetChatDisplay()` also resets the two new fields.
+- [ ] Step 6: `pnpm test` green. Commit `feat(display): text reveal speed, bar alignment, window reset token`.
+
+### Task 2: Phase label mapping + pipeline hook
+
+**Files:**
+- Create: `src/lib/services/chat/chat-phase.ts`
+- Test: `src/lib/services/chat/chat-phase.test.ts`
+- Modify: `src/lib/services/chat/companion-chat.ts`
+
+**Interfaces:**
+- Produces: `type ThinkingPhase = 'remembering' | 'seeing' | 'thinking'`;
+  `phaseLabel(phase: ThinkingPhase): string` (Remembering... / Looking at your photo... / Thinking...);
+  optional hook `setPhase?: (phase: ThinkingPhase) => void` on `CompanionChatHooks`.
+
+- [ ] Step 1: Failing test for `phaseLabel` covering all three values.
+- [ ] Step 2: Verify fail, implement, verify pass.
+- [ ] Step 3: In `sendCompanionMessage`: `hooks.setPhase?.('remembering')` right after `setTyping(true)`; `hooks.setPhase?.(images.length > 0 ? 'seeing' : 'thinking')` immediately before the LLM request goes out.
+- [ ] Step 4: `pnpm test` + `pnpm check` green. Commit `feat(chat): thinking phase hook with real pipeline stages`.
+
+### Task 3: ShimmerLabel primitive
+
+**Files:**
+- Create: `src/lib/components/ui/ShimmerLabel.svelte`
+- Modify: `src/lib/components/ui/index.ts` (export)
+
+**Interfaces:**
+- Produces: `<ShimmerLabel label={string} />`. Gradient sweep via
+  `background: linear-gradient(90deg, var(--text-tertiary), var(--text-primary), var(--text-tertiary)); background-size: 200% 100%; -webkit-background-clip: text; color: transparent;` animating `background-position` 2s linear infinite. Under `prefers-reduced-motion`: static `var(--text-secondary)`, no animation. Label swaps crossfade with a 150ms key transition.
+
+- [ ] Step 1: Implement component. Step 2: `pnpm check` green. Commit `feat(ui): shimmer label primitive`.
+
+### Task 4: Reveal helper + StreamingText primitive
+
+**Files:**
+- Create: `src/lib/components/chat/reveal-markup.ts`
+- Test: `src/lib/components/chat/reveal-markup.test.ts`
+- Create: `src/lib/components/ui/StreamingText.svelte`
+
+**Interfaces:**
+- Produces: `wrapWordsInHtml(html: string): { html: string; wordCount: number }`
+  walks text nodes only, wraps each whitespace-delimited word in
+  `<span class="reveal-word" style="--word-index:N">`, preserves inline tags
+  (strong, em, code) and whitespace exactly. `<StreamingText text speedMs onComplete />`
+  for plain text (bubble): word spans fade in on an interval, blinking caret while
+  revealing; `speedMs <= 0` or reduced motion renders instantly and fires onComplete.
+
+- [ ] Step 1: Failing tests for `wrapWordsInHtml`: plain text, nested strong/em, code spans kept whole per word, whitespace preservation, empty string. Uses a minimal hand-rolled tag tokenizer (no DOM in node --test).
+- [ ] Step 2: Verify fail, implement, verify pass.
+- [ ] Step 3: Implement StreamingText with `$state` shown counter, `$effect` interval cleanup on unmount and text change.
+- [ ] Step 4: Gates green. Commit `feat(ui): word-by-word reveal primitives`.
+
+### Task 5: chat-draft store
+
+**Files:**
+- Create: `src/lib/stores/chat-draft.svelte.ts`
+
+**Interfaces:**
+- Produces: `chatDraftStore` with `draft: string` (get/set), `pending: { image: PreparedImage; url: string }[]`, `addPending(image, url)`, `removePending(id)` (revokes URL), `takeAll(): { text: string; images: PreparedImage[] }` (returns trimmed draft plus images, revokes URLs, clears state).
+
+- [ ] Step 1: Implement (thin runes store; mirrors existing store style).
+- [ ] Step 2: `pnpm check` green. Commit `feat(chat): shared draft store for input surfaces`.
+
+### Task 6: ChatInput extraction + BottomChatBar refactor + gray restyle
+
+**Files:**
+- Create: `src/lib/components/chat/ChatInput.svelte`
+- Modify: `src/lib/components/chat/BottomChatBar.svelte`
+
+**Interfaces:**
+- Produces: `<ChatInput onSend disabled visionCapable overlay docked onAttachBlocked />`;
+  reads/writes chatDraftStore; owns textarea autosize, Enter-to-send, mic/STT states,
+  pending chips, attach picker. `onAttachBlocked()` lets the host surface the vision hint.
+- BottomChatBar new props: `barHidden: boolean` (window open), alignment from displayStore.
+
+- [ ] Step 1: Move input core into ChatInput; keep behavior identical (drag-drop stays in BottomChatBar and feeds `chatDraftStore.addPending`).
+- [ ] Step 2: BottomChatBar renders ChatInput; hides `.bar-row` and mood fab when `barHidden`; keeps drop zone and toasts mounted. Alignment: `left | center | right` maps to flex positioning of the fixed container.
+- [ ] Step 3: Restyle: input surface and mood fab `--bg-secondary` + `1px solid var(--border-subtle)`; docked variant flat (no pill radius, no shadow).
+- [ ] Step 4: Gates green. Manual smoke in dev server. Commit `refactor(chat): extract ChatInput with shared draft, gray restyle`.
+
+### Task 7: ChatWindow (rename, custom resize, docked input, reveal, shimmer)
+
+**Files:**
+- Rename: `src/lib/components/chat/ChatSidebar.svelte` -> `ChatWindow.svelte`
+- Modify: `src/routes/app/+page.svelte` (import)
+
+**Interfaces:**
+- Produces: `<ChatWindow open onClose isTyping phase onSend disabled visionCapable />`.
+
+- [ ] Step 1: Rename component and update imports.
+- [ ] Step 2: Replace `resize: both` with eight handle divs (n s e w ne nw se sw). Pointer-capture drag: on down store start rect + pointer; on move apply direction deltas with min 260x220 and viewport clamp; on up persist. Remove the ResizeObserver.
+- [ ] Step 3: Re-clamp saved rect on every open and on window resize. Observe `displayStore.chatWindowResetToken`; on change clear `utsuwa-chat-panel` and re-derive default rect.
+- [ ] Step 4: Header gains mood chip (moodInfo icon + color, title attribute description). Bottom row renders docked ChatInput above a `--border-subtle` top border.
+- [ ] Step 5: Latest assistant message renders via `wrapWordsInHtml(renderMarkdown(content))` with staggered fade-in using `--word-index` and the reveal cadence from `displayStore.textRevealSpeed`; older messages static. Typing row shows `<ShimmerLabel label={phaseLabel(phase)} />`.
+- [ ] Step 6: Gates green. Commit `feat(chat): chat window with docked input, custom resize, reveal`.
+
+### Task 8: App page + SpeechBubble + overlay wiring
+
+**Files:**
+- Modify: `src/routes/app/+page.svelte`
+- Modify: `src/lib/components/chat/SpeechBubble.svelte`
+- Modify: `src/routes/overlay/+page.svelte`
+
+- [ ] Step 1: App page: `phase` state fed by `setPhase` hook; window-open state hides the floating bar (`barHidden`); ChatWindow receives send wiring; Both mode = bubble + window (input in window).
+- [ ] Step 2: SpeechBubble: typing indicator -> ShimmerLabel with phase label; message -> StreamingText with `REVEAL_SPEED_MS[displayStore.textRevealSpeed]`.
+- [ ] Step 3: Overlay page: pass setPhase, same bubble upgrades; no window there.
+- [ ] Step 4: Gates green. Commit `feat(chat): wire phase, reveal, and docking through app and overlay`.
+
+### Task 9: Display settings page
+
+**Files:**
+- Modify: `src/routes/app/settings/display/+page.svelte`
+
+- [ ] Step 1: Mode labels Immersive / Chat window / Both / Off with updated hint copy. Chat Window card: snap side + Reset window position button (`displayStore.requestChatWindowReset()`). Floating Bar card: alignment segments. Text Reveal card: speed segments.
+- [ ] Step 2: Gates green. Commit `feat(settings): chat placement and reveal controls`.
+
+### Task 10: Docs + gates + e2e + PR
+
+- [ ] Step 1: README feature bullets; companion-system.md pipeline hooks section (setPhase).
+- [ ] Step 2: `pnpm test` and `pnpm check` fully clean.
+- [ ] Step 3: utsuwa-e2e live verification: all four modes; dock transition mid-draft (text + queued photo survive); resize all edges, close, reopen, resize; reset window position; settings persist across reload; overlay shimmer + reveal; reduced-motion check.
+- [ ] Step 4: PR with evidence-based body. Do not merge without authorization.

--- a/docs/superpowers/specs/2026-07-18-camera-jiggle-design.md
+++ b/docs/superpowers/specs/2026-07-18-camera-jiggle-design.md
@@ -1,0 +1,42 @@
+# Camera-Driven Spring Bone Impulse ("jiggle on orbit")
+
+Date: 2026-07-18
+Status: approved
+Scope: PR 2 of 2 (follows the chat UX overhaul)
+
+## Goal
+
+Orbiting or dollying the camera should excite the VRM spring bones (hair,
+chest, accessories) in the main view and in photo mode, so the model reads as
+physical instead of frozen while the viewpoint moves.
+
+## Decision (locked with CJ)
+
+Scaled by the existing physics intensity setting. No new UI.
+
+## Approach
+
+VRM spring bones only react to bone movement, so camera motion produces no
+force today. We inject one: each frame, compute the camera's angular and
+positional velocity, derive a world-space impulse, and apply it to the spring
+bone simulation scaled by `physicsIntensity`.
+
+- Pure logic (`src/lib/engine/camera-impulse.ts`, TDD): given previous and
+  current camera state (position, quaternion) and delta time, produce a
+  clamped impulse vector. Dead zone for tiny drifts, cap for whip pans,
+  exponential decay so the impulse settles instead of cutting.
+- Integration: the scene's per-frame update applies the impulse to the spring
+  bone manager before its update tick. Exact injection point against
+  three-vrm's spring bone API (joint settings vs manual offset of joint
+  initial state) is a short research spike at implementation start; the spec
+  commits to behavior, not the mechanism.
+- Photo mode shares the same scene loop, so it comes free. Verify explicitly
+  in e2e.
+
+## Testing
+
+- TDD for the impulse math: dead zone, clamping, decay, intensity scaling,
+  zero-delta safety.
+- `pnpm test` and `pnpm check` clean.
+- Live e2e: orbit in main view and in photo mode at intensity 0 (no effect),
+  default, and max; confirm no drift or oscillation after the camera stops.

--- a/docs/superpowers/specs/2026-07-18-chat-ux-overhaul-design.md
+++ b/docs/superpowers/specs/2026-07-18-chat-ux-overhaul-design.md
@@ -1,0 +1,136 @@
+# Chat UX Overhaul
+
+Date: 2026-07-18
+Status: approved
+Scope: PR 1 of 2 (PR 2 is camera-driven jiggle physics, separate spec)
+
+## Goal
+
+Make the chat experience feel deliberate and polished: the input docks into the
+chat window when it is open, the chat surfaces use the design system's gray
+tokens, thinking states narrate the real pipeline phases with a shimmer label,
+replies reveal word by word, the window resizes reliably, and Display settings
+give real placement control.
+
+## Decisions (locked with CJ)
+
+1. Input docks into the chat window whenever the window is open, in every mode
+   that shows the window (Chat window, Both). The floating bar returns when the
+   window closes.
+2. Mode labels become Immersive / Chat window / Both / Off. Stored values
+   (`bubble`, `sidebar`, `both`, `off`) are unchanged; no migration.
+3. Thinking indicator is a phase-aware shimmer label driven by real pipeline
+   stages. No fake chain of thought.
+4. Reply text reveals word by word at a fixed cadence, independent of TTS.
+   Speed setting: off / slow / normal / fast. Reduced motion means instant.
+5. Display settings gain: window snap side (existing), reset window position,
+   floating bar alignment (left / center / right), text reveal speed.
+6. Input architecture: extract a shared ChatInput component; typed draft and
+   queued photos live in a store so they survive surface switches.
+7. Visual primitives are implemented from scratch against Mizu UI's documented
+   behavior (license unverifiable, so no source is copied).
+
+## Components
+
+### New primitives (`src/lib/components/ui/`)
+
+- `ShimmerLabel.svelte`: text with an animated gradient sweep
+  (background-clip: text, background-position keyframes). Props: `label`.
+  Falls back to static secondary-color text under `prefers-reduced-motion`.
+- `StreamingText.svelte`: reveals `text` word by word. Words wrap in spans that
+  fade in; an interval advances the shown count every `speedMs`. Props:
+  `text`, `speedMs`, `onComplete`. `speedMs <= 0` or reduced motion renders
+  instantly. Also exports a helper used by the chat window to walk rendered
+  markdown HTML and wrap text-node words in reveal spans so inline markup
+  (strong, em, code) survives.
+
+### Input extraction
+
+- `ChatInput.svelte` (new, from BottomChatBar): textarea with autosize,
+  Enter-to-send, attach button plus hidden file input, mic / STT states
+  (listening, transcribing, visualizer), pending photo chips. Prop `docked`
+  switches pill styling (floating) to flat row styling (docked).
+- `chat-draft.svelte.ts` (new store): `draft` text and `pending` photo queue
+  (PreparedImage + object URL). Both surfaces bind to it; object URLs are
+  revoked on send/remove exactly as today.
+- `BottomChatBar.svelte` keeps: mood fab, stats tray, drop-zone overlay,
+  toasts (STT error, vision hint, privacy notice), Tauri drag-drop wiring, and
+  now renders `ChatInput` in floating style. It stays mounted while the chat
+  window is open (drops and toasts must keep working) but hides its visible
+  bar row and mood fab; dropped photos land in the shared draft store and
+  appear as chips in the window's docked input.
+
+### Chat window
+
+- `ChatSidebar.svelte` renamed to `ChatWindow.svelte`.
+- Custom resize: pointer-captured handles on all four edges and corners
+  replacing native `resize: both`. Min 260x220, clamped to viewport. Rect
+  persists under the existing `utsuwa-chat-panel` key; re-clamped on every
+  open and on window resize (fixes the reopen-resize bug).
+- Header: mood chip (replaces the floating mood fab while docked), title,
+  snap left / right, clear, close. Drag-to-move unchanged.
+- Bottom row: docked `ChatInput` above a subtle top border.
+- Latest assistant message renders through the markdown-aware reveal helper;
+  older messages render statically.
+
+### Pipeline phase hook
+
+- `companion-chat.ts` hooks gain `setPhase(phase)` with values
+  `remembering | seeing | thinking`. Fired at the real stages: memory
+  retrieval start (remembering), then at LLM request start either seeing
+  (when the turn includes images) or thinking. Seeing wins over thinking for
+  image turns. `setTyping(false)` clears the phase.
+- Phase-to-label mapping is a pure function with tests:
+  remembering -> "Remembering...", seeing -> "Looking at your photo...",
+  thinking -> "Thinking...".
+- SpeechBubble and ChatWindow show `ShimmerLabel` with the mapped label where
+  the bouncing dots were. The existing typing-indicator delay and wait tone
+  gate visibility unchanged. The desktop overlay gets the same through the
+  shared components.
+
+### Display store and settings
+
+- New persisted fields with defaults: `chatBarAlignment: 'center'`
+  (`left | center | right`), `textRevealSpeed: 'normal'`
+  (`off | slow | normal | fast`; cadence map off=0, slow=110ms, normal=60ms,
+  fast=30ms per word).
+- `parseDisplaySettings` sanitizes both (unknown values fall back to
+  defaults); tests first, TDD.
+- Reset window position: displayStore gains a `chatWindowResetToken` counter;
+  the settings button increments it, ChatWindow observes it, clears the saved
+  rect, and re-derives the default rect.
+- Settings page layout per the approved mock: Chat Display segments with new
+  labels and hint copy, Chat Window card (snap side + reset button), Floating
+  Bar card (alignment), Text Reveal card (speed), existing Typing Indicator
+  card unchanged.
+
+### Gray restyle
+
+- Input surface (floating pill and docked row) moves from `--bg-primary` to
+  `--bg-secondary` with a `--border-subtle` border, both themes. Mood fab
+  matches. Contrast spot-checked in light and dark.
+
+## Error handling
+
+- Phase hook is optional in the hooks interface; overlay or future callers
+  that do not pass it lose nothing.
+- StreamingText clears its interval on unmount and on text change; a new
+  message mid-reveal restarts cleanly.
+- Malformed persisted rects or display settings fall back to defaults (already
+  the pattern; extended to new fields).
+
+## Testing
+
+- TDD (pure logic): display-parser new fields, phase label mapping, word
+  splitting / markdown text-node walking for the reveal helper.
+- `pnpm test` and `pnpm check` clean.
+- Live e2e (utsuwa-e2e): every mode renders correctly; dock transition
+  mid-draft preserves text and queued photo; resize from all edges, close,
+  reopen, resize again; reset window position rescues an off-screen window;
+  new settings persist across reload; overlay shimmer and reveal; reduced
+  motion sanity check.
+
+## Docs
+
+- README feature list; `src/content/docs/technology/companion-system.md`
+  pipeline hooks section.

--- a/src/content/docs/technology/companion-system.md
+++ b/src/content/docs/technology/companion-system.md
@@ -319,6 +319,10 @@ The system prompt is built from up to 7 layers:
 6. **Event** *(optional)* — Present only for system events such as a fired reminder: the trigger text arrives in an `<event>` block instead of a user turn
 7. **Instructions** — Stage-specific behavior guidance, JSON output format
 
+### Turn Progress Hooks
+
+The send loop (`companion-chat.ts`) reports progress to whichever surface hosts it (main app or desktop overlay) through a small hooks interface. Beyond the typing flag and the final reply, an optional `setPhase` hook narrates what the turn is actually doing: `remembering` while memory retrieval builds the prompt, then `seeing` (image turns) or `thinking` once the model call starts. The UI renders these as a shimmer label in the speech bubble and chat window instead of anonymous typing dots. The phases are driven by the real pipeline stages, never simulated.
+
 ### System Events and Reminders
 
 Not every turn starts with the user. The companion can schedule reminders and timers, either by emitting a `[reminder:5min]content[/reminder]` tag in her reply or from natural phrasing like "remind me in 10 minutes" via a client-side fallback. Reminders persist in the `reminders` table, fire from a poll loop that survives reloads, and timers missed while the app was closed surface on the next launch.

--- a/src/lib/components/chat/BottomChatBar.svelte
+++ b/src/lib/components/chat/BottomChatBar.svelte
@@ -8,6 +8,7 @@
 	import { displayStore } from '$lib/stores/display.svelte';
 	import { chatHintStore } from '$lib/stores/chat-hint.svelte';
 	import { queueFiles, imageMimeFromPath } from './attach-files';
+	import { chatDraftStore } from '$lib/stores/chat-draft.svelte';
 	import { type PreparedImage } from '$lib/services/storage/keepsakes';
 	import ChatInput from './ChatInput.svelte';
 	import { pop, fadeFast } from '$lib/utils/motion';
@@ -67,8 +68,8 @@
 		return () => chatHintStore.destroy();
 	});
 
-	// Drag-to-show: the whole window is a drop target; the bar morphs into one.
-	let dragActive = $state(false);
+	// Drag-to-show: the whole window is a drop target. The active flag lives in
+	// the draft store so whichever surface is visible shows the affordance.
 	let dragDepth = 0;
 
 	function dragHasFiles(e: DragEvent): boolean {
@@ -78,7 +79,7 @@
 	function handleDragEnter(e: DragEvent) {
 		if (overlay || !dragHasFiles(e)) return;
 		dragDepth++;
-		dragActive = true;
+		chatDraftStore.setDropActive(true);
 	}
 
 	function handleDragOver(e: DragEvent) {
@@ -90,7 +91,7 @@
 		dragDepth--;
 		if (dragDepth <= 0) {
 			dragDepth = 0;
-			dragActive = false;
+			chatDraftStore.setDropActive(false);
 		}
 	}
 
@@ -98,7 +99,7 @@
 		if (!dragHasFiles(e)) return;
 		e.preventDefault();
 		dragDepth = 0;
-		dragActive = false;
+		chatDraftStore.setDropActive(false);
 		if (!overlay) queueFiles(e.dataTransfer?.files ?? null, visionCapable);
 	}
 
@@ -114,12 +115,12 @@
 			if (cancelled) return;
 			unlisten = await getCurrentWindow().onDragDropEvent(async (event) => {
 				if (event.payload.type === 'over') {
-					dragActive = true;
+					chatDraftStore.setDropActive(true);
 				} else if (event.payload.type === 'leave') {
-					dragActive = false;
+					chatDraftStore.setDropActive(false);
 					dragDepth = 0;
 				} else if (event.payload.type === 'drop') {
-					dragActive = false;
+					chatDraftStore.setDropActive(false);
 					dragDepth = 0;
 					const imagePaths = event.payload.paths.filter((p) => imageMimeFromPath(p));
 					if (imagePaths.length === 0) return; // not images (VrmUploader etc. handle those)
@@ -209,18 +210,22 @@
 {#if !barHidden}
 	<div
 		class="bottom-chat-bar"
-		class:dragging={dragActive}
+		class:dragging={chatDraftStore.dropActive}
 		class:align-left={displayStore.chatBarAlignment === 'left'}
 		class:align-right={displayStore.chatBarAlignment === 'right'}
 	>
-		{#if dragActive}
+		{#if chatDraftStore.dropActive}
 			<div class="drop-zone" out:fadeFast={{ duration: 120 }}>
 				<Icon name="camera" size={22} />
 				<span>Drop a photo to show her</span>
 			</div>
 		{/if}
 		{#if showStats && !overlay}
-			<div class="stats-tray" out:pop={{ base: 'translateX(-50%)', y: 8, duration: 200 }}>
+			<div class="stats-tray" out:pop={{ y: 8, duration: 200 }}>
+				<div class="tray-mood">
+					<span class="mood-dot" style="color: {moodInfo.color}"><Icon name={moodInfo.icon} size={16} /></span>
+					<span>{moodInfo.description}</span>
+				</div>
 				<div class="stat-list">
 					{#each stats as stat}
 						<div class="stat-row">
@@ -253,20 +258,9 @@
 					title={moodInfo.description}
 				>
 					<span class="mood-dot" style="color: {moodInfo.color}"><Icon name={moodInfo.icon} size={20} /></span>
-					{#if showStats}
-						<span class="mood-fab-label" in:fadeFast={{ duration: 150 }}>{moodInfo.description}</span>
-					{/if}
 				</button>
 			{/if}
 			<ChatInput {onSend} {disabled} {visionCapable} {overlay} />
-		</div>
-	</div>
-{:else if dragActive}
-	<!-- Window mode: the bar is hidden but drops still land in the shared draft -->
-	<div class="bottom-chat-bar">
-		<div class="drop-zone" out:fadeFast={{ duration: 120 }}>
-			<Icon name="camera" size={22} />
-			<span>Drop a photo to show her</span>
 		</div>
 	</div>
 {/if}
@@ -402,15 +396,15 @@
 	}
 
 	/* Floating mood button (companion status) */
+	/* Fixed size: expanding it would shove the input pill off center */
 	.mood-fab {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		gap: 0.45rem;
 		flex-shrink: 0;
 		height: 56px;
-		min-width: 56px;
-		padding: 0 1rem;
+		width: 56px;
+		padding: 0;
 		border: 1px solid var(--border-subtle);
 		border-radius: var(--radius-full);
 		background: var(--bg-secondary);
@@ -431,12 +425,6 @@
 		flex-shrink: 0;
 	}
 
-	.mood-fab-label {
-		font-size: 0.85rem;
-		font-weight: 500;
-		white-space: nowrap;
-	}
-
 	/* Stats tray (expands above the pill) */
 	.stats-tray {
 		margin-bottom: 0.5rem;
@@ -450,6 +438,16 @@
 	@keyframes trayIn {
 		from { opacity: 0; transform: translateY(8px); }
 		to { opacity: 1; transform: translateY(0); }
+	}
+
+	.tray-mood {
+		display: flex;
+		align-items: center;
+		gap: 0.45rem;
+		margin-bottom: 0.7rem;
+		font-size: 0.82rem;
+		font-weight: 600;
+		color: var(--text-primary);
 	}
 
 	.stat-list {

--- a/src/lib/components/chat/BottomChatBar.svelte
+++ b/src/lib/components/chat/BottomChatBar.svelte
@@ -2,12 +2,14 @@
 	import { Icon } from '$lib/components/ui';
 	import { characterStore } from '$lib/stores/character.svelte';
 	import { localPath } from '$lib/config/links';
-	import { browser } from '$app/environment';
 	import { isTauri } from '$lib/services/platform/platform';
-	import { sttStore } from '$lib/stores/stt.svelte';
 	import { ttsStore } from '$lib/stores/tts.svelte';
-	import { prepareImage, UnsupportedImageError, type PreparedImage } from '$lib/services/storage/keepsakes';
-	import AudioVisualizer from './AudioVisualizer.svelte';
+	import { sttStore } from '$lib/stores/stt.svelte';
+	import { displayStore } from '$lib/stores/display.svelte';
+	import { chatHintStore } from '$lib/stores/chat-hint.svelte';
+	import { queueFiles, imageMimeFromPath } from './attach-files';
+	import { type PreparedImage } from '$lib/services/storage/keepsakes';
+	import ChatInput from './ChatInput.svelte';
 	import { pop, fadeFast } from '$lib/utils/motion';
 
 	interface Props {
@@ -18,6 +20,9 @@
 		providerIsLocal?: boolean;
 		/** Overlay window: image-showing is disabled (no native file dialog / drop). */
 		overlay?: boolean;
+		/** The chat window is open and owns the input; keep drops and toasts alive
+		 *  but hide the visible bar. */
+		barHidden?: boolean;
 	}
 
 	let {
@@ -26,7 +31,8 @@
 		visionCapable = true,
 		providerLabel = 'your AI provider',
 		providerIsLocal = false,
-		overlay = false
+		overlay = false,
+		barHidden = false
 	}: Props = $props();
 
 	// Companion mood + stats, merged into the command bar.
@@ -50,63 +56,17 @@
 	]);
 	const stats = $derived(isCompanionMode ? companionStats : datingStats);
 
-	// Brief toast for image issues (blind model, unsupported format).
-	let hint = $state<string | null>(null);
-	let hintTimer: ReturnType<typeof setTimeout> | null = null;
-
-	function showHint(message: string) {
-		hint = message;
-		if (hintTimer) clearTimeout(hintTimer);
-		hintTimer = setTimeout(() => (hint = null), 6000);
-	}
-
-	$effect(() => {
-		return () => {
-			if (hintTimer) clearTimeout(hintTimer);
-		};
-	});
-
 	// Surface voice playback failures; without this a TTS misconfiguration
 	// (like a stale voice id after switching providers) looks like she simply
 	// chose not to speak.
 	$effect(() => {
-		if (ttsStore.lastError) showHint(ttsStore.lastError);
+		if (ttsStore.lastError) chatHintStore.showHint(ttsStore.lastError);
 	});
 
-	function promptVision() {
-		showHint(
-			"This model can't see images. Pick a vision model (GPT-4o, Claude, Gemini, or a local one like llava) in Settings."
-		);
-	}
+	$effect(() => {
+		return () => chatHintStore.destroy();
+	});
 
-	// One-time "where do photos go" disclosure, shown the first time an image is
-	// attached and then remembered so it never nags again.
-	const PRIVACY_ACK_KEY = 'utsuwa-image-privacy-ack';
-	let showPrivacy = $state(false);
-
-	function maybeShowPrivacyNotice() {
-		if (!browser || localStorage.getItem(PRIVACY_ACK_KEY) === '1') return;
-		showPrivacy = true;
-	}
-	function ackPrivacy() {
-		if (browser) localStorage.setItem(PRIVACY_ACK_KEY, '1');
-		showPrivacy = false;
-	}
-
-	function openPicker() {
-		if (overlay) return;
-		if (!visionCapable) {
-			promptVision();
-			return;
-		}
-		fileInput?.click();
-	}
-
-	let inputValue = $state('');
-	let textareaRef = $state<HTMLTextAreaElement | null>(null);
-	let fileInput = $state<HTMLInputElement | null>(null);
-	// Images queued to show her, each with a preview URL for the chip.
-	let pending = $state<{ image: PreparedImage; url: string }[]>([]);
 	// Drag-to-show: the whole window is a drop target; the bar morphs into one.
 	let dragActive = $state(false);
 	let dragDepth = 0;
@@ -139,60 +99,12 @@
 		e.preventDefault();
 		dragDepth = 0;
 		dragActive = false;
-		handleFiles(e.dataTransfer?.files ?? null);
-	}
-
-	const isListening = $derived(sttStore.isListening);
-	const isTranscribing = $derived(sttStore.isTranscribing);
-	const audioLevel = $derived(sttStore.audioLevel);
-	const displayTranscript = $derived(sttStore.displayTranscript);
-	const sttError = $derived(sttStore.error);
-
-	// Track if there's content to send
-	const hasContent = $derived(
-		inputValue.trim().length > 0 || displayTranscript.trim().length > 0 || pending.length > 0
-	);
-
-	async function handleFiles(files: FileList | File[] | null) {
-		if (overlay || !files) return;
-		if (!visionCapable) {
-			promptVision();
-			return;
-		}
-		for (const file of Array.from(files)) {
-			if (!file.type.startsWith('image/')) continue;
-			try {
-				const image = await prepareImage(file);
-				pending = [...pending, { image, url: URL.createObjectURL(file) }];
-				maybeShowPrivacyNotice();
-			} catch (e) {
-				showHint(
-					e instanceof UnsupportedImageError
-						? "That image format isn't supported. Try a JPEG, PNG, GIF or WebP (iPhone HEIC photos won't work)."
-						: "Couldn't read that image. Try a different one."
-				);
-			}
-		}
-		if (fileInput) fileInput.value = '';
+		if (!overlay) queueFiles(e.dataTransfer?.files ?? null, visionCapable);
 	}
 
 	// On desktop, Tauri's webview intercepts drag-and-drop so dataTransfer.files
 	// is empty (native drag-drop stays on for VRM upload). Read dropped image
 	// files via Tauri's own event + the fs plugin, mirroring VrmUploader.
-	const IMAGE_MIME: Record<string, string> = {
-		png: 'image/png',
-		jpg: 'image/jpeg',
-		jpeg: 'image/jpeg',
-		gif: 'image/gif',
-		webp: 'image/webp',
-		heic: 'image/heic',
-		heif: 'image/heif',
-		bmp: 'image/bmp'
-	};
-	function imageMimeFromPath(path: string): string | null {
-		return IMAGE_MIME[path.split('.').pop()?.toLowerCase() ?? ''] ?? null;
-	}
-
 	$effect(() => {
 		if (!isTauri() || overlay) return;
 		let cancelled = false;
@@ -211,10 +123,6 @@
 					dragDepth = 0;
 					const imagePaths = event.payload.paths.filter((p) => imageMimeFromPath(p));
 					if (imagePaths.length === 0) return; // not images (VrmUploader etc. handle those)
-					if (!visionCapable) {
-						promptVision();
-						return;
-					}
 					const { readFile } = await import('@tauri-apps/plugin-fs');
 					const files: File[] = [];
 					for (const path of imagePaths) {
@@ -223,10 +131,10 @@
 							const name = path.split(/[/\\]/).pop() || 'image';
 							files.push(new File([contents], name, { type: imageMimeFromPath(path)! }));
 						} catch {
-							showHint("Couldn't read that image. Try a different one.");
+							chatHintStore.showHint("Couldn't read that image. Try a different one.");
 						}
 					}
-					if (files.length) await handleFiles(files);
+					if (files.length) await queueFiles(files, visionCapable);
 				}
 			});
 		})();
@@ -235,66 +143,9 @@
 			unlisten?.();
 		};
 	});
-
-	function removePending(id: string) {
-		pending = pending.filter((p) => {
-			if (p.image.id === id) URL.revokeObjectURL(p.url);
-			return p.image.id !== id;
-		});
-	}
-
-	// Single send path: text plus any queued images.
-	function doSend(text: string) {
-		if (disabled) return;
-		const images = pending.map((p) => p.image);
-		if (!text && images.length === 0) return;
-		onSend(text, images);
-		pending.forEach((p) => URL.revokeObjectURL(p.url));
-		pending = [];
-		inputValue = '';
-		if (textareaRef) textareaRef.style.height = 'auto';
-	}
-
-	function handleSubmit(e: SubmitEvent) {
-		e.preventDefault();
-		doSend(inputValue.trim());
-	}
-
-	function handleKeydown(e: KeyboardEvent) {
-		if (e.key === 'Enter' && !e.shiftKey) {
-			e.preventDefault();
-			doSend(inputValue.trim());
-		}
-	}
-
-	function handleInput() {
-		if (textareaRef) {
-			textareaRef.style.height = 'auto';
-			textareaRef.style.height = Math.min(textareaRef.scrollHeight, 120) + 'px';
-		}
-	}
-
-	function handleMicClick() {
-		if (!sttStore.isSupported()) {
-			sttStore.showUnsupportedError();
-			return;
-		}
-		if (isListening) {
-			sttStore.stopListening();
-		} else {
-			sttStore.startListening((text) => {
-				onSend(text);
-			});
-		}
-	}
-
-	function handleCancelRecording() {
-		sttStore.cancel();
-	}
-
 </script>
 
-{#if sttError}
+{#if sttStore.error}
 	<div
 		class="stt-error"
 		out:pop={{ base: 'translateX(-50%)', y: -10, duration: 200 }}
@@ -309,14 +160,14 @@
 		tabindex="0"
 	>
 		<Icon name="alert" size={16} />
-		<span>{sttError}</span>
+		<span>{sttStore.error}</span>
 		<button type="button" class="dismiss-btn" aria-label="Dismiss">
 			<Icon name="x" size={14} />
 		</button>
 	</div>
 {/if}
 
-{#if hint}
+{#if chatHintStore.hint}
 	<div
 		class="vision-hint"
 		role="status"
@@ -324,11 +175,11 @@
 		out:pop={{ base: 'translateX(-50%)', y: -10, duration: 200 }}
 	>
 		<Icon name="camera" size={16} />
-		<span>{hint}</span>
+		<span>{chatHintStore.hint}</span>
 	</div>
 {/if}
 
-{#if showPrivacy}
+{#if chatHintStore.showPrivacy}
 	<div
 		class="privacy-notice"
 		out:pop={{ base: 'translateX(-50%)', y: -10, duration: 200 }}
@@ -344,7 +195,7 @@
 				saved on this device; delete them anytime from the board.
 			{/if}
 		</span>
-		<button type="button" class="privacy-ack" onclick={ackPrivacy}>Got it</button>
+		<button type="button" class="privacy-ack" onclick={() => chatHintStore.ackPrivacy()}>Got it</button>
 	</div>
 {/if}
 
@@ -355,136 +206,72 @@
 	ondrop={handleDrop}
 />
 
-<div class="bottom-chat-bar" class:dragging={dragActive}>
-	{#if dragActive}
+{#if !barHidden}
+	<div
+		class="bottom-chat-bar"
+		class:dragging={dragActive}
+		class:align-left={displayStore.chatBarAlignment === 'left'}
+		class:align-right={displayStore.chatBarAlignment === 'right'}
+	>
+		{#if dragActive}
+			<div class="drop-zone" out:fadeFast={{ duration: 120 }}>
+				<Icon name="camera" size={22} />
+				<span>Drop a photo to show her</span>
+			</div>
+		{/if}
+		{#if showStats && !overlay}
+			<div class="stats-tray" out:pop={{ base: 'translateX(-50%)', y: 8, duration: 200 }}>
+				<div class="stat-list">
+					{#each stats as stat}
+						<div class="stat-row">
+							<span class="s-icon" style="color: {stat.color}"><Icon name={stat.icon} size={15} /></span>
+							<span class="s-label">{stat.label}</span>
+							<span class="s-track"><span class="s-fill" style="width: {stat.value}%; background: {stat.color}"></span></span>
+							<span class="s-val">{Math.round(stat.value)}</span>
+						</div>
+					{/each}
+				</div>
+				<div class="stat-foot">
+					<span class="foot-stat"><Icon name="calendar" size={12} />{charState.daysKnown}d</span>
+					<span class="foot-stat"><Icon name="message-circle" size={12} />{charState.totalInteractions}</span>
+					{#if charState.currentStreak > 1}
+						<span class="foot-stat streak"><Icon name="flame" size={12} />{charState.currentStreak}</span>
+					{/if}
+					<a href={localPath('app', '/settings/persona')} class="foot-link">Profile <Icon name="arrow-right" size={12} /></a>
+				</div>
+			</div>
+		{/if}
+		<div class="bar-row">
+			{#if !overlay}
+				<button
+					type="button"
+					class="mood-fab"
+					class:active={showStats}
+					onclick={() => (showStats = !showStats)}
+					aria-label="Companion status"
+					aria-expanded={showStats}
+					title={moodInfo.description}
+				>
+					<span class="mood-dot" style="color: {moodInfo.color}"><Icon name={moodInfo.icon} size={20} /></span>
+					{#if showStats}
+						<span class="mood-fab-label" in:fadeFast={{ duration: 150 }}>{moodInfo.description}</span>
+					{/if}
+				</button>
+			{/if}
+			<ChatInput {onSend} {disabled} {visionCapable} {overlay} />
+		</div>
+	</div>
+{:else if dragActive}
+	<!-- Window mode: the bar is hidden but drops still land in the shared draft -->
+	<div class="bottom-chat-bar">
 		<div class="drop-zone" out:fadeFast={{ duration: 120 }}>
 			<Icon name="camera" size={22} />
 			<span>Drop a photo to show her</span>
 		</div>
-	{/if}
-	{#if showStats && !overlay}
-		<div class="stats-tray" out:pop={{ base: 'translateX(-50%)', y: 8, duration: 200 }}>
-			<div class="stat-list">
-				{#each stats as stat}
-					<div class="stat-row">
-						<span class="s-icon" style="color: {stat.color}"><Icon name={stat.icon} size={15} /></span>
-						<span class="s-label">{stat.label}</span>
-						<span class="s-track"><span class="s-fill" style="width: {stat.value}%; background: {stat.color}"></span></span>
-						<span class="s-val">{Math.round(stat.value)}</span>
-					</div>
-				{/each}
-			</div>
-			<div class="stat-foot">
-				<span class="foot-stat"><Icon name="calendar" size={12} />{charState.daysKnown}d</span>
-				<span class="foot-stat"><Icon name="message-circle" size={12} />{charState.totalInteractions}</span>
-				{#if charState.currentStreak > 1}
-					<span class="foot-stat streak"><Icon name="flame" size={12} />{charState.currentStreak}</span>
-				{/if}
-				<a href={localPath('app', '/settings/persona')} class="foot-link">Profile <Icon name="arrow-right" size={12} /></a>
-			</div>
-		</div>
-	{/if}
-	{#if pending.length > 0}
-		<div class="pending-row" out:fadeFast={{ duration: 150 }}>
-			{#each pending as p (p.image.id)}
-				<div class="pending-chip" in:pop={{ duration: 200, y: 6, scale: 0.9 }} out:fadeFast={{ duration: 120 }}>
-					<img src={p.url} alt="To show her" />
-					<button type="button" class="remove-chip" aria-label="Remove image" onclick={() => removePending(p.image.id)}>
-						<Icon name="x" size={12} />
-					</button>
-				</div>
-			{/each}
-		</div>
-	{/if}
-	<div class="bar-row">
-		{#if !overlay}
-			<button
-				type="button"
-				class="mood-fab"
-				class:active={showStats}
-				onclick={() => (showStats = !showStats)}
-				aria-label="Companion status"
-				aria-expanded={showStats}
-				title={moodInfo.description}
-			>
-				<span class="mood-dot" style="color: {moodInfo.color}"><Icon name={moodInfo.icon} size={20} /></span>
-				{#if showStats}
-					<span class="mood-fab-label" in:fadeFast={{ duration: 150 }}>{moodInfo.description}</span>
-				{/if}
-			</button>
-		{/if}
-		<form class="chat-form" onsubmit={handleSubmit}>
-			{#if !overlay}
-				<input
-					bind:this={fileInput}
-					type="file"
-					accept="image/*"
-					multiple
-					style="display:none"
-					onchange={(e) => handleFiles(e.currentTarget.files)}
-				/>
-			{/if}
-			<div class="input-wrapper" class:recording={isListening} class:transcribing={isTranscribing} class:focused={hasContent}>
-				{#if isTranscribing}
-					<div class="transcribing-label">Transcribing...</div>
-					<button
-						type="button"
-						class="mic-btn recording"
-						disabled
-						aria-label="Transcribing"
-					>
-						<Icon name="loader" size={20} />
-					</button>
-				{:else if isListening}
-					<AudioVisualizer {audioLevel} transcript={displayTranscript} />
-					<button
-						type="button"
-						class="mic-btn recording"
-						onclick={() => sttStore.stopListening()}
-						aria-label="Stop recording"
-						title="Stop recording"
-					>
-						<Icon name="stop" size={16} />
-					</button>
-				{:else}
-					{#if !overlay}
-						<button
-							type="button"
-							class="mic-btn"
-							class:vision-off={!visionCapable}
-							onclick={openPicker}
-							aria-label="Attach an image"
-							title={visionCapable ? 'Attach an image' : 'This model cannot see images'}
-						>
-							<Icon name="paperclip" size={20} />
-						</button>
-					{/if}
-					<textarea
-						bind:this={textareaRef}
-						bind:value={inputValue}
-						onkeydown={handleKeydown}
-						oninput={handleInput}
-						placeholder="Type a message..."
-						rows="1"
-						{disabled}
-					></textarea>
-					<button
-						type="button"
-						class="mic-btn"
-						onclick={handleMicClick}
-						aria-label="Voice input"
-						title="Voice input"
-					>
-						<Icon name="mic" size={20} />
-					</button>
-				{/if}
-			</div>
-		</form>
 	</div>
-</div>
+{/if}
 
 <style>
-	.mic-btn.vision-off { opacity: 0.45; }
 	.vision-hint {
 		position: fixed;
 		top: calc(1.25rem + env(safe-area-inset-top, 0));
@@ -584,58 +371,6 @@
 		0%, 100% { transform: translateY(0) rotate(0deg); }
 		50% { transform: translateY(-4px) rotate(-6deg); }
 	}
-	.pending-row { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.5rem; padding: 0 0.5rem; }
-	.pending-chip {
-		position: relative;
-		width: 56px;
-		height: 56px;
-		cursor: pointer;
-		transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
-	}
-	.pending-chip:hover {
-		transform: scale(1.12) translateY(-3px) rotate(-3deg);
-		z-index: 2;
-	}
-	.pending-chip img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-		border-radius: var(--radius-md);
-		border: 1px solid var(--border-light);
-		box-shadow: var(--shadow-sm);
-		transition: box-shadow 0.2s ease, border-color 0.2s ease;
-	}
-	.pending-chip:hover img {
-		border-color: var(--accent);
-		box-shadow: var(--shadow-glow);
-	}
-	.remove-chip {
-		position: absolute;
-		top: -5px;
-		right: -5px;
-		width: 19px;
-		height: 19px;
-		border: 2px solid var(--bg-primary);
-		border-radius: var(--radius-full);
-		background: var(--color-error);
-		color: #fff;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		cursor: pointer;
-		padding: 0;
-		box-shadow: var(--shadow-sm);
-		opacity: 0;
-		transform: scale(0.4);
-		transition: opacity 0.16s ease, transform 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
-	}
-	.pending-chip:hover .remove-chip {
-		opacity: 1;
-		transform: scale(1);
-	}
-	.remove-chip:hover {
-		transform: scale(1.2);
-	}
 	.bottom-chat-bar {
 		position: fixed;
 		bottom: 2.5rem;
@@ -645,6 +380,18 @@
 		max-width: 600px;
 		padding: 0 1rem;
 		z-index: 40;
+	}
+
+	/* Alignment: pin the bar toward an edge instead of centered */
+	.bottom-chat-bar.align-left {
+		left: 0;
+		transform: none;
+	}
+
+	.bottom-chat-bar.align-right {
+		left: auto;
+		right: 0;
+		transform: none;
 	}
 
 	/* Command row: mood satellite + input pill */
@@ -664,9 +411,9 @@
 		height: 56px;
 		min-width: 56px;
 		padding: 0 1rem;
-		border: none;
+		border: 1px solid var(--border-subtle);
 		border-radius: var(--radius-full);
-		background: var(--bg-primary);
+		background: var(--bg-secondary);
 		color: var(--text-primary);
 		cursor: pointer;
 		font-family: inherit;
@@ -865,118 +612,6 @@
 	.dismiss-btn:hover {
 		opacity: 1;
 		background: rgba(255, 255, 255, 0.3);
-	}
-
-	.chat-form {
-		flex: 1;
-		min-width: 0;
-	}
-
-	.input-wrapper {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		background: var(--bg-primary);
-		backdrop-filter: blur(20px);
-		-webkit-backdrop-filter: blur(20px);
-		border-radius: var(--radius-full);
-		padding: 0.5rem;
-		min-height: 56px;
-		box-shadow: var(--shadow-md);
-		transition: box-shadow 0.2s;
-	}
-
-	.input-wrapper:focus-within,
-	.input-wrapper.focused {
-		box-shadow: 0 0 0 3px var(--accent-muted), var(--shadow-glow);
-	}
-
-	.input-wrapper.recording {
-		box-shadow: 0 0 0 3px var(--accent-muted), var(--shadow-glow);
-	}
-
-	.input-wrapper.transcribing {
-		box-shadow: 0 0 0 3px var(--accent-muted), var(--shadow-md);
-	}
-
-	.transcribing-label {
-		flex: 1;
-		padding: 0.625rem 0.5rem;
-		font-size: 0.9rem;
-		color: var(--text-tertiary);
-		font-style: italic;
-	}
-
-	.mic-btn.recording:disabled {
-		opacity: 0.7;
-		cursor: wait;
-		animation: none;
-	}
-
-	textarea {
-		flex: 1;
-		padding: 0.625rem 0.5rem;
-		border: none;
-		background: transparent;
-		color: var(--text-primary);
-		font-size: 1rem;
-		resize: none;
-		outline: none;
-		font-family: inherit;
-		line-height: 1.5;
-		max-height: 120px;
-	}
-
-	textarea::placeholder {
-		color: var(--text-tertiary);
-	}
-
-	textarea:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	.mic-btn {
-		width: 44px;
-		height: 44px;
-		border: none;
-		border-radius: var(--radius-full);
-		cursor: pointer;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		transition: background 0.2s, color 0.2s, box-shadow 0.2s, transform 0.15s;
-		flex-shrink: 0;
-		position: relative;
-	}
-
-	.mic-btn {
-		background: transparent;
-		color: var(--text-tertiary);
-	}
-
-	.mic-btn:hover:not(:disabled) {
-		color: var(--text-primary);
-		background: var(--bg-secondary);
-	}
-
-	.mic-btn:active:not(:disabled) {
-		transform: scale(0.94);
-	}
-
-	.mic-btn.recording {
-		background: var(--accent);
-		color: #fff;
-		animation: recording-pulse 1.6s ease-in-out infinite;
-	}
-
-	.mic-btn.recording:hover {
-		background: var(--accent-hover);
-	}
-
-	@keyframes recording-pulse {
-		0%, 100% { box-shadow: 0 0 0 0 var(--accent-muted); }
-		50% { box-shadow: 0 0 0 6px transparent; }
 	}
 
 	/* Mic sits where send used to; Enter sends the message. */

--- a/src/lib/components/chat/ChatInput 2.svelte
+++ b/src/lib/components/chat/ChatInput 2.svelte
@@ -59,7 +59,7 @@
 		const { text, images } = chatDraftStore.takeAll();
 		if (!text && images.length === 0) return;
 		onSend(text, images);
-		if (textareaRef) textareaRef.scrollLeft = 0;
+		if (textareaRef) textareaRef.style.height = 'auto';
 	}
 
 	function handleSubmit(e: SubmitEvent) {
@@ -71,6 +71,13 @@
 		if (e.key === 'Enter' && !e.shiftKey) {
 			e.preventDefault();
 			doSend();
+		}
+	}
+
+	function handleInput() {
+		if (textareaRef) {
+			textareaRef.style.height = 'auto';
+			textareaRef.style.height = Math.min(textareaRef.scrollHeight, 120) + 'px';
 		}
 	}
 
@@ -153,16 +160,13 @@
 						<Icon name="paperclip" size={20} />
 					</button>
 				{/if}
-				<!-- wrap="off" keeps long messages trailing forward on one line
-				     instead of stacking; pasted newlines are preserved, just not
-				     shown as extra rows -->
 				<textarea
 					bind:this={textareaRef}
 					bind:value={chatDraftStore.draft}
 					onkeydown={handleKeydown}
+					oninput={handleInput}
 					placeholder="Type a message..."
 					rows="1"
-					wrap="off"
 					{disabled}
 				></textarea>
 				<button
@@ -251,8 +255,7 @@
 		transform: scale(1.2);
 	}
 
-	/* Gray input surface, shared by both variants. Fixed height so swapping
-	   between typing, listening, and transcribing never resizes the pill */
+	/* Gray input surface, shared by both variants */
 	.input-wrapper {
 		display: flex;
 		align-items: center;
@@ -263,7 +266,7 @@
 		-webkit-backdrop-filter: blur(20px);
 		border-radius: var(--radius-full);
 		padding: 0.5rem;
-		height: 56px;
+		min-height: 56px;
 		box-shadow: var(--shadow-md);
 		transition: box-shadow 0.2s;
 	}
@@ -281,16 +284,12 @@
 		box-shadow: 0 0 0 3px var(--accent-muted), var(--shadow-md);
 	}
 
-	/* Docked: flat compact row that reads as part of the chat window and
-	   keeps shrinking gracefully as the window narrows */
+	/* Docked: flat row that reads as part of the chat window */
 	.docked .input-wrapper {
 		border-radius: var(--radius-md);
 		border: none;
 		box-shadow: none;
-		height: 42px;
-		min-width: 0;
-		gap: 0.25rem;
-		padding: 0.25rem 0.35rem;
+		min-height: 48px;
 		backdrop-filter: none;
 		-webkit-backdrop-filter: none;
 	}
@@ -317,7 +316,6 @@
 
 	textarea {
 		flex: 1;
-		min-width: 0;
 		padding: 0.625rem 0.5rem;
 		border: none;
 		background: transparent;
@@ -327,21 +325,11 @@
 		outline: none;
 		font-family: inherit;
 		line-height: 1.5;
-		height: calc(1.5em + 1rem);
-		white-space: nowrap;
-		overflow-x: auto;
-		overflow-y: hidden;
-		scrollbar-width: none;
-	}
-
-	textarea::-webkit-scrollbar {
-		display: none;
+		max-height: 120px;
 	}
 
 	.docked textarea {
-		font-size: 0.875rem;
-		padding: 0.375rem 0.4rem;
-		height: calc(1.5em + 0.75rem);
+		font-size: 0.9rem;
 	}
 
 	textarea::placeholder {
@@ -370,13 +358,8 @@
 	}
 
 	.docked .mic-btn {
-		width: 34px;
-		height: 34px;
-	}
-
-	.docked .pending-chip {
-		width: 44px;
-		height: 44px;
+		width: 38px;
+		height: 38px;
 	}
 
 	.mic-btn:hover:not(:disabled) {

--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -1,0 +1,402 @@
+<script lang="ts">
+	import { Icon } from '$lib/components/ui';
+	import { sttStore } from '$lib/stores/stt.svelte';
+	import { chatDraftStore } from '$lib/stores/chat-draft.svelte';
+	import { queueFiles, showVisionHint } from './attach-files';
+	import { type PreparedImage } from '$lib/services/storage/keepsakes';
+	import AudioVisualizer from './AudioVisualizer.svelte';
+	import { pop, fadeFast } from '$lib/utils/motion';
+
+	interface Props {
+		onSend: (content: string, images?: PreparedImage[]) => void;
+		disabled?: boolean;
+		visionCapable?: boolean;
+		/** Overlay window: image-showing is disabled (no native file dialog / drop). */
+		overlay?: boolean;
+		/** Flat row inside the chat window instead of the floating pill. */
+		docked?: boolean;
+	}
+
+	let {
+		onSend,
+		disabled = false,
+		visionCapable = true,
+		overlay = false,
+		docked = false
+	}: Props = $props();
+
+	let textareaRef = $state<HTMLTextAreaElement | null>(null);
+	let fileInput = $state<HTMLInputElement | null>(null);
+
+	const isListening = $derived(sttStore.isListening);
+	const isTranscribing = $derived(sttStore.isTranscribing);
+	const audioLevel = $derived(sttStore.audioLevel);
+	const displayTranscript = $derived(sttStore.displayTranscript);
+
+	const hasContent = $derived(
+		chatDraftStore.draft.trim().length > 0 ||
+			displayTranscript.trim().length > 0 ||
+			chatDraftStore.pending.length > 0
+	);
+
+	function openPicker() {
+		if (overlay) return;
+		if (!visionCapable) {
+			showVisionHint();
+			return;
+		}
+		fileInput?.click();
+	}
+
+	async function handlePicked(files: FileList | null) {
+		await queueFiles(files, visionCapable);
+		if (fileInput) fileInput.value = '';
+	}
+
+	// Single send path: text plus any queued images
+	function doSend() {
+		if (disabled) return;
+		const { text, images } = chatDraftStore.takeAll();
+		if (!text && images.length === 0) return;
+		onSend(text, images);
+		if (textareaRef) textareaRef.style.height = 'auto';
+	}
+
+	function handleSubmit(e: SubmitEvent) {
+		e.preventDefault();
+		doSend();
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter' && !e.shiftKey) {
+			e.preventDefault();
+			doSend();
+		}
+	}
+
+	function handleInput() {
+		if (textareaRef) {
+			textareaRef.style.height = 'auto';
+			textareaRef.style.height = Math.min(textareaRef.scrollHeight, 120) + 'px';
+		}
+	}
+
+	function handleMicClick() {
+		if (!sttStore.isSupported()) {
+			sttStore.showUnsupportedError();
+			return;
+		}
+		if (isListening) {
+			sttStore.stopListening();
+		} else {
+			sttStore.startListening((text) => {
+				onSend(text);
+			});
+		}
+	}
+</script>
+
+<div class="chat-input" class:docked>
+	{#if chatDraftStore.pending.length > 0}
+		<div class="pending-row" out:fadeFast={{ duration: 150 }}>
+			{#each chatDraftStore.pending as p (p.image.id)}
+				<div class="pending-chip" in:pop={{ duration: 200, y: 6, scale: 0.9 }} out:fadeFast={{ duration: 120 }}>
+					<img src={p.url} alt="To show her" />
+					<button
+						type="button"
+						class="remove-chip"
+						aria-label="Remove image"
+						onclick={() => chatDraftStore.removePending(p.image.id)}
+					>
+						<Icon name="x" size={12} />
+					</button>
+				</div>
+			{/each}
+		</div>
+	{/if}
+	<form class="chat-form" onsubmit={handleSubmit}>
+		{#if !overlay}
+			<input
+				bind:this={fileInput}
+				type="file"
+				accept="image/*"
+				multiple
+				style="display:none"
+				onchange={(e) => handlePicked(e.currentTarget.files)}
+			/>
+		{/if}
+		<div
+			class="input-wrapper"
+			class:recording={isListening}
+			class:transcribing={isTranscribing}
+			class:focused={hasContent}
+		>
+			{#if isTranscribing}
+				<div class="transcribing-label">Transcribing...</div>
+				<button type="button" class="mic-btn recording" disabled aria-label="Transcribing">
+					<Icon name="loader" size={20} />
+				</button>
+			{:else if isListening}
+				<AudioVisualizer {audioLevel} transcript={displayTranscript} />
+				<button
+					type="button"
+					class="mic-btn recording"
+					onclick={() => sttStore.stopListening()}
+					aria-label="Stop recording"
+					title="Stop recording"
+				>
+					<Icon name="stop" size={16} />
+				</button>
+			{:else}
+				{#if !overlay}
+					<button
+						type="button"
+						class="mic-btn"
+						class:vision-off={!visionCapable}
+						onclick={openPicker}
+						aria-label="Attach an image"
+						title={visionCapable ? 'Attach an image' : 'This model cannot see images'}
+					>
+						<Icon name="paperclip" size={20} />
+					</button>
+				{/if}
+				<textarea
+					bind:this={textareaRef}
+					bind:value={chatDraftStore.draft}
+					onkeydown={handleKeydown}
+					oninput={handleInput}
+					placeholder="Type a message..."
+					rows="1"
+					{disabled}
+				></textarea>
+				<button
+					type="button"
+					class="mic-btn"
+					onclick={handleMicClick}
+					aria-label="Voice input"
+					title="Voice input"
+				>
+					<Icon name="mic" size={20} />
+				</button>
+			{/if}
+		</div>
+	</form>
+</div>
+
+<style>
+	.chat-form {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.pending-row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		margin-bottom: 0.5rem;
+		padding: 0 0.5rem;
+	}
+
+	.pending-chip {
+		position: relative;
+		width: 56px;
+		height: 56px;
+		cursor: pointer;
+		transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+	}
+
+	.pending-chip:hover {
+		transform: scale(1.12) translateY(-3px) rotate(-3deg);
+		z-index: 2;
+	}
+
+	.pending-chip img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		border-radius: var(--radius-md);
+		border: 1px solid var(--border-light);
+		box-shadow: var(--shadow-sm);
+		transition: box-shadow 0.2s ease, border-color 0.2s ease;
+	}
+
+	.pending-chip:hover img {
+		border-color: var(--accent);
+		box-shadow: var(--shadow-glow);
+	}
+
+	.remove-chip {
+		position: absolute;
+		top: -5px;
+		right: -5px;
+		width: 19px;
+		height: 19px;
+		border: 2px solid var(--bg-primary);
+		border-radius: var(--radius-full);
+		background: var(--color-error);
+		color: #fff;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		cursor: pointer;
+		padding: 0;
+		box-shadow: var(--shadow-sm);
+		opacity: 0;
+		transform: scale(0.4);
+		transition: opacity 0.16s ease, transform 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+	}
+
+	.pending-chip:hover .remove-chip {
+		opacity: 1;
+		transform: scale(1);
+	}
+
+	.remove-chip:hover {
+		transform: scale(1.2);
+	}
+
+	/* Gray input surface, shared by both variants */
+	.input-wrapper {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-subtle);
+		backdrop-filter: blur(20px);
+		-webkit-backdrop-filter: blur(20px);
+		border-radius: var(--radius-full);
+		padding: 0.5rem;
+		min-height: 56px;
+		box-shadow: var(--shadow-md);
+		transition: box-shadow 0.2s;
+	}
+
+	.input-wrapper:focus-within,
+	.input-wrapper.focused {
+		box-shadow: 0 0 0 3px var(--accent-muted), var(--shadow-glow);
+	}
+
+	.input-wrapper.recording {
+		box-shadow: 0 0 0 3px var(--accent-muted), var(--shadow-glow);
+	}
+
+	.input-wrapper.transcribing {
+		box-shadow: 0 0 0 3px var(--accent-muted), var(--shadow-md);
+	}
+
+	/* Docked: flat row that reads as part of the chat window */
+	.docked .input-wrapper {
+		border-radius: var(--radius-md);
+		border: none;
+		box-shadow: none;
+		min-height: 48px;
+		backdrop-filter: none;
+		-webkit-backdrop-filter: none;
+	}
+
+	.docked .input-wrapper:focus-within,
+	.docked .input-wrapper.focused,
+	.docked .input-wrapper.recording,
+	.docked .input-wrapper.transcribing {
+		box-shadow: inset 0 0 0 2px var(--accent-muted);
+	}
+
+	.docked .pending-row {
+		margin-bottom: 0.35rem;
+		padding: 0 0.25rem;
+	}
+
+	.transcribing-label {
+		flex: 1;
+		padding: 0.625rem 0.5rem;
+		font-size: 0.9rem;
+		color: var(--text-tertiary);
+		font-style: italic;
+	}
+
+	textarea {
+		flex: 1;
+		padding: 0.625rem 0.5rem;
+		border: none;
+		background: transparent;
+		color: var(--text-primary);
+		font-size: 1rem;
+		resize: none;
+		outline: none;
+		font-family: inherit;
+		line-height: 1.5;
+		max-height: 120px;
+	}
+
+	.docked textarea {
+		font-size: 0.9rem;
+	}
+
+	textarea::placeholder {
+		color: var(--text-tertiary);
+	}
+
+	textarea:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.mic-btn {
+		width: 44px;
+		height: 44px;
+		border: none;
+		border-radius: var(--radius-full);
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		transition: background 0.2s, color 0.2s, box-shadow 0.2s, transform 0.15s;
+		flex-shrink: 0;
+		position: relative;
+		background: transparent;
+		color: var(--text-tertiary);
+	}
+
+	.docked .mic-btn {
+		width: 38px;
+		height: 38px;
+	}
+
+	.mic-btn:hover:not(:disabled) {
+		color: var(--text-primary);
+		background: var(--bg-tertiary);
+	}
+
+	.mic-btn:active:not(:disabled) {
+		transform: scale(0.94);
+	}
+
+	.mic-btn.vision-off {
+		opacity: 0.45;
+	}
+
+	.mic-btn.recording {
+		background: var(--accent);
+		color: #fff;
+		animation: recording-pulse 1.6s ease-in-out infinite;
+	}
+
+	.mic-btn.recording:hover {
+		background: var(--accent-hover);
+	}
+
+	.mic-btn.recording:disabled {
+		opacity: 0.7;
+		cursor: wait;
+		animation: none;
+	}
+
+	@keyframes recording-pulse {
+		0%, 100% {
+			box-shadow: 0 0 0 0 var(--accent-muted);
+		}
+		50% {
+			box-shadow: 0 0 0 6px transparent;
+		}
+	}
+</style>

--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -59,7 +59,7 @@
 		const { text, images } = chatDraftStore.takeAll();
 		if (!text && images.length === 0) return;
 		onSend(text, images);
-		if (textareaRef) textareaRef.style.height = 'auto';
+		if (textareaRef) textareaRef.scrollLeft = 0;
 	}
 
 	function handleSubmit(e: SubmitEvent) {
@@ -71,13 +71,6 @@
 		if (e.key === 'Enter' && !e.shiftKey) {
 			e.preventDefault();
 			doSend();
-		}
-	}
-
-	function handleInput() {
-		if (textareaRef) {
-			textareaRef.style.height = 'auto';
-			textareaRef.style.height = Math.min(textareaRef.scrollHeight, 120) + 'px';
 		}
 	}
 
@@ -160,13 +153,16 @@
 						<Icon name="paperclip" size={20} />
 					</button>
 				{/if}
+				<!-- wrap="off" keeps long messages trailing forward on one line
+				     instead of stacking; pasted newlines are preserved, just not
+				     shown as extra rows -->
 				<textarea
 					bind:this={textareaRef}
 					bind:value={chatDraftStore.draft}
 					onkeydown={handleKeydown}
-					oninput={handleInput}
 					placeholder="Type a message..."
 					rows="1"
+					wrap="off"
 					{disabled}
 				></textarea>
 				<button
@@ -284,12 +280,16 @@
 		box-shadow: 0 0 0 3px var(--accent-muted), var(--shadow-md);
 	}
 
-	/* Docked: flat row that reads as part of the chat window */
+	/* Docked: flat compact row that reads as part of the chat window and
+	   keeps shrinking gracefully as the window narrows */
 	.docked .input-wrapper {
 		border-radius: var(--radius-md);
 		border: none;
 		box-shadow: none;
-		min-height: 48px;
+		min-height: 42px;
+		min-width: 0;
+		gap: 0.25rem;
+		padding: 0.25rem 0.35rem;
 		backdrop-filter: none;
 		-webkit-backdrop-filter: none;
 	}
@@ -316,6 +316,7 @@
 
 	textarea {
 		flex: 1;
+		min-width: 0;
 		padding: 0.625rem 0.5rem;
 		border: none;
 		background: transparent;
@@ -325,11 +326,21 @@
 		outline: none;
 		font-family: inherit;
 		line-height: 1.5;
-		max-height: 120px;
+		height: calc(1.5em + 1.25rem);
+		white-space: nowrap;
+		overflow-x: auto;
+		overflow-y: hidden;
+		scrollbar-width: none;
+	}
+
+	textarea::-webkit-scrollbar {
+		display: none;
 	}
 
 	.docked textarea {
-		font-size: 0.9rem;
+		font-size: 0.875rem;
+		padding: 0.5rem 0.4rem;
+		height: calc(1.5em + 1rem);
 	}
 
 	textarea::placeholder {
@@ -358,8 +369,13 @@
 	}
 
 	.docked .mic-btn {
-		width: 38px;
-		height: 38px;
+		width: 34px;
+		height: 34px;
+	}
+
+	.docked .pending-chip {
+		width: 44px;
+		height: 44px;
 	}
 
 	.mic-btn:hover:not(:disabled) {

--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -180,6 +180,13 @@
 </div>
 
 <style>
+	/* Fill the bar's flex row; without this the pill collapses to the
+	   textarea's intrinsic width */
+	.chat-input {
+		flex: 1;
+		min-width: 0;
+	}
+
 	.chat-form {
 		flex: 1;
 		min-width: 0;

--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -263,7 +263,8 @@
 		-webkit-backdrop-filter: blur(20px);
 		border-radius: var(--radius-full);
 		padding: 0.5rem;
-		height: 56px;
+		/* 44px buttons + 0.5rem padding either side: the pill's original stature */
+		height: 60px;
 		box-shadow: var(--shadow-md);
 		transition: box-shadow 0.2s;
 	}

--- a/src/lib/components/chat/ChatWindow 2.svelte
+++ b/src/lib/components/chat/ChatWindow 2.svelte
@@ -9,7 +9,6 @@
 	import { wrapWordsInHtml } from './reveal-markup';
 	import { phaseLabel, type ThinkingPhase } from '$lib/services/chat/chat-phase';
 	import { type PreparedImage } from '$lib/services/storage/keepsakes';
-	import { chatDraftStore } from '$lib/stores/chat-draft.svelte';
 	import ChatInput from './ChatInput.svelte';
 
 	interface Props {
@@ -42,8 +41,8 @@
 	// rect persists so it comes back where you left it. Until the user drags,
 	// it anchors to the docked side from settings.
 	const GEOMETRY_KEY = 'utsuwa-chat-panel';
-	const DEFAULT_WIDTH = 460;
-	const DEFAULT_HEIGHT_VH = 0.72;
+	const DEFAULT_WIDTH = 340;
+	const DEFAULT_HEIGHT_VH = 0.62;
 	const MIN_WIDTH = 260;
 	const MIN_HEIGHT = 220;
 	const MARGIN = 12;
@@ -59,14 +58,6 @@
 	function defaultRect(): PanelRect {
 		const vw = window.innerWidth;
 		const vh = window.innerHeight;
-		// Mobile: dock low in the viewport so her face stays visible above the
-		// chat, hugging the snap side with a slim margin
-		if (vw <= 640) {
-			const w = Math.max(MIN_WIDTH, Math.round(vw * 0.7));
-			const h = Math.round(vh * 0.42);
-			const x = displayStore.sidebarPosition === 'left' ? MARGIN : vw - w - MARGIN;
-			return { x, y: vh - h - MARGIN * 2, w, h };
-		}
 		const w = DEFAULT_WIDTH;
 		const h = Math.round(vh * DEFAULT_HEIGHT_VH);
 		const x = displayStore.sidebarPosition === 'left' ? MARGIN : vw - w - MARGIN;
@@ -350,13 +341,6 @@
 	<div class="input-dock">
 		<ChatInput {onSend} {disabled} {visionCapable} docked />
 	</div>
-
-	{#if open && chatDraftStore.dropActive}
-		<div class="drop-overlay">
-			<Icon name="camera" size={22} />
-			<span>Drop a photo to show her</span>
-		</div>
-	{/if}
 </div>
 
 <style>
@@ -591,32 +575,5 @@
 		padding: 0.5rem 0.625rem;
 		border-top: 1px solid var(--border-subtle);
 		background: var(--bg-secondary);
-	}
-
-	/* Drag-to-show target while the window owns the input */
-	.drop-overlay {
-		position: absolute;
-		inset: 6px;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 0.55rem;
-		border-radius: calc(var(--radius-xl) - 4px);
-		background: var(--accent-subtle);
-		border: 2px dashed var(--accent);
-		color: var(--accent);
-		font-size: 0.95rem;
-		font-weight: 600;
-		z-index: 4;
-		pointer-events: none;
-	}
-
-	.drop-overlay :global(svg) {
-		animation: dropIcon 0.9s ease-in-out infinite;
-	}
-
-	@keyframes dropIcon {
-		0%, 100% { transform: translateY(0) rotate(0deg); }
-		50% { transform: translateY(-4px) rotate(-6deg); }
 	}
 </style>

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -58,6 +58,14 @@
 	function defaultRect(): PanelRect {
 		const vw = window.innerWidth;
 		const vh = window.innerHeight;
+		// Mobile: dock low in the viewport so her face stays visible above the
+		// chat, hugging the snap side with a slim margin
+		if (vw <= 640) {
+			const w = Math.max(MIN_WIDTH, Math.round(vw * 0.7));
+			const h = Math.round(vh * 0.42);
+			const x = displayStore.sidebarPosition === 'left' ? MARGIN : vw - w - MARGIN;
+			return { x, y: vh - h - MARGIN * 2, w, h };
+		}
 		const w = DEFAULT_WIDTH;
 		const h = Math.round(vh * DEFAULT_HEIGHT_VH);
 		const x = displayStore.sidebarPosition === 'left' ? MARGIN : vw - w - MARGIN;

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -1,29 +1,49 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
 	import { chatStore } from '$lib/stores/chat.svelte';
-	import { displayStore } from '$lib/stores/display.svelte';
-	import { Icon } from '$lib/components/ui';
+	import { displayStore, REVEAL_SPEED_MS } from '$lib/stores/display.svelte';
+	import { characterStore } from '$lib/stores/character.svelte';
+	import { Icon, ShimmerLabel } from '$lib/components/ui';
 	import { renderMarkdown } from './render-markdown';
+	import { wrapWordsInHtml } from './reveal-markup';
+	import { phaseLabel, type ThinkingPhase } from '$lib/services/chat/chat-phase';
+	import { type PreparedImage } from '$lib/services/storage/keepsakes';
+	import ChatInput from './ChatInput.svelte';
 
 	interface Props {
 		open: boolean;
 		onClose?: () => void;
 		isTyping?: boolean;
+		phase?: ThinkingPhase;
+		onSend: (content: string, images?: PreparedImage[]) => void;
+		disabled?: boolean;
+		visionCapable?: boolean;
 	}
 
-	let { open, onClose, isTyping = false }: Props = $props();
+	let {
+		open,
+		onClose,
+		isTyping = false,
+		phase = 'thinking',
+		onSend,
+		disabled = false,
+		visionCapable = true
+	}: Props = $props();
+
+	const moodInfo = $derived(characterStore.moodInfo);
 
 	let messagesEl: HTMLDivElement | null = $state(null);
-	let panelEl: HTMLDivElement | null = $state(null);
 	let scrollRaf: number | null = null;
 
 	// --- Floating geometry -----------------------------------------------------
-	// The panel floats: drag it by the header, resize it from the corner. Its
+	// The panel floats: drag it by the header, resize it from any edge. Its
 	// rect persists so it comes back where you left it. Until the user drags,
 	// it anchors to the docked side from settings.
 	const GEOMETRY_KEY = 'utsuwa-chat-panel';
-	const DEFAULT_WIDTH = 320;
+	const DEFAULT_WIDTH = 340;
 	const DEFAULT_HEIGHT_VH = 0.62;
+	const MIN_WIDTH = 260;
+	const MIN_HEIGHT = 220;
 	const MARGIN = 12;
 	const TOP_OFFSET = 68; // below the top button row
 
@@ -46,8 +66,8 @@
 	function clampRect(r: PanelRect): PanelRect {
 		const vw = window.innerWidth;
 		const vh = window.innerHeight;
-		const w = Math.min(Math.max(r.w, 260), vw - MARGIN * 2);
-		const h = Math.min(Math.max(r.h, 220), vh - MARGIN * 2);
+		const w = Math.min(Math.max(r.w, MIN_WIDTH), vw - MARGIN * 2);
+		const h = Math.min(Math.max(r.h, MIN_HEIGHT), vh - MARGIN * 2);
 		return {
 			x: Math.min(Math.max(r.x, MARGIN - w + 80), vw - 80),
 			y: Math.min(Math.max(r.y, 0), vh - 48),
@@ -68,8 +88,29 @@
 		}
 	});
 
+	// Reopening after a viewport change must never leave the panel stranded
+	$effect(() => {
+		if (open && rect) rect = clampRect(rect);
+	});
+
+	// Settings can rescue a lost window: clear the saved rect, start fresh
+	$effect(() => {
+		const token = displayStore.chatWindowResetToken;
+		if (token > 0 && browser) {
+			localStorage.removeItem(GEOMETRY_KEY);
+			rect = defaultRect();
+		}
+	});
+
 	function persistRect() {
 		if (browser && rect) localStorage.setItem(GEOMETRY_KEY, JSON.stringify(rect));
+	}
+
+	function handleViewportResize() {
+		if (rect) {
+			rect = clampRect(rect);
+			persistRect();
+		}
 	}
 
 	// Dragging via the header
@@ -97,22 +138,65 @@
 		persistRect();
 	}
 
-	// Resize via the native CSS handle; observe and persist the result
-	$effect(() => {
-		const el = panelEl;
-		if (!el) return;
-		const observer = new ResizeObserver(() => {
-			if (!rect) return;
-			const w = el.offsetWidth;
-			const h = el.offsetHeight;
-			if (w !== rect.w || h !== rect.h) {
-				rect = clampRect({ ...rect, w, h });
-				persistRect();
-			}
-		});
-		observer.observe(el);
-		return () => observer.disconnect();
-	});
+	// --- Custom resize ---------------------------------------------------------
+	// Native CSS resize only offers the bottom-right corner and fought the
+	// clamping logic; these handles cover every edge and corner.
+	type ResizeDir = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
+	const RESIZE_DIRS: ResizeDir[] = ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw'];
+
+	let resizing: {
+		dir: ResizeDir;
+		pointerId: number;
+		startX: number;
+		startY: number;
+		start: PanelRect;
+	} | null = null;
+
+	function onResizeDown(e: PointerEvent, dir: ResizeDir) {
+		if (!rect) return;
+		e.preventDefault();
+		resizing = {
+			dir,
+			pointerId: e.pointerId,
+			startX: e.clientX,
+			startY: e.clientY,
+			start: { ...rect }
+		};
+		(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+	}
+
+	function onResizeMove(e: PointerEvent) {
+		if (!resizing) return;
+		const { dir, start } = resizing;
+		const dx = e.clientX - resizing.startX;
+		const dy = e.clientY - resizing.startY;
+		const vw = window.innerWidth;
+		const vh = window.innerHeight;
+
+		let { x, y, w, h } = start;
+		if (dir.includes('e')) w = start.w + dx;
+		if (dir.includes('w')) w = start.w - dx;
+		if (dir.includes('s')) h = start.h + dy;
+		if (dir.includes('n')) h = start.h - dy;
+
+		w = Math.min(Math.max(w, MIN_WIDTH), vw - MARGIN * 2);
+		h = Math.min(Math.max(h, MIN_HEIGHT), vh - MARGIN * 2);
+
+		// Dragging a west or north edge moves the origin; anchor the opposite edge
+		if (dir.includes('w')) x = start.x + start.w - w;
+		if (dir.includes('n')) y = start.y + start.h - h;
+
+		x = Math.min(Math.max(x, MARGIN - w + 80), vw - 80);
+		y = Math.min(Math.max(y, 0), vh - 48);
+
+		rect = { x, y, w, h };
+	}
+
+	function onResizeUp() {
+		if (!resizing) return;
+		resizing = null;
+		persistRect();
+	}
 
 	// The dock buttons become "snap to edge" shortcuts for the floating panel
 	function snapTo(side: 'left' | 'right') {
@@ -145,13 +229,17 @@
 		};
 	});
 
-	// The last assistant message id – used to highlight while typing
+	// The last assistant message id, highlighted while typing and revealed word
+	// by word when it lands. Keyed each blocks keep the DOM stable, so the
+	// reveal animation plays once and never replays on open/close.
 	const lastAssistantId = $derived(
 		[...chatStore.messages].reverse().find((m) => m.role === 'assistant')?.id ?? null
 	);
 
 	// System messages are kept for LLM context but not shown in the visible history
 	const visibleMessages = $derived(chatStore.messages.filter((m) => m.role !== 'system'));
+
+	const revealCadenceMs = $derived(REVEAL_SPEED_MS[displayStore.textRevealSpeed]);
 
 	function handleClearHistory() {
 		if (!browser) return;
@@ -161,26 +249,39 @@
 	}
 </script>
 
+<svelte:window onresize={handleViewportResize} />
+
 <div
-	class="sidebar"
+	class="chat-window"
 	class:open
-	bind:this={panelEl}
 	style:left={rect ? `${rect.x}px` : undefined}
 	style:top={rect ? `${rect.y}px` : undefined}
 	style:width={rect ? `${rect.w}px` : undefined}
 	style:height={rect ? `${rect.h}px` : undefined}
 >
+	{#each RESIZE_DIRS as dir}
+		<div
+			class="resize-handle {dir}"
+			onpointerdown={(e) => onResizeDown(e, dir)}
+			onpointermove={onResizeMove}
+			onpointerup={onResizeUp}
+			onpointercancel={onResizeUp}
+		></div>
+	{/each}
 	<div
-		class="sidebar-header"
+		class="window-header"
 		onpointerdown={onHeaderDown}
 		onpointermove={onHeaderMove}
 		onpointerup={onHeaderUp}
 		onpointercancel={onHeaderUp}
 	>
+		<span class="mood-chip" style="color: {moodInfo.color}" title={moodInfo.description}>
+			<Icon name={moodInfo.icon} size={16} />
+		</span>
+		<span class="window-title">Chat</span>
 		<button class="dock-btn" onclick={() => snapTo('left')} aria-label="Snap to left edge" title="Snap left">
 			<Icon name="chevron-left" size={16} />
 		</button>
-		<span class="sidebar-title">Chat History</span>
 		<button class="dock-btn" onclick={() => snapTo('right')} aria-label="Snap to right edge" title="Snap right">
 			<Icon name="chevron-right" size={16} />
 		</button>
@@ -193,34 +294,46 @@
 		>
 			<Icon name="trash" size={14} />
 		</button>
-		<button
-			class="close-btn"
-			onclick={onClose}
-			aria-label="Close chat history"
-			title="Close chat history"
-		>
+		<button class="close-btn" onclick={onClose} aria-label="Close chat" title="Close chat">
 			<Icon name="x" size={16} />
 		</button>
 	</div>
 
 	<div class="messages" bind:this={messagesEl}>
-		{#if visibleMessages.length === 0}
+		{#if visibleMessages.length === 0 && !isTyping}
 			<p class="empty-hint">No messages yet.</p>
 		{:else}
 			{#each visibleMessages as msg (msg.id)}
 				{@const isLastAssistant = msg.id === lastAssistantId}
 				<div class="message" class:user={msg.role === 'user'} class:assistant={msg.role === 'assistant'}>
 					<div class="bubble" class:speaking={isLastAssistant && isTyping}>
-						<p>{@html renderMarkdown(msg.content)}</p>
+						{#if isLastAssistant && revealCadenceMs > 0 && msg.content}
+							<p style="--reveal-cadence: {revealCadenceMs}ms">
+								{@html wrapWordsInHtml(renderMarkdown(msg.content)).html}
+							</p>
+						{:else}
+							<p>{@html renderMarkdown(msg.content)}</p>
+						{/if}
 					</div>
 				</div>
 			{/each}
+			{#if isTyping}
+				<div class="message assistant">
+					<div class="bubble thinking">
+						<ShimmerLabel label={phaseLabel(phase)} />
+					</div>
+				</div>
+			{/if}
 		{/if}
+	</div>
+
+	<div class="input-dock">
+		<ChatInput {onSend} {disabled} {visionCapable} docked />
 	</div>
 </div>
 
 <style>
-	.sidebar {
+	.chat-window {
 		position: fixed;
 		display: flex;
 		flex-direction: column;
@@ -235,19 +348,59 @@
 		opacity: 0;
 		transform: translateY(6px) scale(0.985);
 		transition: opacity 0.22s ease, transform 0.22s cubic-bezier(0.16, 1, 0.3, 1);
-		resize: both;
 		overflow: hidden;
 		min-width: 260px;
 		min-height: 220px;
 	}
 
-	.sidebar.open {
+	.chat-window.open {
 		opacity: 1;
 		transform: translateY(0) scale(1);
 		pointer-events: auto;
 	}
 
-	.sidebar-header {
+	/* Invisible grab areas along every edge and corner */
+	.resize-handle {
+		position: absolute;
+		z-index: 3;
+	}
+
+	.resize-handle.n,
+	.resize-handle.s {
+		left: 10px;
+		right: 10px;
+		height: 6px;
+		cursor: ns-resize;
+	}
+
+	.resize-handle.n { top: -3px; }
+	.resize-handle.s { bottom: -3px; }
+
+	.resize-handle.e,
+	.resize-handle.w {
+		top: 10px;
+		bottom: 10px;
+		width: 6px;
+		cursor: ew-resize;
+	}
+
+	.resize-handle.e { right: -3px; }
+	.resize-handle.w { left: -3px; }
+
+	.resize-handle.ne,
+	.resize-handle.nw,
+	.resize-handle.se,
+	.resize-handle.sw {
+		width: 12px;
+		height: 12px;
+	}
+
+	.resize-handle.ne { top: -4px; right: -4px; cursor: nesw-resize; }
+	.resize-handle.sw { bottom: -4px; left: -4px; cursor: nesw-resize; }
+	.resize-handle.nw { top: -4px; left: -4px; cursor: nwse-resize; }
+	.resize-handle.se { bottom: -4px; right: -4px; cursor: nwse-resize; }
+
+	.window-header {
 		display: flex;
 		align-items: center;
 		gap: 0.25rem;
@@ -259,13 +412,21 @@
 		touch-action: none;
 	}
 
-	.sidebar-header:active {
+	.window-header:active {
 		cursor: grabbing;
 	}
 
-	.sidebar-title {
+	.mood-chip {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 28px;
+		height: 28px;
+		flex-shrink: 0;
+	}
+
+	.window-title {
 		flex: 1;
-		text-align: center;
 		font-size: 0.8125rem;
 		font-weight: 600;
 		color: var(--text-primary);
@@ -347,6 +508,10 @@
 		border-bottom-left-radius: var(--radius-sm);
 	}
 
+	.bubble.thinking {
+		padding: 0.55rem 0.85rem;
+	}
+
 	.bubble p {
 		margin: 0;
 	}
@@ -367,6 +532,26 @@
 		background: color-mix(in srgb, var(--text-primary), transparent 92%);
 	}
 
+	/* Word-by-word reveal for the latest reply */
+	.bubble :global(.reveal-word) {
+		opacity: 0;
+		animation: word-in 0.24s ease-out forwards;
+		animation-delay: calc(var(--word-index) * var(--reveal-cadence, 60ms));
+	}
+
+	@keyframes word-in {
+		to {
+			opacity: 1;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.bubble :global(.reveal-word) {
+			animation: none;
+			opacity: 1;
+		}
+	}
+
 	.empty-hint {
 		text-align: center;
 		font-size: 0.8125rem;
@@ -376,5 +561,12 @@
 
 	.bubble.speaking {
 		border-color: color-mix(in srgb, var(--accent), transparent 55%);
+	}
+
+	.input-dock {
+		flex-shrink: 0;
+		padding: 0.5rem 0.625rem;
+		border-top: 1px solid var(--border-subtle);
+		background: var(--bg-secondary);
 	}
 </style>

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { browser } from '$app/environment';
 	import { chatStore } from '$lib/stores/chat.svelte';
 	import { displayStore, REVEAL_SPEED_MS } from '$lib/stores/display.svelte';
@@ -88,9 +89,14 @@
 		}
 	});
 
-	// Reopening after a viewport change must never leave the panel stranded
+	// Reopening after a viewport change must never leave the panel stranded.
+	// untrack keeps rect out of the dependency list; reacting to our own
+	// rect write would loop the effect forever.
 	$effect(() => {
-		if (open && rect) rect = clampRect(rect);
+		if (!open) return;
+		untrack(() => {
+			if (rect) rect = clampRect(rect);
+		});
 	});
 
 	// Settings can rescue a lost window: clear the saved rect, start fresh
@@ -305,17 +311,22 @@
 		{:else}
 			{#each visibleMessages as msg (msg.id)}
 				{@const isLastAssistant = msg.id === lastAssistantId}
-				<div class="message" class:user={msg.role === 'user'} class:assistant={msg.role === 'assistant'}>
-					<div class="bubble" class:speaking={isLastAssistant && isTyping}>
-						{#if isLastAssistant && revealCadenceMs > 0 && msg.content}
-							<p style="--reveal-cadence: {revealCadenceMs}ms">
-								{@html wrapWordsInHtml(renderMarkdown(msg.content)).html}
-							</p>
-						{:else}
-							<p>{@html renderMarkdown(msg.content)}</p>
-						{/if}
+				<!-- While she's typing, the shimmer bubble below stands in for the
+				     streaming message; rendering partial content would restart the
+				     reveal animation on every delta -->
+				{#if !(isLastAssistant && isTyping)}
+					<div class="message" class:user={msg.role === 'user'} class:assistant={msg.role === 'assistant'}>
+						<div class="bubble">
+							{#if isLastAssistant && revealCadenceMs > 0 && msg.content}
+								<p style="--reveal-cadence: {revealCadenceMs}ms">
+									{@html wrapWordsInHtml(renderMarkdown(msg.content)).html}
+								</p>
+							{:else}
+								<p>{@html renderMarkdown(msg.content)}</p>
+							{/if}
+						</div>
 					</div>
-				</div>
+				{/if}
 			{/each}
 			{#if isTyping}
 				<div class="message assistant">
@@ -557,10 +568,6 @@
 		font-size: 0.8125rem;
 		color: var(--text-tertiary);
 		margin-top: 2rem;
-	}
-
-	.bubble.speaking {
-		border-color: color-mix(in srgb, var(--accent), transparent 55%);
 	}
 
 	.input-dock {

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -41,8 +41,8 @@
 	// rect persists so it comes back where you left it. Until the user drags,
 	// it anchors to the docked side from settings.
 	const GEOMETRY_KEY = 'utsuwa-chat-panel';
-	const DEFAULT_WIDTH = 340;
-	const DEFAULT_HEIGHT_VH = 0.62;
+	const DEFAULT_WIDTH = 460;
+	const DEFAULT_HEIGHT_VH = 0.72;
 	const MIN_WIDTH = 260;
 	const MIN_HEIGHT = 220;
 	const MARGIN = 12;

--- a/src/lib/components/chat/SpeechBubble.svelte
+++ b/src/lib/components/chat/SpeechBubble.svelte
@@ -1,17 +1,23 @@
 <script lang="ts">
 	import { vrmStore } from '$lib/stores/vrm.svelte';
+	import { displayStore, REVEAL_SPEED_MS } from '$lib/stores/display.svelte';
+	import { ShimmerLabel, StreamingText } from '$lib/components/ui';
+	import { phaseLabel, type ThinkingPhase } from '$lib/services/chat/chat-phase';
 	import { pop, fadeFast } from '$lib/utils/motion';
 
 	interface Props {
 		message: string;
 		isTyping?: boolean;
+		phase?: ThinkingPhase;
 		onHide?: () => void;
 		/** Docked dialog mode: the window moves around in overlay mode, so the
 		 *  bubble anchors above the bottom controls instead of chasing the head */
 		docked?: boolean;
 	}
 
-	let { message, isTyping = false, onHide, docked = false }: Props = $props();
+	let { message, isTyping = false, phase = 'thinking', onHide, docked = false }: Props = $props();
+
+	const revealSpeedMs = $derived(REVEAL_SPEED_MS[displayStore.textRevealSpeed]);
 
 	// Get screen position from VRM store for 3D tracking
 	const screenPos = $derived(vrmStore.headScreenPosition);
@@ -69,13 +75,11 @@
 			{#key isTyping ? '::typing' : message}
 				<div class="speech-bubble-content" in:fadeFast={{ duration: 180 }}>
 					{#if isTyping}
-						<div class="typing-indicator">
-							<span></span>
-							<span></span>
-							<span></span>
+						<div class="thinking-row">
+							<ShimmerLabel label={phaseLabel(phase)} />
 						</div>
 					{:else}
-						<p class="message">{message}</p>
+						<p class="message"><StreamingText text={message} speedMs={revealSpeedMs} /></p>
 					{/if}
 				</div>
 			{/key}
@@ -189,39 +193,10 @@
 		color: var(--text-primary);
 	}
 
-	.typing-indicator {
+	.thinking-row {
 		display: flex;
-		gap: 4px;
+		align-items: center;
 		padding: 0.125rem 0;
-	}
-
-	.typing-indicator span {
-		width: 8px;
-		height: 8px;
-		background: var(--accent);
-		border-radius: 50%;
-		animation: bounce 1.4s ease-in-out infinite;
-	}
-
-	.typing-indicator span:nth-child(1) {
-		animation-delay: 0s;
-	}
-
-	.typing-indicator span:nth-child(2) {
-		animation-delay: 0.2s;
-	}
-
-	.typing-indicator span:nth-child(3) {
-		animation-delay: 0.4s;
-	}
-
-	@keyframes bounce {
-		0%, 60%, 100% {
-			transform: translateY(0);
-		}
-		30% {
-			transform: translateY(-4px);
-		}
 	}
 
 	@media (max-width: 640px) {

--- a/src/lib/components/chat/attach-files 2.ts
+++ b/src/lib/components/chat/attach-files 2.ts
@@ -1,0 +1,51 @@
+import { prepareImage, UnsupportedImageError } from '$lib/services/storage/keepsakes';
+import { chatDraftStore } from '$lib/stores/chat-draft.svelte';
+import { chatHintStore } from '$lib/stores/chat-hint.svelte';
+
+export const IMAGE_MIME: Record<string, string> = {
+	png: 'image/png',
+	jpg: 'image/jpeg',
+	jpeg: 'image/jpeg',
+	gif: 'image/gif',
+	webp: 'image/webp',
+	heic: 'image/heic',
+	heif: 'image/heif',
+	bmp: 'image/bmp'
+};
+
+export function imageMimeFromPath(path: string): string | null {
+	return IMAGE_MIME[path.split('.').pop()?.toLowerCase() ?? ''] ?? null;
+}
+
+export function showVisionHint() {
+	chatHintStore.showHint(
+		"This model can't see images. Pick a vision model (GPT-4o, Claude, Gemini, or a local one like llava) in Settings."
+	);
+}
+
+/**
+ * Queue dropped or picked files onto the shared draft. Non-images are
+ * skipped; failures surface as hints. Shared by the picker (ChatInput) and
+ * both drag-drop paths (BottomChatBar).
+ */
+export async function queueFiles(files: FileList | File[] | null, visionCapable: boolean) {
+	if (!files) return;
+	if (!visionCapable) {
+		showVisionHint();
+		return;
+	}
+	for (const file of Array.from(files)) {
+		if (!file.type.startsWith('image/')) continue;
+		try {
+			const image = await prepareImage(file);
+			chatDraftStore.addPending(image, URL.createObjectURL(file));
+			chatHintStore.requestPrivacyNotice();
+		} catch (e) {
+			chatHintStore.showHint(
+				e instanceof UnsupportedImageError
+					? "That image format isn't supported. Try a JPEG, PNG, GIF or WebP (iPhone HEIC photos won't work)."
+					: "Couldn't read that image. Try a different one."
+			);
+		}
+	}
+}

--- a/src/lib/components/chat/attach-files.ts
+++ b/src/lib/components/chat/attach-files.ts
@@ -1,0 +1,51 @@
+import { prepareImage, UnsupportedImageError } from '$lib/services/storage/keepsakes';
+import { chatDraftStore } from '$lib/stores/chat-draft.svelte';
+import { chatHintStore } from '$lib/stores/chat-hint.svelte';
+
+export const IMAGE_MIME: Record<string, string> = {
+	png: 'image/png',
+	jpg: 'image/jpeg',
+	jpeg: 'image/jpeg',
+	gif: 'image/gif',
+	webp: 'image/webp',
+	heic: 'image/heic',
+	heif: 'image/heif',
+	bmp: 'image/bmp'
+};
+
+export function imageMimeFromPath(path: string): string | null {
+	return IMAGE_MIME[path.split('.').pop()?.toLowerCase() ?? ''] ?? null;
+}
+
+export function showVisionHint() {
+	chatHintStore.showHint(
+		"This model can't see images. Pick a vision model (GPT-4o, Claude, Gemini, or a local one like llava) in Settings."
+	);
+}
+
+/**
+ * Queue dropped or picked files onto the shared draft. Non-images are
+ * skipped; failures surface as hints. Shared by the picker (ChatInput) and
+ * both drag-drop paths (BottomChatBar).
+ */
+export async function queueFiles(files: FileList | File[] | null, visionCapable: boolean) {
+	if (!files) return;
+	if (!visionCapable) {
+		showVisionHint();
+		return;
+	}
+	for (const file of Array.from(files)) {
+		if (!file.type.startsWith('image/')) continue;
+		try {
+			const image = await prepareImage(file);
+			chatDraftStore.addPending(image, URL.createObjectURL(file));
+			chatHintStore.requestPrivacyNotice();
+		} catch (e) {
+			chatHintStore.showHint(
+				e instanceof UnsupportedImageError
+					? "That image format isn't supported. Try a JPEG, PNG, GIF or WebP (iPhone HEIC photos won't work)."
+					: "Couldn't read that image. Try a different one."
+			);
+		}
+	}
+}

--- a/src/lib/components/chat/reveal-markup 2.ts
+++ b/src/lib/components/chat/reveal-markup 2.ts
@@ -1,0 +1,34 @@
+/**
+ * Wrap every word of a rendered-markdown HTML string in a reveal span so the
+ * chat window can stagger-fade words in without breaking inline markup.
+ *
+ * Only ever fed the output of renderMarkdown (escaped text plus bare
+ * strong/em/code tags), so a simple tag/text tokenizer is enough; no DOM
+ * parsing and safe to run under node --test.
+ */
+export function wrapWordsInHtml(html: string): { html: string; wordCount: number } {
+	let out = '';
+	let wordIndex = 0;
+
+	// Split into tag tokens and text runs; tags pass through untouched
+	const tokens = html.split(/(<[^>]+>)/);
+	for (const token of tokens) {
+		if (token === '') continue;
+		if (token.startsWith('<')) {
+			out += token;
+			continue;
+		}
+		// Text run: alternate whitespace and word segments, keep whitespace as-is
+		for (const segment of token.split(/(\s+)/)) {
+			if (segment === '') continue;
+			if (/^\s+$/.test(segment)) {
+				out += segment;
+			} else {
+				out += `<span class="reveal-word" style="--word-index:${wordIndex}">${segment}</span>`;
+				wordIndex++;
+			}
+		}
+	}
+
+	return { html: out, wordCount: wordIndex };
+}

--- a/src/lib/components/chat/reveal-markup.test 2.ts
+++ b/src/lib/components/chat/reveal-markup.test 2.ts
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { wrapWordsInHtml } from './reveal-markup.ts';
+
+test('wraps plain text words with sequential indexes', () => {
+	const { html, wordCount } = wrapWordsInHtml('hello there world');
+	assert.equal(wordCount, 3);
+	assert.equal(
+		html,
+		'<span class="reveal-word" style="--word-index:0">hello</span> ' +
+			'<span class="reveal-word" style="--word-index:1">there</span> ' +
+			'<span class="reveal-word" style="--word-index:2">world</span>'
+	);
+});
+
+test('preserves inline tags around and inside words', () => {
+	const { html, wordCount } = wrapWordsInHtml('so <strong>very good</strong> today');
+	assert.equal(wordCount, 4);
+	assert.equal(
+		html,
+		'<span class="reveal-word" style="--word-index:0">so</span> ' +
+			'<strong><span class="reveal-word" style="--word-index:1">very</span> ' +
+			'<span class="reveal-word" style="--word-index:2">good</span></strong> ' +
+			'<span class="reveal-word" style="--word-index:3">today</span>'
+	);
+});
+
+test('handles nested strong and em', () => {
+	const { html, wordCount } = wrapWordsInHtml('<strong><em>wow</em></strong>');
+	assert.equal(wordCount, 1);
+	assert.equal(
+		html,
+		'<strong><em><span class="reveal-word" style="--word-index:0">wow</span></em></strong>'
+	);
+});
+
+test('wraps words inside code spans', () => {
+	const { html, wordCount } = wrapWordsInHtml('run <code>pnpm test</code> now');
+	assert.equal(wordCount, 4);
+	assert.equal(
+		html,
+		'<span class="reveal-word" style="--word-index:0">run</span> ' +
+			'<code><span class="reveal-word" style="--word-index:1">pnpm</span> ' +
+			'<span class="reveal-word" style="--word-index:2">test</span></code> ' +
+			'<span class="reveal-word" style="--word-index:3">now</span>'
+	);
+});
+
+test('keeps entities intact within a word', () => {
+	const { html, wordCount } = wrapWordsInHtml('salt &amp; pepper');
+	assert.equal(wordCount, 3);
+	assert.ok(html.includes('>&amp;</span>'));
+});
+
+test('preserves multiple spaces and newlines between words', () => {
+	const { html } = wrapWordsInHtml('a  b\nc');
+	assert.ok(html.includes('</span>  <span'));
+	assert.ok(html.includes('</span>\n<span'));
+});
+
+test('empty string yields empty result', () => {
+	const { html, wordCount } = wrapWordsInHtml('');
+	assert.equal(html, '');
+	assert.equal(wordCount, 0);
+});

--- a/src/lib/components/chat/reveal-markup.test.ts
+++ b/src/lib/components/chat/reveal-markup.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { wrapWordsInHtml } from './reveal-markup.ts';
+
+test('wraps plain text words with sequential indexes', () => {
+	const { html, wordCount } = wrapWordsInHtml('hello there world');
+	assert.equal(wordCount, 3);
+	assert.equal(
+		html,
+		'<span class="reveal-word" style="--word-index:0">hello</span> ' +
+			'<span class="reveal-word" style="--word-index:1">there</span> ' +
+			'<span class="reveal-word" style="--word-index:2">world</span>'
+	);
+});
+
+test('preserves inline tags around and inside words', () => {
+	const { html, wordCount } = wrapWordsInHtml('so <strong>very good</strong> today');
+	assert.equal(wordCount, 4);
+	assert.equal(
+		html,
+		'<span class="reveal-word" style="--word-index:0">so</span> ' +
+			'<strong><span class="reveal-word" style="--word-index:1">very</span> ' +
+			'<span class="reveal-word" style="--word-index:2">good</span></strong> ' +
+			'<span class="reveal-word" style="--word-index:3">today</span>'
+	);
+});
+
+test('handles nested strong and em', () => {
+	const { html, wordCount } = wrapWordsInHtml('<strong><em>wow</em></strong>');
+	assert.equal(wordCount, 1);
+	assert.equal(
+		html,
+		'<strong><em><span class="reveal-word" style="--word-index:0">wow</span></em></strong>'
+	);
+});
+
+test('wraps words inside code spans', () => {
+	const { html, wordCount } = wrapWordsInHtml('run <code>pnpm test</code> now');
+	assert.equal(wordCount, 4);
+	assert.equal(
+		html,
+		'<span class="reveal-word" style="--word-index:0">run</span> ' +
+			'<code><span class="reveal-word" style="--word-index:1">pnpm</span> ' +
+			'<span class="reveal-word" style="--word-index:2">test</span></code> ' +
+			'<span class="reveal-word" style="--word-index:3">now</span>'
+	);
+});
+
+test('keeps entities intact within a word', () => {
+	const { html, wordCount } = wrapWordsInHtml('salt &amp; pepper');
+	assert.equal(wordCount, 3);
+	assert.ok(html.includes('>&amp;</span>'));
+});
+
+test('preserves multiple spaces and newlines between words', () => {
+	const { html } = wrapWordsInHtml('a  b\nc');
+	assert.ok(html.includes('</span>  <span'));
+	assert.ok(html.includes('</span>\n<span'));
+});
+
+test('empty string yields empty result', () => {
+	const { html, wordCount } = wrapWordsInHtml('');
+	assert.equal(html, '');
+	assert.equal(wordCount, 0);
+});

--- a/src/lib/components/chat/reveal-markup.ts
+++ b/src/lib/components/chat/reveal-markup.ts
@@ -1,0 +1,34 @@
+/**
+ * Wrap every word of a rendered-markdown HTML string in a reveal span so the
+ * chat window can stagger-fade words in without breaking inline markup.
+ *
+ * Only ever fed the output of renderMarkdown (escaped text plus bare
+ * strong/em/code tags), so a simple tag/text tokenizer is enough; no DOM
+ * parsing and safe to run under node --test.
+ */
+export function wrapWordsInHtml(html: string): { html: string; wordCount: number } {
+	let out = '';
+	let wordIndex = 0;
+
+	// Split into tag tokens and text runs; tags pass through untouched
+	const tokens = html.split(/(<[^>]+>)/);
+	for (const token of tokens) {
+		if (token === '') continue;
+		if (token.startsWith('<')) {
+			out += token;
+			continue;
+		}
+		// Text run: alternate whitespace and word segments, keep whitespace as-is
+		for (const segment of token.split(/(\s+)/)) {
+			if (segment === '') continue;
+			if (/^\s+$/.test(segment)) {
+				out += segment;
+			} else {
+				out += `<span class="reveal-word" style="--word-index:${wordIndex}">${segment}</span>`;
+				wordIndex++;
+			}
+		}
+	}
+
+	return { html: out, wordCount: wordIndex };
+}

--- a/src/lib/components/ui/ShimmerLabel.svelte
+++ b/src/lib/components/ui/ShimmerLabel.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { fadeFast } from '$lib/utils/motion';
+
+	interface Props {
+		label: string;
+	}
+
+	let { label }: Props = $props();
+</script>
+
+{#key label}
+	<span class="shimmer-label" in:fadeFast={{ duration: 150 }}>{label}</span>
+{/key}
+
+<style>
+	.shimmer-label {
+		display: inline-block;
+		font-size: 0.8125rem;
+		font-weight: 500;
+		background: linear-gradient(
+			90deg,
+			var(--text-tertiary) 0%,
+			var(--text-primary) 50%,
+			var(--text-tertiary) 100%
+		);
+		background-size: 200% 100%;
+		-webkit-background-clip: text;
+		background-clip: text;
+		color: transparent;
+		animation: shimmer-sweep 2s linear infinite;
+	}
+
+	@keyframes shimmer-sweep {
+		from {
+			background-position: 200% 0;
+		}
+		to {
+			background-position: -200% 0;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.shimmer-label {
+			animation: none;
+			background: none;
+			color: var(--text-secondary);
+		}
+	}
+</style>

--- a/src/lib/components/ui/StreamingText.svelte
+++ b/src/lib/components/ui/StreamingText.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+
+	interface Props {
+		text: string;
+		/** Per-word cadence; <= 0 renders instantly. */
+		speedMs?: number;
+		onComplete?: () => void;
+	}
+
+	let { text, speedMs = 60, onComplete }: Props = $props();
+
+	const reducedMotion = browser
+		? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+		: false;
+
+	// Whitespace kept as segments so spacing renders exactly as written;
+	// words carry their index, whitespace carries -1
+	const segments = $derived.by(() => {
+		let wordIndex = 0;
+		return text
+			.split(/(\s+)/)
+			.filter((s) => s !== '')
+			.map((s) => ({ text: s, index: /^\s+$/.test(s) ? -1 : wordIndex++ }));
+	});
+	const wordCount = $derived(segments.filter((s) => s.index >= 0).length);
+
+	let shown = $state(0);
+
+	const instant = $derived(speedMs <= 0 || reducedMotion);
+	const revealing = $derived(!instant && shown < wordCount);
+
+	$effect(() => {
+		// Re-run (and reset) whenever the message changes
+		const _text = text;
+		if (instant) {
+			shown = wordCount;
+			onComplete?.();
+			return;
+		}
+		shown = 0;
+		const timer = setInterval(() => {
+			shown += 1;
+			if (shown >= wordCount) {
+				clearInterval(timer);
+				onComplete?.();
+			}
+		}, speedMs);
+		return () => clearInterval(timer);
+	});
+</script>
+
+<span class="streaming-text">
+	{#each segments as segment, i (i)}
+		{#if segment.index < 0}{segment.text}{:else}
+			<span class="word" class:shown={instant || segment.index < shown}>{segment.text}</span>
+		{/if}
+	{/each}
+	{#if revealing}<span class="caret" aria-hidden="true"></span>{/if}
+</span>
+
+<style>
+	.streaming-text {
+		white-space: pre-wrap;
+	}
+
+	.word {
+		opacity: 0;
+	}
+
+	.word.shown {
+		opacity: 1;
+		transition: opacity 0.24s ease-out;
+	}
+
+	.caret {
+		display: inline-block;
+		width: 2px;
+		height: 1em;
+		margin-left: 2px;
+		vertical-align: text-bottom;
+		background: var(--text-secondary);
+		animation: caret-blink 1s steps(2, start) infinite;
+	}
+
+	@keyframes caret-blink {
+		to {
+			visibility: hidden;
+		}
+	}
+</style>

--- a/src/lib/components/ui/index.ts
+++ b/src/lib/components/ui/index.ts
@@ -10,3 +10,5 @@ export { default as InfoModal } from './InfoModal.svelte';
 export { default as ProviderDropdown } from './ProviderDropdown.svelte';
 export { default as ModelDropdown } from './ModelDropdown.svelte';
 export { default as ContextSizeSlider } from './ContextSizeSlider.svelte';
+export { default as ShimmerLabel } from './ShimmerLabel.svelte';
+export { default as StreamingText } from './StreamingText.svelte';

--- a/src/lib/services/chat/chat-phase.test.ts
+++ b/src/lib/services/chat/chat-phase.test.ts
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { phaseLabel } from './chat-phase.ts';
+
+test('maps remembering to its label', () => {
+	assert.equal(phaseLabel('remembering'), 'Remembering...');
+});
+
+test('maps seeing to its label', () => {
+	assert.equal(phaseLabel('seeing'), 'Looking at your photo...');
+});
+
+test('maps thinking to its label', () => {
+	assert.equal(phaseLabel('thinking'), 'Thinking...');
+});

--- a/src/lib/services/chat/chat-phase.ts
+++ b/src/lib/services/chat/chat-phase.ts
@@ -1,0 +1,12 @@
+/** What the companion is actually doing while a turn is in flight. */
+export type ThinkingPhase = 'remembering' | 'seeing' | 'thinking';
+
+const LABELS: Record<ThinkingPhase, string> = {
+	remembering: 'Remembering...',
+	seeing: 'Looking at your photo...',
+	thinking: 'Thinking...'
+};
+
+export function phaseLabel(phase: ThinkingPhase): string {
+	return LABELS[phase];
+}

--- a/src/lib/services/chat/companion-chat.ts
+++ b/src/lib/services/chat/companion-chat.ts
@@ -5,6 +5,7 @@
 // post-turn processing, keepsakes, TTS, and the talking animation. Pages provide
 // a small set of hooks to sync their own reactive state.
 import { characterStore } from '$lib/stores/character.svelte';
+import type { ThinkingPhase } from './chat-phase';
 import { chatStore } from '$lib/stores/chat.svelte';
 import { settingsStore } from '$lib/stores/settings.svelte';
 import { modulesStore } from '$lib/stores/modules.svelte';
@@ -38,6 +39,8 @@ export interface CompanionChatHooks {
 	onNewMemory?: (memory: string | undefined) => void;
 	/** Runs just before streaming starts (e.g. the overlay collapses its chat). */
 	beforeStream?: () => void;
+	/** What she is doing right now (remembering, seeing, thinking). */
+	setPhase?: (phase: ThinkingPhase) => void;
 }
 
 async function buildCompanionPrompt(
@@ -171,6 +174,7 @@ export async function sendCompanionMessage(
 	chatStore.setError(null);
 	hooks.setTyping(true);
 	hooks.setLatestResponse('');
+	hooks.setPhase?.('remembering');
 	hooks.beforeStream?.();
 
 	// Only touch relationship-time state once the character has loaded, or an
@@ -197,6 +201,9 @@ export async function sendCompanionMessage(
 		if (providerMeta?.requiresApiKey && !apiKey) {
 			throw new Error(`Please configure API key for ${providerMeta.name} in Settings > Providers`);
 		}
+
+		// Prompt building (memory retrieval) is done; the model call starts now
+		hooks.setPhase?.(images.length > 0 ? 'seeing' : 'thinking');
 
 		chatStore.addMessage('assistant', '');
 		const selectedModel = model || providerMeta?.models?.[0]?.id || '';

--- a/src/lib/stores/chat-draft.svelte.ts
+++ b/src/lib/stores/chat-draft.svelte.ts
@@ -1,0 +1,54 @@
+import type { PreparedImage } from '$lib/services/storage/keepsakes';
+
+export interface PendingPhoto {
+	image: PreparedImage;
+	url: string;
+}
+
+/**
+ * The in-progress message: typed text plus queued photos. Lives outside the
+ * input components so the draft survives moving between the floating bar and
+ * the chat window's docked input.
+ */
+function createChatDraftStore() {
+	let draft = $state('');
+	let pending = $state<PendingPhoto[]>([]);
+
+	function addPending(image: PreparedImage, url: string) {
+		pending = [...pending, { image, url }];
+	}
+
+	function removePending(id: string) {
+		pending = pending.filter((p) => {
+			if (p.image.id === id) URL.revokeObjectURL(p.url);
+			return p.image.id !== id;
+		});
+	}
+
+	/** Drain the draft for sending: returns content, revokes URLs, clears state. */
+	function takeAll(): { text: string; images: PreparedImage[] } {
+		const text = draft.trim();
+		const images = pending.map((p) => p.image);
+		pending.forEach((p) => URL.revokeObjectURL(p.url));
+		pending = [];
+		draft = '';
+		return { text, images };
+	}
+
+	return {
+		get draft() {
+			return draft;
+		},
+		set draft(value: string) {
+			draft = value;
+		},
+		get pending() {
+			return pending;
+		},
+		addPending,
+		removePending,
+		takeAll
+	};
+}
+
+export const chatDraftStore = createChatDraftStore();

--- a/src/lib/stores/chat-draft.svelte.ts
+++ b/src/lib/stores/chat-draft.svelte.ts
@@ -13,6 +13,13 @@ export interface PendingPhoto {
 function createChatDraftStore() {
 	let draft = $state('');
 	let pending = $state<PendingPhoto[]>([]);
+	// Files are being dragged over the app; whichever input surface is visible
+	// (floating bar or chat window) shows the drop affordance
+	let dropActive = $state(false);
+
+	function setDropActive(active: boolean) {
+		dropActive = active;
+	}
 
 	function addPending(image: PreparedImage, url: string) {
 		pending = [...pending, { image, url }];
@@ -45,6 +52,10 @@ function createChatDraftStore() {
 		get pending() {
 			return pending;
 		},
+		get dropActive() {
+			return dropActive;
+		},
+		setDropActive,
 		addPending,
 		removePending,
 		takeAll

--- a/src/lib/stores/chat-hint.svelte.ts
+++ b/src/lib/stores/chat-hint.svelte.ts
@@ -1,0 +1,50 @@
+import { browser } from '$app/environment';
+
+const PRIVACY_ACK_KEY = 'utsuwa-image-privacy-ack';
+
+/**
+ * Transient chat toasts (image hints, TTS errors) plus the one-time photo
+ * privacy disclosure. Lives in a store so any input surface can raise them
+ * while BottomChatBar, which is always mounted, renders them.
+ */
+function createChatHintStore() {
+	let hint = $state<string | null>(null);
+	let showPrivacy = $state(false);
+	let hintTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function showHint(message: string) {
+		hint = message;
+		if (hintTimer) clearTimeout(hintTimer);
+		hintTimer = setTimeout(() => (hint = null), 6000);
+	}
+
+	/** Shown once, the first time a photo is attached, then remembered. */
+	function requestPrivacyNotice() {
+		if (!browser || localStorage.getItem(PRIVACY_ACK_KEY) === '1') return;
+		showPrivacy = true;
+	}
+
+	function ackPrivacy() {
+		if (browser) localStorage.setItem(PRIVACY_ACK_KEY, '1');
+		showPrivacy = false;
+	}
+
+	function destroy() {
+		if (hintTimer) clearTimeout(hintTimer);
+	}
+
+	return {
+		get hint() {
+			return hint;
+		},
+		get showPrivacy() {
+			return showPrivacy;
+		},
+		showHint,
+		requestPrivacyNotice,
+		ackPrivacy,
+		destroy
+	};
+}
+
+export const chatHintStore = createChatHintStore();

--- a/src/lib/stores/display-parser.test.ts
+++ b/src/lib/stores/display-parser.test.ts
@@ -9,7 +9,9 @@ import {
 	DEFAULT_CHAT_DISPLAY_MODE,
 	DEFAULT_SIDEBAR_POSITION,
 	DEFAULT_TYPING_INDICATOR_DELAY_MS,
-	DEFAULT_WAIT_TONE_ENABLED
+	DEFAULT_WAIT_TONE_ENABLED,
+	DEFAULT_TEXT_REVEAL_SPEED,
+	DEFAULT_CHAT_BAR_ALIGNMENT
 } from './display-types.ts';
 
 test('returns defaults for null input', () => {
@@ -186,4 +188,28 @@ test('ignores invalid typingIndicatorDelayMs values', () => {
 test('ignores NaN typingIndicatorDelayMs', () => {
 	const result = parseDisplaySettings({ typingIndicatorDelayMs: NaN });
 	assert.equal(result.typingIndicatorDelayMs, DEFAULT_TYPING_INDICATOR_DELAY_MS);
+});
+
+test('parses text reveal speed and bar alignment', () => {
+	const result = parseDisplaySettings({ textRevealSpeed: 'fast', chatBarAlignment: 'left' });
+	assert.equal(result.textRevealSpeed, 'fast');
+	assert.equal(result.chatBarAlignment, 'left');
+});
+
+test('falls back to defaults for unknown reveal speed and alignment', () => {
+	const result = parseDisplaySettings({ textRevealSpeed: 'warp', chatBarAlignment: 'top' });
+	assert.equal(result.textRevealSpeed, DEFAULT_TEXT_REVEAL_SPEED);
+	assert.equal(result.chatBarAlignment, DEFAULT_CHAT_BAR_ALIGNMENT);
+});
+
+test('falls back to defaults for non-string reveal speed and alignment', () => {
+	const result = parseDisplaySettings({ textRevealSpeed: 42, chatBarAlignment: null });
+	assert.equal(result.textRevealSpeed, DEFAULT_TEXT_REVEAL_SPEED);
+	assert.equal(result.chatBarAlignment, DEFAULT_CHAT_BAR_ALIGNMENT);
+});
+
+test('defaults reveal speed and alignment when absent', () => {
+	const result = parseDisplaySettings({ chatDisplayMode: 'bubble' });
+	assert.equal(result.textRevealSpeed, DEFAULT_TEXT_REVEAL_SPEED);
+	assert.equal(result.chatBarAlignment, DEFAULT_CHAT_BAR_ALIGNMENT);
 });

--- a/src/lib/stores/display-parser.ts
+++ b/src/lib/stores/display-parser.ts
@@ -10,9 +10,13 @@ import {
 	DEFAULT_SIDEBAR_POSITION,
 	DEFAULT_TYPING_INDICATOR_DELAY_MS,
 	DEFAULT_WAIT_TONE_ENABLED,
+	DEFAULT_TEXT_REVEAL_SPEED,
+	DEFAULT_CHAT_BAR_ALIGNMENT,
 	type CameraSettings,
 	type ChatDisplayMode,
-	type SidebarPosition
+	type SidebarPosition,
+	type TextRevealSpeed,
+	type ChatBarAlignment
 } from './display-types.ts';
 
 const clamp = (v: number, min: number, max: number) => Math.max(min, Math.min(max, v));
@@ -37,6 +41,14 @@ function isSidebarPosition(value: unknown): value is SidebarPosition {
 	return value === 'left' || value === 'right';
 }
 
+function isTextRevealSpeed(value: unknown): value is TextRevealSpeed {
+	return value === 'off' || value === 'slow' || value === 'normal' || value === 'fast';
+}
+
+function isChatBarAlignment(value: unknown): value is ChatBarAlignment {
+	return value === 'left' || value === 'center' || value === 'right';
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -50,6 +62,8 @@ export interface ParsedDisplaySettings {
 	sidebarPosition: SidebarPosition;
 	waitToneEnabled: boolean;
 	typingIndicatorDelayMs: number;
+	textRevealSpeed: TextRevealSpeed;
+	chatBarAlignment: ChatBarAlignment;
 }
 
 /**
@@ -79,7 +93,9 @@ export function parseDisplaySettings(raw: unknown): ParsedDisplaySettings {
 			chatDisplayMode: DEFAULT_CHAT_DISPLAY_MODE,
 			sidebarPosition: DEFAULT_SIDEBAR_POSITION,
 			waitToneEnabled: DEFAULT_WAIT_TONE_ENABLED,
-			typingIndicatorDelayMs: DEFAULT_TYPING_INDICATOR_DELAY_MS
+			typingIndicatorDelayMs: DEFAULT_TYPING_INDICATOR_DELAY_MS,
+			textRevealSpeed: DEFAULT_TEXT_REVEAL_SPEED,
+			chatBarAlignment: DEFAULT_CHAT_BAR_ALIGNMENT
 		};
 	}
 
@@ -129,5 +145,13 @@ export function parseDisplaySettings(raw: unknown): ParsedDisplaySettings {
 		typingIndicatorDelayMs = Math.max(0, Math.min(10000, parsed.typingIndicatorDelayMs));
 	}
 
-	return { camera, overlayCamera, physicsIntensity, sceneBackground, chatDisplayMode, sidebarPosition, waitToneEnabled, typingIndicatorDelayMs };
+	const textRevealSpeed = isTextRevealSpeed(parsed.textRevealSpeed)
+		? parsed.textRevealSpeed
+		: DEFAULT_TEXT_REVEAL_SPEED;
+
+	const chatBarAlignment = isChatBarAlignment(parsed.chatBarAlignment)
+		? parsed.chatBarAlignment
+		: DEFAULT_CHAT_BAR_ALIGNMENT;
+
+	return { camera, overlayCamera, physicsIntensity, sceneBackground, chatDisplayMode, sidebarPosition, waitToneEnabled, typingIndicatorDelayMs, textRevealSpeed, chatBarAlignment };
 }

--- a/src/lib/stores/display-types.ts
+++ b/src/lib/stores/display-types.ts
@@ -10,12 +10,24 @@ export interface CameraSettings {
 export type CameraProfile = 'main' | 'overlay';
 export type ChatDisplayMode = 'bubble' | 'sidebar' | 'both' | 'off';
 export type SidebarPosition = 'left' | 'right';
+export type TextRevealSpeed = 'off' | 'slow' | 'normal' | 'fast';
+export type ChatBarAlignment = 'left' | 'center' | 'right';
 
 export const CAMERA_DEFAULTS: CameraSettings = { fov: 35, zoom: 1, height: 0 };
 export const DEFAULT_CHAT_DISPLAY_MODE: ChatDisplayMode = 'bubble';
 export const DEFAULT_SIDEBAR_POSITION: SidebarPosition = 'right';
 export const DEFAULT_WAIT_TONE_ENABLED = false;
 export const DEFAULT_TYPING_INDICATOR_DELAY_MS = 0;
+export const DEFAULT_TEXT_REVEAL_SPEED: TextRevealSpeed = 'normal';
+export const DEFAULT_CHAT_BAR_ALIGNMENT: ChatBarAlignment = 'center';
+
+/** Per-word reveal cadence for each speed; 0 disables the effect. */
+export const REVEAL_SPEED_MS: Record<TextRevealSpeed, number> = {
+	off: 0,
+	slow: 110,
+	normal: 60,
+	fast: 30
+};
 
 export const CAMERA_LIMITS = {
 	fov: { min: 20, max: 60 },

--- a/src/lib/stores/display.svelte.ts
+++ b/src/lib/stores/display.svelte.ts
@@ -7,10 +7,15 @@ import {
 	DEFAULT_SIDEBAR_POSITION,
 	DEFAULT_TYPING_INDICATOR_DELAY_MS,
 	DEFAULT_WAIT_TONE_ENABLED,
+	DEFAULT_TEXT_REVEAL_SPEED,
+	DEFAULT_CHAT_BAR_ALIGNMENT,
+	REVEAL_SPEED_MS,
 	type CameraSettings,
 	type CameraProfile,
 	type ChatDisplayMode,
-	type SidebarPosition
+	type SidebarPosition,
+	type TextRevealSpeed,
+	type ChatBarAlignment
 } from './display-types';
 import { parseDisplaySettings, sanitizeCamera } from './display-parser';
 import {
@@ -25,14 +30,17 @@ import {
 
 const STORAGE_KEY = 'utsuwa-display';
 
-export type { CameraSettings, CameraProfile, ChatDisplayMode, SidebarPosition };
+export type { CameraSettings, CameraProfile, ChatDisplayMode, SidebarPosition, TextRevealSpeed, ChatBarAlignment };
 export {
 	CAMERA_DEFAULTS,
 	CAMERA_LIMITS,
 	DEFAULT_CHAT_DISPLAY_MODE,
 	DEFAULT_SIDEBAR_POSITION,
 	DEFAULT_TYPING_INDICATOR_DELAY_MS,
-	DEFAULT_WAIT_TONE_ENABLED
+	DEFAULT_WAIT_TONE_ENABLED,
+	DEFAULT_TEXT_REVEAL_SPEED,
+	DEFAULT_CHAT_BAR_ALIGNMENT,
+	REVEAL_SPEED_MS
 };
 
 function createDisplayStore() {
@@ -52,6 +60,12 @@ function createDisplayStore() {
 	let typingIndicatorDelayMs = $state(DEFAULT_TYPING_INDICATOR_DELAY_MS);
 	// Optional soft audio ping while the companion is thinking
 	let waitToneEnabled = $state(DEFAULT_WAIT_TONE_ENABLED);
+	// Word-by-word reveal cadence for replies
+	let textRevealSpeed = $state<TextRevealSpeed>(DEFAULT_TEXT_REVEAL_SPEED);
+	// Where the floating bar sits along the bottom edge
+	let chatBarAlignment = $state<ChatBarAlignment>(DEFAULT_CHAT_BAR_ALIGNMENT);
+	// Session-only counter; the chat window clears its saved rect when it changes
+	let chatWindowResetToken = $state(0);
 
 	if (browser) {
 		const saved = localStorage.getItem(STORAGE_KEY);
@@ -65,6 +79,8 @@ function createDisplayStore() {
 			sidebarPosition = parsed.sidebarPosition;
 			typingIndicatorDelayMs = parsed.typingIndicatorDelayMs;
 			waitToneEnabled = parsed.waitToneEnabled;
+			textRevealSpeed = parsed.textRevealSpeed;
+			chatBarAlignment = parsed.chatBarAlignment;
 		}
 	}
 
@@ -80,7 +96,9 @@ function createDisplayStore() {
 					chatDisplayMode,
 					sidebarPosition,
 					typingIndicatorDelayMs,
-					waitToneEnabled
+					waitToneEnabled,
+					textRevealSpeed,
+					chatBarAlignment
 				})
 			);
 		}
@@ -136,7 +154,23 @@ function createDisplayStore() {
 		sidebarPosition = next.sidebarPosition;
 		typingIndicatorDelayMs = DEFAULT_TYPING_INDICATOR_DELAY_MS;
 		waitToneEnabled = DEFAULT_WAIT_TONE_ENABLED;
+		textRevealSpeed = DEFAULT_TEXT_REVEAL_SPEED;
+		chatBarAlignment = DEFAULT_CHAT_BAR_ALIGNMENT;
 		save();
+	}
+
+	function setTextRevealSpeed(speed: TextRevealSpeed) {
+		textRevealSpeed = speed;
+		save();
+	}
+
+	function setChatBarAlignment(alignment: ChatBarAlignment) {
+		chatBarAlignment = alignment;
+		save();
+	}
+
+	function requestChatWindowReset() {
+		chatWindowResetToken += 1;
 	}
 
 	function setTypingIndicatorDelayMs(ms: number) {
@@ -175,6 +209,15 @@ function createDisplayStore() {
 		get waitToneEnabled() {
 			return waitToneEnabled;
 		},
+		get textRevealSpeed() {
+			return textRevealSpeed;
+		},
+		get chatBarAlignment() {
+			return chatBarAlignment;
+		},
+		get chatWindowResetToken() {
+			return chatWindowResetToken;
+		},
 		setCamera,
 		resetCamera,
 		setPhysicsIntensity,
@@ -183,7 +226,10 @@ function createDisplayStore() {
 		setSidebarPosition,
 		resetChatDisplay,
 		setTypingIndicatorDelayMs,
-		setWaitToneEnabled
+		setWaitToneEnabled,
+		setTextRevealSpeed,
+		setChatBarAlignment,
+		requestChatWindowReset
 	};
 }
 

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -26,7 +26,8 @@
 		return null;
 	});
 	import SpeechBubble from '$lib/components/chat/SpeechBubble.svelte';
-	import ChatSidebar from '$lib/components/chat/ChatSidebar.svelte';
+	import ChatWindow from '$lib/components/chat/ChatWindow.svelte';
+	import { type ThinkingPhase } from '$lib/services/chat/chat-phase';
 	import ThinkingImages from '$lib/components/chat/ThinkingImages.svelte';
 	import Photoboard from '$lib/components/chat/Photoboard.svelte';
 	import { EventScene } from '$lib/components/events';
@@ -85,6 +86,8 @@
 	// Speech bubble state
 	let latestResponse = $state('');
 	let isTyping = $state(false);
+	// What she's doing this turn, for the shimmer label
+	let thinkingPhase = $state<ThinkingPhase>('thinking');
 	// Chat sidebar state — start open when sidebar mode is enabled
 	let sidebarOpen = $state(
 		displayStore.chatDisplayMode === 'sidebar' || displayStore.chatDisplayMode === 'both'
@@ -235,6 +238,7 @@
 			setTyping: (v) => (isTyping = v),
 			setLatestResponse: (v) => (latestResponse = v),
 			setActiveEvent: (e) => (activeEvent = e),
+			setPhase: (p) => (thinkingPhase = p),
 			onShownImages: (shown) => (thinkingImages = shown),
 			onNewMemory: (m) => (lastNewMemory = m)
 		}, options);
@@ -380,27 +384,33 @@
 			<SpeechBubble
 				message={latestResponse}
 				isTyping={isTyping && typingDotsVisible}
+				phase={thinkingPhase}
 				onHide={handleBubbleHide}
 			/>
 		{/if}
 
-			<!-- Chat History Sidebar (hides with the rest of the chat UI in photo mode) -->
-			<ChatSidebar
+			<!-- Chat window (hides with the rest of the chat UI in photo mode) -->
+			<ChatWindow
 				open={sidebarOpen && showSidebarTrigger}
 				onClose={() => sidebarOpen = false}
 				isTyping={isTyping && typingDotsVisible}
+				phase={thinkingPhase}
+				onSend={handleSend}
+				disabled={chatStore.isLoading}
+				{visionCapable}
 			/>
 
 			<!-- The image she's being shown, floated above her head while she considers it -->
 			<ThinkingImages images={thinkingImages} show={isTyping} />
 
-			<!-- Bottom Chat Bar -->
+			<!-- Bottom Chat Bar (its input docks into the chat window while open) -->
 			<BottomChatBar
 				onSend={handleSend}
 				disabled={chatStore.isLoading}
 				{visionCapable}
 				providerLabel={imageProvider.label}
 				providerIsLocal={imageProvider.isLocal}
+				barHidden={sidebarOpen && showSidebarTrigger}
 			/>
 		</div>
 		{#if photomodeStore.active}

--- a/src/routes/app/settings/display/+page.svelte
+++ b/src/routes/app/settings/display/+page.svelte
@@ -242,7 +242,6 @@
 
 	.card {
 		background: var(--bg-primary);
-		border: 1px solid var(--border-light);
 		border-radius: var(--radius-lg);
 		padding: 1rem 1.25rem;
 		box-shadow: var(--shadow-sm);
@@ -282,7 +281,6 @@
 		display: flex;
 		width: 100%;
 		background: var(--bg-secondary);
-		border: 1px solid var(--border-light);
 		border-radius: var(--radius-md);
 		padding: 0.25rem;
 		gap: 0.25rem;
@@ -314,20 +312,19 @@
 
 	.reset-btn {
 		padding: 0.375rem 0.75rem;
-		background: transparent;
-		border: 1px solid var(--border-light);
+		background: var(--bg-secondary);
+		border: none;
 		border-radius: var(--radius-md);
 		color: var(--text-secondary);
 		font-size: 0.8125rem;
 		font-weight: 500;
 		cursor: pointer;
-		transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+		transition: background 0.15s ease, color 0.15s ease;
 	}
 
 	.reset-btn:hover {
-		background: var(--bg-secondary);
+		background: var(--bg-tertiary);
 		color: var(--text-primary);
-		border-color: var(--border-light);
 	}
 
 	.hint {
@@ -417,7 +414,7 @@
 		width: 2rem;
 		height: 2rem;
 		border-radius: var(--radius-md);
-		border: 1px solid var(--border-light);
+		border: none;
 		background: var(--bg-secondary);
 		color: var(--text-primary);
 		font-size: 1rem;
@@ -439,7 +436,7 @@
 		width: 3.5rem;
 		padding: 0.35rem 0.5rem;
 		border-radius: var(--radius-md);
-		border: 1px solid var(--border-light);
+		border: none;
 		background: var(--bg-secondary);
 		font-size: 0.875rem;
 		color: var(--text-primary);

--- a/src/routes/app/settings/display/+page.svelte
+++ b/src/routes/app/settings/display/+page.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
-	import { displayStore, type ChatDisplayMode, type SidebarPosition } from '$lib/stores/display.svelte';
+	import {
+		displayStore,
+		type ChatDisplayMode,
+		type SidebarPosition,
+		type ChatBarAlignment,
+		type TextRevealSpeed
+	} from '$lib/stores/display.svelte';
 
+	// Stored values keep their original names; only the labels changed
 	const modes: { value: ChatDisplayMode; label: string }[] = [
-		{ value: 'bubble', label: 'Bubble' },
-		{ value: 'sidebar', label: 'Sidebar' },
+		{ value: 'bubble', label: 'Immersive' },
+		{ value: 'sidebar', label: 'Chat window' },
 		{ value: 'both', label: 'Both' },
 		{ value: 'off', label: 'Off' }
 	];
@@ -13,9 +20,30 @@
 		{ value: 'right', label: 'Right' }
 	];
 
+	const alignments: { value: ChatBarAlignment; label: string }[] = [
+		{ value: 'left', label: 'Left' },
+		{ value: 'center', label: 'Center' },
+		{ value: 'right', label: 'Right' }
+	];
+
+	const revealSpeeds: { value: TextRevealSpeed; label: string }[] = [
+		{ value: 'off', label: 'Off' },
+		{ value: 'slow', label: 'Slow' },
+		{ value: 'normal', label: 'Normal' },
+		{ value: 'fast', label: 'Fast' }
+	];
+
 	const sidebarActive = $derived(
 		displayStore.chatDisplayMode === 'sidebar' || displayStore.chatDisplayMode === 'both'
 	);
+
+	let windowResetDone = $state(false);
+
+	function resetWindowPosition() {
+		displayStore.requestChatWindowReset();
+		windowResetDone = true;
+		setTimeout(() => (windowResetDone = false), 2000);
+	}
 
 	function stepDelay(delta: number) {
 		const current = displayStore.typingIndicatorDelayMs / 1000;
@@ -50,29 +78,90 @@
 				</button>
 			{/each}
 		</div>
-		<p class="hint">Bubble shows only the latest reply. Sidebar shows the full history.</p>
+		<p class="hint">
+			Immersive shows her replies in a bubble by her head. Chat window is a messenger-style
+			window with the full history and the input docked inside.
+		</p>
 	</section>
 
 	{#if sidebarActive}
 		<section class="card">
 			<div class="card-header">
-				<h3>Sidebar Position</h3>
+				<h3>Chat Window</h3>
 			</div>
 
-			<div class="segment-control" role="group" aria-label="Sidebar position">
-				{#each positions as pos}
-					<button
-						class="segment-btn"
-						class:active={displayStore.sidebarPosition === pos.value}
-						onclick={() => displayStore.setSidebarPosition(pos.value)}
-						aria-pressed={displayStore.sidebarPosition === pos.value}
-					>
-						{pos.label}
+			<div class="settings-stack">
+				<div class="setting-row">
+					<div class="setting-info">
+						<span class="setting-label">Snap side</span>
+						<span class="setting-desc">Which edge the window starts on</span>
+					</div>
+					<div class="segment-control compact" role="group" aria-label="Chat window snap side">
+						{#each positions as pos}
+							<button
+								class="segment-btn"
+								class:active={displayStore.sidebarPosition === pos.value}
+								onclick={() => displayStore.setSidebarPosition(pos.value)}
+								aria-pressed={displayStore.sidebarPosition === pos.value}
+							>
+								{pos.label}
+							</button>
+						{/each}
+					</div>
+				</div>
+
+				<div class="setting-row">
+					<div class="setting-info">
+						<span class="setting-label">Window position</span>
+						<span class="setting-desc">Bring the window back if it ends up off screen</span>
+					</div>
+					<button class="reset-btn" onclick={resetWindowPosition}>
+						{windowResetDone ? 'Done' : 'Reset position'}
 					</button>
-				{/each}
+				</div>
 			</div>
 		</section>
 	{/if}
+
+	<section class="card">
+		<div class="card-header">
+			<h3>Floating Bar</h3>
+		</div>
+
+		<div class="segment-control" role="group" aria-label="Floating bar alignment">
+			{#each alignments as alignment}
+				<button
+					class="segment-btn"
+					class:active={displayStore.chatBarAlignment === alignment.value}
+					onclick={() => displayStore.setChatBarAlignment(alignment.value)}
+					aria-pressed={displayStore.chatBarAlignment === alignment.value}
+				>
+					{alignment.label}
+				</button>
+			{/each}
+		</div>
+		<p class="hint">Where the input bar sits along the bottom edge.</p>
+	</section>
+
+	<section class="card">
+		<div class="card-header">
+			<h3>Text Reveal</h3>
+		</div>
+
+		<div class="segment-control" role="group" aria-label="Text reveal speed">
+			{#each revealSpeeds as speed}
+				<button
+					class="segment-btn"
+					class:active={displayStore.textRevealSpeed === speed.value}
+					onclick={() => displayStore.setTextRevealSpeed(speed.value)}
+					aria-pressed={displayStore.textRevealSpeed === speed.value}
+				>
+					{speed.label}
+				</button>
+			{/each}
+		</div>
+		<p class="hint">How quickly her replies appear, word by word. Off shows text instantly.</p>
+	</section>
 
 	<section class="card">
 		<div class="card-header">
@@ -177,6 +266,16 @@
 		display: flex;
 		flex-direction: column;
 		gap: 1rem;
+	}
+
+	.segment-control.compact {
+		width: auto;
+		flex-shrink: 0;
+	}
+
+	.segment-control.compact .segment-btn {
+		flex: 0 0 auto;
+		padding: 0.4rem 0.9rem;
 	}
 
 	.segment-control {

--- a/src/routes/app/settings/display/+page.svelte
+++ b/src/routes/app/settings/display/+page.svelte
@@ -174,16 +174,17 @@
 					<span class="setting-label">Wait tone</span>
 					<span class="setting-desc">Soft audio ping while the typing indicator is visible</span>
 				</div>
-				<label class="toggle">
-					<input
-						type="checkbox"
-						checked={displayStore.waitToneEnabled}
-						onchange={(e) => displayStore.setWaitToneEnabled(e.currentTarget.checked)}
-					/>
+				<button
+					class="service-toggle"
+					class:enabled={displayStore.waitToneEnabled}
+					onclick={() => displayStore.setWaitToneEnabled(!displayStore.waitToneEnabled)}
+					aria-label="Toggle wait tone"
+					aria-pressed={displayStore.waitToneEnabled}
+				>
 					<span class="toggle-track">
 						<span class="toggle-thumb"></span>
 					</span>
-				</label>
+				</button>
 			</div>
 
 			<div class="setting-row">
@@ -357,20 +358,16 @@
 		color: var(--text-secondary);
 	}
 
-	.toggle {
+	/* Same switch as the LLM / TTS / STT pages */
+	.service-toggle {
 		position: relative;
-		display: inline-block;
 		width: 40px;
 		height: 22px;
+		background: transparent;
+		border: none;
+		padding: 0;
 		cursor: pointer;
 		flex-shrink: 0;
-	}
-
-	.toggle input {
-		opacity: 0;
-		width: 0;
-		height: 0;
-		position: absolute;
 	}
 
 	.toggle-track {
@@ -378,12 +375,11 @@
 		width: 100%;
 		height: 100%;
 		background: var(--bg-tertiary);
-		border-radius: 11px;
-		transition: background 0.2s ease-out;
-		box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.15);
+		border-radius: var(--radius-full);
+		transition: background 0.2s ease;
 	}
 
-	.toggle input:checked ~ .toggle-track {
+	.service-toggle.enabled .toggle-track {
 		background: var(--accent);
 	}
 
@@ -393,14 +389,13 @@
 		left: 2px;
 		width: 18px;
 		height: 18px;
-		background: var(--bg-primary);
-		border-radius: 50%;
-		transition: transform 0.2s ease-out;
-		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-		pointer-events: none;
+		background: #fff;
+		border-radius: var(--radius-full);
+		transition: transform 0.2s ease;
+		box-shadow: var(--shadow-xs);
 	}
 
-	.toggle input:checked ~ .toggle-track .toggle-thumb {
+	.service-toggle.enabled .toggle-thumb {
 		transform: translateX(18px);
 	}
 

--- a/src/routes/overlay/+page.svelte
+++ b/src/routes/overlay/+page.svelte
@@ -22,6 +22,7 @@
 	import { overlayStore } from '$lib/stores/overlay.svelte';
 	import { isTauri, startDragging } from '$lib/services/platform';
 	import { sendCompanionMessage, type SendCompanionMessageOptions } from '$lib/services/chat/companion-chat';
+	import { type ThinkingPhase } from '$lib/services/chat/chat-phase';
 	import { createReminderFiredHandler } from '$lib/services/chat/reminder-chat';
 	import { type PreparedImage } from '$lib/services/storage/keepsakes';
 	import { eventsApi } from '$lib/engine/events';
@@ -40,6 +41,7 @@
 
 	let latestResponse = $state('');
 	let isTyping = $state(false);
+	let thinkingPhase = $state<ThinkingPhase>('thinking');
 	let activeEvent = $state<EventDefinition | null>(null);
 	let showCamera = $state(false);
 	let positionLocked = $state(false);
@@ -226,6 +228,7 @@
 			setTyping: (v) => (isTyping = v),
 			setLatestResponse: (v) => (latestResponse = v),
 			setActiveEvent: (e) => (activeEvent = e),
+			setPhase: (p) => (thinkingPhase = p),
 			beforeStream: () => overlayStore.setChatExpanded(false)
 		});
 	}
@@ -236,6 +239,7 @@
 			setTyping: (v) => (isTyping = v),
 			setLatestResponse: (v) => (latestResponse = v),
 			setActiveEvent: (e) => (activeEvent = e),
+			setPhase: (p) => (thinkingPhase = p),
 			beforeStream: () => overlayStore.setChatExpanded(false)
 		}, options);
 	}
@@ -334,6 +338,7 @@
 	<SpeechBubble
 		message={latestResponse}
 		isTyping={isTyping}
+		phase={thinkingPhase}
 		onHide={handleBubbleHide}
 		docked
 	/>


### PR DESCRIPTION
## What

- Chat input docks into the chat window when it is open; the floating bar returns when it closes. Typed drafts and queued photos survive the transition via a shared draft store
- Chat surfaces restyled to the design system grays (bg-secondary + border-subtle)
- Thinking states narrate real pipeline phases (Remembering / Looking at your photo / Thinking) with a shimmer label, replacing the bouncing dots in both the bubble and the window
- Replies reveal word by word at a configurable speed (off / slow / normal / fast), markdown-safe in the window
- ChatSidebar rebuilt as ChatWindow: custom resize handles on all edges and corners (fixes the resize-after-reopen bug), viewport re-clamping, reset-position rescue in settings
- Display settings: modes relabeled Immersive / Chat window / Both / Off (stored values unchanged), plus window snap side, reset window position, floating bar alignment, text reveal speed
- Desktop overlay gets shimmer and reveal through the shared components

## Verification

- pnpm test: 379 passing (new TDD suites for display-parser fields, phase labels, reveal markup walker)
- pnpm check: 0 errors, 0 warnings
- Live e2e on localhost:5173: all four modes, dock transition mid-draft (text preserved), edge/corner resize with close/reopen persistence (rect verified via DOM + localStorage), reset position, bar alignment, two live turns against Ollama gemma3:4b confirming phase shimmer in window and bubble plus word reveal, overlay route loads clean
- Found and fixed during e2e: a self-triggering effect loop in the window clamp logic that froze the renderer, and the streaming placeholder rendering as an empty bubble while typing

## Notes

Mode label rename requires no migration; stored values are untouched.