### PR TITLE
feat(vrm): camera-driven spring bone jiggle

### DIFF
--- a/src/lib/components/vrm/VrmModel.svelte
+++ b/src/lib/components/vrm/VrmModel.svelte
@@ -526,7 +526,7 @@
 		direction: number;
 	}
 	let activePulses: ReactionPulse[] = [];
-	let appliedNudges: Array<{ bone: THREE.Object3D; z: number; x: number; y?: number }> = [];
+	let appliedNudges: Array<{ bone: THREE.Object3D; z: number; x: number }> = [];
 	let reactionFace: { name: string; weight: number; t: number; duration: number } | null = null;
 	const recentTaps = { zone: null as TouchZone | null, at: 0, count: 0 };
 	const REACTION_REPEAT_WINDOW_MS = 4000;
@@ -932,7 +932,6 @@
 		for (const applied of appliedNudges) {
 			applied.bone.rotation.z -= applied.z;
 			applied.bone.rotation.x -= applied.x;
-			if (applied.y) applied.bone.rotation.y -= applied.y;
 		}
 		appliedNudges.length = 0;
 
@@ -964,9 +963,9 @@
 			activePulses = remaining;
 		}
 
-		// Camera-driven jiggle: measure orbit velocity, run the damped spring,
-		// nudge chest (full) and head (half) additively; undone next frame like
-		// the tap pulses so nothing accumulates
+		// Camera-driven jiggle: measure orbit velocity and advance the damped
+		// spring. The offsets are applied around vrm.update() further down, so
+		// only the spring bones see the movement, never the rendered skeleton.
 		{
 			camera.current.getWorldPosition(jiggleCamPos);
 			vrm.scene.getWorldPosition(jiggleModelPos);
@@ -974,33 +973,6 @@
 			if (prevCamAngles && delta > 0) {
 				const vel = angularVelocity(prevCamAngles, angles, delta);
 				jiggleState = stepJiggle(jiggleState, vel, displayStore.physicsIntensity, delta);
-				if (Math.abs(jiggleState.yaw) > 1e-5 || Math.abs(jiggleState.pitch) > 1e-5) {
-					const chest =
-						vrm.humanoid.getNormalizedBoneNode('upperChest') ??
-						vrm.humanoid.getNormalizedBoneNode('chest') ??
-						vrm.humanoid.getNormalizedBoneNode('spine');
-					const head = vrm.humanoid.getNormalizedBoneNode('head');
-					// Horizontal orbit reads as a side lean (z) with a touch of
-					// twist (y); vertical orbit as a forward/back sway (x)
-					if (chest) {
-						const z = jiggleState.yaw * 0.8;
-						const y = jiggleState.yaw * 0.4;
-						const x = jiggleState.pitch;
-						chest.rotation.z += z;
-						chest.rotation.y += y;
-						chest.rotation.x += x;
-						appliedNudges.push({ bone: chest, z, x, y });
-					}
-					if (head) {
-						const z = jiggleState.yaw * 0.45;
-						const y = jiggleState.yaw * 0.25;
-						const x = jiggleState.pitch * 0.5;
-						head.rotation.z += z;
-						head.rotation.y += y;
-						head.rotation.x += x;
-						appliedNudges.push({ bone: head, z, x, y });
-					}
-				}
 			}
 			prevCamAngles = angles;
 		}
@@ -1057,9 +1029,53 @@
 			}
 		}
 
