### PR TITLE
fix(tts): stop defaulting the session language to English

### DIFF
--- a/src/lib/services/chat/companion-chat.ts
+++ b/src/lib/services/chat/companion-chat.ts
@@ -338,7 +338,9 @@ export async function sendCompanionMessage(
 					model: (speechSettings.activeModel as string) || ttsConfig.modelId,
 					baseUrl: ttsConfig.baseUrl || ttsMeta?.defaultBaseUrl,
 					speed: (speechSettings.speed as number) ?? 1,
-					language: (speechSettings.activeLanguage as string) || 'en'
+					// Leave unset when the user hasn't picked one; the orchestrator
+					// infers the primary language from the first segment instead.
+					language: (speechSettings.activeLanguage as string) || undefined
 				});
 			}
 		}

--- a/src/lib/services/voice-orchestrator.test.ts
+++ b/src/lib/services/voice-orchestrator.test.ts
@@ -202,3 +202,38 @@ test('interrupt stops playback and onComplete fires', async () => {
 	assert.equal(complete, true);
 	assert.equal(orchestrator.getIsPlaying(), false);
 });
+
+// --- alt-voice language selection ------------------------------------------
+// The companion pipeline must not invent a session language. When it is unset
+// the orchestrator infers the primary language from the first segment; pinning
+// it to 'en' inverts alt-voice selection for every non-English companion.
+
+async function altVoiceTags(sessionLanguage: string | undefined): Promise<(string | undefined)[]> {
+	globalThis.fetch = () => mockFetchResponse();
+
+	const orchestrator = new VoiceOrchestrator();
+	const tags: (string | undefined)[] = [];
+
+	await orchestrator.speakSegments(
+		[
+			{ text: 'これはテストです。', language: 'ja' },
+			{ text: 'This is a test.', language: 'en' }
+		],
+		{ ...baseOptions, altVoiceId: 'alt-voice', language: sessionLanguage },
+		{ onSegmentStart: (seg) => tags.push(seg.voiceId) }
+	);
+
+	return tags;
+}
+
+test('infers primary language from the first segment when none is configured', async () => {
+	// Japanese leads, so Japanese is primary and only the English line switches.
+	assert.deepEqual(await altVoiceTags(undefined), [undefined, 'alt']);
+});
+
+test('an explicitly configured primary language overrides inference', async () => {
+	// This is why the caller must send undefined rather than a default of 'en':
+	// pinning 'en' flips which line is treated as foreign.
+	assert.deepEqual(await altVoiceTags('en'), ['alt', undefined]);
+	assert.deepEqual(await altVoiceTags('ja'), [undefined, 'alt']);
+});


### PR DESCRIPTION
Follow-up 2 of 3 from #139.

`companion-chat.ts` sent `language: (activeLanguage) || 'en'` on every turn, so `sessionOptions.language` was always populated even for users who never picked a language.

The orchestrator treats an unset session language as "infer the primary language from the first segment" (`voice-orchestrator.ts:261`). A pinned `en` defeats that inference and flips alt-voice selection for any non-English companion: the Japanese lines get tagged as the foreign voice and the English lines get the main voice.

## Scope, stated plainly

**This has no user-visible effect today.** I want to be precise about that rather than oversell it:

- The OmniVoice client already defaults to `en` on its own, so request bodies are unchanged
- Nothing in the codebase populates `altVoiceId`, so the alt-voice branch never runs
- No TTS provider currently forwards `StreamOptions.voiceId` to its request, so per-segment voice selection is inert end to end

This is preventative: it keeps the inference contract correct before anyone wires that path up. See the note at the bottom.

## Verification

- Two new orchestrator tests lock the contract. The second one demonstrates the inversion directly: with `language: 'en'` the tags come back `['alt', undefined]`, with `undefined` or `'ja'` they come back `[undefined, 'alt']`
- `pnpm test` 411 pass / 0 fail. `pnpm check` 0 errors / 0 warnings
- **Live check**: with `language: undefined` the OmniVoice request body still sends `"language": "en"`, and a user-picked `de` still sends `"de"`, confirming no change to what any server receives

## Note for a separate decision

Alt-voice is dead plumbing right now: the orchestrator computes `resolveVoiceId`, but no provider reads `StreamOptions.voiceId`, and nothing sets `altVoiceId`. It is worth deciding whether to wire it up or delete it. That is a product call, not part of this PR.