+		// Camera jiggle, phase 1: displace the chest and head so the spring
+		// solver inside vrm.update() reads their movement and swings hair,
+		// clothes, and accessories accordingly.
+		const jiggleActive =
+			Math.abs(jiggleState.yaw) > 1e-5 || Math.abs(jiggleState.pitch) > 1e-5;
+		let jiggleChest: THREE.Object3D | null = null;
+		let jiggleHead: THREE.Object3D | null = null;
+		if (jiggleActive) {
+			jiggleChest =
+				vrm.humanoid.getNormalizedBoneNode('upperChest') ??
+				vrm.humanoid.getNormalizedBoneNode('chest') ??
+				vrm.humanoid.getNormalizedBoneNode('spine');
+			jiggleHead = vrm.humanoid.getNormalizedBoneNode('head');
+			if (jiggleChest) {
+				jiggleChest.rotation.z += jiggleState.yaw * 0.8;
+				jiggleChest.rotation.y += jiggleState.yaw * 0.4;
+				jiggleChest.rotation.x += jiggleState.pitch;
+			}
+			if (jiggleHead) {
+				jiggleHead.rotation.z += jiggleState.yaw * 0.45;
+				jiggleHead.rotation.y += jiggleState.yaw * 0.25;
+				jiggleHead.rotation.x += jiggleState.pitch * 0.5;
+			}
+		}
+
 		// Update VRM core. The delta is clamped because a huge frame gap (tab
 		// refocus, window drag) otherwise launches the spring bones violently.
 		vrm.update(clampFrameDelta(delta));
+
+		// Camera jiggle, phase 2: put the skeleton straight back. The solver
+		// already sampled the displaced pose; re-syncing the humanoid pushes
+		// the rest pose back onto the raw render skeleton (vrm.update copied
+		// the displaced one), so the body stays planted while only the spring
+		// bones carry the motion.
+		if (jiggleActive) {
+			if (jiggleChest) {
+				jiggleChest.rotation.z -= jiggleState.yaw * 0.8;
+				jiggleChest.rotation.y -= jiggleState.yaw * 0.4;
+				jiggleChest.rotation.x -= jiggleState.pitch;
+			}
+			if (jiggleHead) {
+				jiggleHead.rotation.z -= jiggleState.yaw * 0.45;
+				jiggleHead.rotation.y -= jiggleState.yaw * 0.25;
+				jiggleHead.rotation.x -= jiggleState.pitch * 0.5;
+			}
+			if (jiggleChest || jiggleHead) vrm.humanoid.update();
+		}
 
 		// Track head position for 3D speech bubble
 		const headBone = vrm.humanoid.getNormalizedBoneNode('head');

--- a/src/lib/components/vrm/VrmModel.svelte
+++ b/src/lib/components/vrm/VrmModel.svelte
@@ -15,6 +15,13 @@
 		clampFrameDelta,
 		type SpringJointParams
 	} from '$lib/engine/spring-physics';
+	import {
+		cameraAngles,
+		angularVelocity,
+		stepJiggle,
+		createJiggleState,
+		type CameraAngles
+	} from '$lib/engine/camera-impulse';
 	import { lipSyncAnalyzer } from '$lib/services/lipsync/analyzer';
 	import { untrack } from 'svelte';
 	import * as THREE from 'three';
@@ -519,7 +526,7 @@
 		direction: number;
 	}
 	let activePulses: ReactionPulse[] = [];
-	let appliedNudges: Array<{ bone: THREE.Object3D; z: number; x: number }> = [];
+	let appliedNudges: Array<{ bone: THREE.Object3D; z: number; x: number; y?: number }> = [];
 	let reactionFace: { name: string; weight: number; t: number; duration: number } | null = null;
 	const recentTaps = { zone: null as TouchZone | null, at: 0, count: 0 };
 	const REACTION_REPEAT_WINDOW_MS = 4000;
@@ -904,6 +911,12 @@
 	let headTrackWeight = 0;
 	const headWorld = new THREE.Vector3();
 	const camWorld = new THREE.Vector3();
+	// Camera jiggle: orbiting excites the spring bones via a damped nudge on
+	// the chest and head; the rig's own springs do the visible swinging
+	const jiggleCamPos = new THREE.Vector3();
+	const jiggleModelPos = new THREE.Vector3();
+	let jiggleState = createJiggleState();
+	let prevCamAngles: CameraAngles | null = null;
 	const lookDir = new THREE.Vector3();
 	const parentQuat = new THREE.Quaternion();
 	const lookQuat = new THREE.Quaternion();
@@ -919,6 +932,7 @@
 		for (const applied of appliedNudges) {
 			applied.bone.rotation.z -= applied.z;
 			applied.bone.rotation.x -= applied.x;
+			if (applied.y) applied.bone.rotation.y -= applied.y;
 		}
 		appliedNudges.length = 0;
 
@@ -949,6 +963,42 @@
 			}
 			activePulses = remaining;
 		}
+
+		// Camera-driven jiggle: measure orbit velocity, run the damped spring,
+		// nudge chest (full) and head (half) additively; undone next frame like
+		// the tap pulses so nothing accumulates
+		{
+			camera.current.getWorldPosition(jiggleCamPos);
+			vrm.scene.getWorldPosition(jiggleModelPos);
+			const angles = cameraAngles(jiggleCamPos, jiggleModelPos);
+			if (prevCamAngles && delta > 0) {
+				const vel = angularVelocity(prevCamAngles, angles, delta);
+				jiggleState = stepJiggle(jiggleState, vel, displayStore.physicsIntensity, delta);
+				if (Math.abs(jiggleState.yaw) > 1e-5 || Math.abs(jiggleState.pitch) > 1e-5) {
+					const chest =
+						vrm.humanoid.getNormalizedBoneNode('upperChest') ??
+						vrm.humanoid.getNormalizedBoneNode('chest') ??
+						vrm.humanoid.getNormalizedBoneNode('spine');
+					const head = vrm.humanoid.getNormalizedBoneNode('head');
+					if (chest) {
+						const y = jiggleState.yaw;
+						const x = jiggleState.pitch;
+						chest.rotation.y += y;
+						chest.rotation.x += x;
+						appliedNudges.push({ bone: chest, z: 0, x, y });
+					}
+					if (head) {
+						const y = jiggleState.yaw * 0.5;
+						const x = jiggleState.pitch * 0.5;
+						head.rotation.y += y;
+						head.rotation.x += x;
+						appliedNudges.push({ bone: head, z: 0, x, y });
+					}
+				}
+			}
+			prevCamAngles = angles;
+		}
+
 		if (reactionFace && vrm.expressionManager) {
 			reactionFace.t += delta;
 			const progress = reactionFace.t / reactionFace.duration;

--- a/src/lib/components/vrm/VrmModel.svelte
+++ b/src/lib/components/vrm/VrmModel.svelte
@@ -980,19 +980,25 @@
 						vrm.humanoid.getNormalizedBoneNode('chest') ??
 						vrm.humanoid.getNormalizedBoneNode('spine');
 					const head = vrm.humanoid.getNormalizedBoneNode('head');
+					// Horizontal orbit reads as a side lean (z) with a touch of
+					// twist (y); vertical orbit as a forward/back sway (x)
 					if (chest) {
-						const y = jiggleState.yaw;
+						const z = jiggleState.yaw * 0.8;
+						const y = jiggleState.yaw * 0.4;
 						const x = jiggleState.pitch;
+						chest.rotation.z += z;
 						chest.rotation.y += y;
 						chest.rotation.x += x;
-						appliedNudges.push({ bone: chest, z: 0, x, y });
+						appliedNudges.push({ bone: chest, z, x, y });
 					}
 					if (head) {
-						const y = jiggleState.yaw * 0.5;
+						const z = jiggleState.yaw * 0.45;
+						const y = jiggleState.yaw * 0.25;
 						const x = jiggleState.pitch * 0.5;
+						head.rotation.z += z;
 						head.rotation.y += y;
 						head.rotation.x += x;
-						appliedNudges.push({ bone: head, z: 0, x, y });
+						appliedNudges.push({ bone: head, z, x, y });
 					}
 				}
 			}

--- a/src/lib/engine/camera-impulse.test.ts
+++ b/src/lib/engine/camera-impulse.test.ts
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+	cameraAngles,
+	angularVelocity,
+	stepJiggle,
+	createJiggleState,
+	JIGGLE
+} from './camera-impulse.ts';
+
+test('cameraAngles derives azimuth and polar from camera position', () => {
+	// Camera on +z axis looking at origin: azimuth 0, polar ~PI/2
+	const a = cameraAngles({ x: 0, y: 0, z: 2 }, { x: 0, y: 0, z: 0 });
+	assert.equal(a.azimuth, 0);
+	assert.ok(Math.abs(a.polar - Math.PI / 2) < 1e-9);
+	// Camera on +x axis: azimuth PI/2
+	const b = cameraAngles({ x: 2, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
+	assert.ok(Math.abs(b.azimuth - Math.PI / 2) < 1e-9);
+});
+
+test('angularVelocity is zero for identical frames and guards bad dt', () => {
+	const a = { azimuth: 1, polar: 1.5 };
+	assert.deepEqual(angularVelocity(a, a, 1 / 60), { yaw: 0, pitch: 0 });
+	assert.deepEqual(angularVelocity(a, { azimuth: 2, polar: 1 }, 0), { yaw: 0, pitch: 0 });
+	assert.deepEqual(angularVelocity(a, { azimuth: 2, polar: 1 }, -1), { yaw: 0, pitch: 0 });
+});
+
+test('angularVelocity wraps the azimuth seam without spiking', () => {
+	// Crossing from just below PI to just above -PI is a tiny move, not a full turn
+	const v = angularVelocity(
+		{ azimuth: Math.PI - 0.01, polar: 1.5 },
+		{ azimuth: -Math.PI + 0.01, polar: 1.5 },
+		1 / 60
+	);
+	assert.ok(Math.abs(v.yaw) < 2);
+});
+
+test('drives below the dead zone leave the state at rest', () => {
+	const state = createJiggleState();
+	const next = stepJiggle(state, { yaw: JIGGLE.deadZone * 0.5, pitch: 0 }, 1.0, 1 / 60);
+	assert.equal(next.yaw, 0);
+	assert.equal(next.yawVel, 0);
+});
+
+test('a strong drive deflects the state and it decays back to rest', () => {
+	let state = createJiggleState();
+	state = stepJiggle(state, { yaw: 3, pitch: 0 }, 1.0, 1 / 60);
+	assert.ok(state.yawVel !== 0);
+	// Let it ring down with no further drive
+	for (let i = 0; i < 600; i++) {
+		state = stepJiggle(state, { yaw: 0, pitch: 0 }, 1.0, 1 / 60);
+	}
+	assert.ok(Math.abs(state.yaw) < 1e-4);
+	assert.ok(Math.abs(state.yawVel) < 1e-4);
+});
+
+test('offset never exceeds the clamp even under a whip pan', () => {
+	let state = createJiggleState();
+	for (let i = 0; i < 120; i++) {
+		state = stepJiggle(state, { yaw: 1000, pitch: -1000 }, 1.6, 1 / 60);
+		assert.ok(Math.abs(state.yaw) <= JIGGLE.maxOffset + 1e-9);
+		assert.ok(Math.abs(state.pitch) <= JIGGLE.maxOffset + 1e-9);
+	}
+});
+
+test('intensity scales the response monotonically', () => {
+	const drive = { yaw: 2, pitch: 0 };
+	const low = stepJiggle(createJiggleState(), drive, 0.5, 1 / 60);
+	const high = stepJiggle(createJiggleState(), drive, 1.6, 1 / 60);
+	assert.ok(Math.abs(high.yawVel) > Math.abs(low.yawVel));
+});
+
+test('zero and negative dt are inert', () => {
+	const state = stepJiggle(createJiggleState(), { yaw: 5, pitch: 5 }, 1.0, 0);
+	assert.deepEqual(state, createJiggleState());
+});

--- a/src/lib/engine/camera-impulse.ts
+++ b/src/lib/engine/camera-impulse.ts
@@ -26,14 +26,15 @@ export const JIGGLE = {
 	deadZone: 0.15,
 	// rad/s cap so a whip pan cannot inject unbounded energy
 	maxVel: 8,
-	// how strongly camera angular velocity accelerates the spring
-	gain: 0.6,
+	// how strongly camera angular velocity accelerates the spring; tuned for
+	// a visible, playful wobble on a brisk orbit (Turret Girls camera energy)
+	gain: 4.0,
 	// spring constant and damping; damping is slightly under critical so the
 	// settle has one soft overshoot, which reads as physical
 	stiffness: 40,
 	damping: 11,
-	// hard cap on the additive rotation offset (radians)
-	maxOffset: 0.09
+	// hard cap on the additive rotation offset (radians, ~8 degrees)
+	maxOffset: 0.14
 } as const;
 
 export function createJiggleState(): JiggleState {

--- a/src/lib/engine/camera-impulse.ts
+++ b/src/lib/engine/camera-impulse.ts
@@ -1,0 +1,110 @@
+// Camera-driven spring bone excitation. Orbiting the camera produces no bone
+// movement on its own, so the scene feeds camera angular velocity through a
+// damped spring whose offset is applied as a small additive bone nudge each
+// frame; the VRM's own spring bones then swing naturally from that movement.
+
+export interface Vec3 {
+	x: number;
+	y: number;
+	z: number;
+}
+
+export interface CameraAngles {
+	azimuth: number;
+	polar: number;
+}
+
+export interface JiggleState {
+	yaw: number;
+	pitch: number;
+	yawVel: number;
+	pitchVel: number;
+}
+
+export const JIGGLE = {
+	// rad/s of camera motion below which nothing reacts (mouse drift)
+	deadZone: 0.15,
+	// rad/s cap so a whip pan cannot inject unbounded energy
+	maxVel: 8,
+	// how strongly camera angular velocity accelerates the spring
+	gain: 0.6,
+	// spring constant and damping; damping is slightly under critical so the
+	// settle has one soft overshoot, which reads as physical
+	stiffness: 40,
+	damping: 11,
+	// hard cap on the additive rotation offset (radians)
+	maxOffset: 0.09
+} as const;
+
+export function createJiggleState(): JiggleState {
+	return { yaw: 0, pitch: 0, yawVel: 0, pitchVel: 0 };
+}
+
+export function cameraAngles(camera: Vec3, target: Vec3): CameraAngles {
+	const dx = camera.x - target.x;
+	const dy = camera.y - target.y;
+	const dz = camera.z - target.z;
+	const r = Math.sqrt(dx * dx + dy * dy + dz * dz);
+	return {
+		azimuth: Math.atan2(dx, dz),
+		polar: r > 1e-9 ? Math.acos(Math.max(-1, Math.min(1, dy / r))) : 0
+	};
+}
+
+const TWO_PI = Math.PI * 2;
+
+function wrapAngle(a: number): number {
+	// Map to [-PI, PI] so crossing the atan2 seam is a small delta
+	return a - TWO_PI * Math.round(a / TWO_PI);
+}
+
+export function angularVelocity(
+	prev: CameraAngles,
+	current: CameraAngles,
+	dt: number
+): { yaw: number; pitch: number } {
+	if (!(dt > 0)) return { yaw: 0, pitch: 0 };
+	return {
+		yaw: wrapAngle(current.azimuth - prev.azimuth) / dt,
+		pitch: (current.polar - prev.polar) / dt
+	};
+}
+
+const clamp = (v: number, min: number, max: number) => Math.max(min, Math.min(max, v));
+
+function applyDeadZone(v: number): number {
+	return Math.abs(v) < JIGGLE.deadZone ? 0 : clamp(v, -JIGGLE.maxVel, JIGGLE.maxVel);
+}
+
+/**
+ * Advance the damped spring one frame. `drive` is camera angular velocity in
+ * rad/s; `intensity` is the physics intensity setting, which scales how much
+ * energy the camera injects (never the spring's return to rest).
+ */
+export function stepJiggle(
+	state: JiggleState,
+	drive: { yaw: number; pitch: number },
+	intensity: number,
+	dt: number
+): JiggleState {
+	if (!(dt > 0)) return { ...state };
+	// Large frame gaps (tab refocus) must not integrate into a violent kick
+	const step = Math.min(dt, 1 / 30);
+
+	const driveYaw = applyDeadZone(drive.yaw) * JIGGLE.gain * intensity * 0.01;
+	const drivePitch = applyDeadZone(drive.pitch) * JIGGLE.gain * intensity * 0.01;
+
+	const yawAcc = driveYaw / step - JIGGLE.stiffness * state.yaw - JIGGLE.damping * state.yawVel;
+	const pitchAcc =
+		drivePitch / step - JIGGLE.stiffness * state.pitch - JIGGLE.damping * state.pitchVel;
+
+	const yawVel = state.yawVel + yawAcc * step;
+	const pitchVel = state.pitchVel + pitchAcc * step;
+
+	return {
+		yaw: clamp(state.yaw + yawVel * step, -JIGGLE.maxOffset, JIGGLE.maxOffset),
+		pitch: clamp(state.pitch + pitchVel * step, -JIGGLE.maxOffset, JIGGLE.maxOffset),
+		yawVel,
+		pitchVel
+	};
+}

--- a/src/lib/engine/camera-impulse.ts
+++ b/src/lib/engine/camera-impulse.ts
@@ -28,7 +28,7 @@ export const JIGGLE = {
 	maxVel: 8,
 	// how strongly camera angular velocity accelerates the spring; tuned for
 	// a visible, playful wobble on a brisk orbit (Turret Girls camera energy)
-	gain: 4.0,
+	gain: 5.0,
 	// spring constant and damping; damping is slightly under critical so the
 	// settle has one soft overshoot, which reads as physical
 	stiffness: 40,

--- a/src/lib/engine/camera-impulse.ts
+++ b/src/lib/engine/camera-impulse.ts
@@ -33,8 +33,8 @@ export const JIGGLE = {
 	// settle has one soft overshoot, which reads as physical
 	stiffness: 40,
 	damping: 11,
-	// hard cap on the additive rotation offset (radians, ~8 degrees)
-	maxOffset: 0.14
+	// hard cap on the additive rotation offset (radians, ~10 degrees)
+	maxOffset: 0.17
 } as const;
 
 export function createJiggleState(): JiggleState {


### PR DESCRIPTION
## What

Orbiting the camera excites the VRM spring bones (hair, outfit, accessories) in both the main view and photo mode.

Camera angular velocity around the model feeds a damped spring (src/lib/engine/camera-impulse.ts). Its offset displaces the chest and head right before vrm.update() so the spring solver samples the movement, then the pose is reverted and the humanoid re-synced immediately after, so the displaced pose never reaches the render skeleton. The body stays planted; only the spring bones carry the motion. Scaled by the existing physics intensity setting; no new UI.

Guardrails: dead zone for mouse drift, velocity cap for whip pans, offset clamp, frame-gap clamp (tab refocus cannot inject energy), slightly underdamped settle.

## Verification

- pnpm test: 373 passing including 8 TDD cases for the impulse math (dead zone, azimuth seam wrap, clamping, decay to rest, intensity scaling, zero-dt safety)
- pnpm check: 0 errors, 0 warnings
- Live e2e on localhost:5173 across two models: camera whips show hair visibly swinging while the skeleton stays vertical (initial cut leaned the whole body; fixed by the apply-sample-revert pattern above), settles cleanly with no residual oscillation; photo mode shares the same path; console clean.