### PR TITLE
fix(omnivoice): add a CPU compose path and publish on loopback

### DIFF
--- a/src/content/docs/guides/omnivoice.md
+++ b/src/content/docs/guides/omnivoice.md
@@ -40,22 +40,35 @@ If the model download is slow or you hit rate limits, set a `HF_TOKEN` environme
 1. Start the proxy.
 2. Open Utsuwa and go to **Settings > Speech (TTS)**.
 3. Enable **Speech** and select **OmniVoice**.
-4. Set the base URL. The proxy binds to every interface, so any of these work once the model is loaded:
+4. Set the base URL. The compose file publishes the proxy on loopback only, so use:
    - `http://localhost:8881/v1/`
    - `http://127.0.0.1:8881/v1/`
-   - `http://<your-machine-ip>:8881/v1/` (for example `http://192.168.1.42:8881/v1/`)
-
-If `localhost` does not resolve from your browser or from inside the development container, use the IP address of your network interface instead. The proxy already sends permissive CORS headers, so a hosted site or another origin can reach it as long as the browser allows the request.
 5. Choose a voice, language, and speed, then send a message.
+
+The proxy sends permissive CORS headers, so a hosted site can reach it as long as the browser allows the request.
+
+## Reaching the proxy from another machine
+
+The proxy has no authentication and accepts requests from any origin, so the compose file binds it to `127.0.0.1` and nothing outside your machine can reach it.
+
+If you want it available to other devices, change the port mapping in `tools/omnivoice/docker-compose.yaml`:
+
+```yaml
+ports:
+  - "8881:8881" # reachable from anything that can route to this machine
+```
+
+Only do this on a network you trust. Anyone who can reach the port can use your GPU to synthesise audio. The same applies when running outside Docker with `--host 0.0.0.0`; the default there is `127.0.0.1`.
+
+Once exposed, use `http://<your-machine-ip>:8881/v1/` as the base URL (for example `http://192.168.1.42:8881/v1/`). If you run Utsuwa in the development container, `localhost` inside the container is not the host machine, so you need this too.
 
 ## CPU-only mode
 
-If you do not have an NVIDIA GPU or `nvidia-container-toolkit`, remove the `deploy.resources.reservations.devices` block in `tools/omnivoice/docker-compose.yaml` and start with `--device cpu`:
+If you do not have an NVIDIA GPU or `nvidia-container-toolkit`, use the CPU compose file:
 
 ```bash
 cd tools/omnivoice
-docker compose run -d --rm --name omnivoice-proxy omnivoice-proxy \
-  python omnivoice-proxy.py --host 0.0.0.0 --port 8881 --device cpu
+docker compose -f docker-compose.cpu.yaml up -d
 ```
 
 CPU synthesis is slower, especially on first load, but it does not require a GPU.
@@ -99,9 +112,9 @@ Close other GPU applications, reduce `--max-concurrent` to `1`, or run with `--d
 
 ### Proxy is healthy but Utsuwa cannot reach it
 
-- Try the base URL with your machine's network IP instead of `localhost`.
+- Confirm you are using `localhost` or `127.0.0.1`. The proxy is bound to loopback by default, so a network IP will not reach it until you change the port mapping. See [Reaching the proxy from another machine](#reaching-the-proxy-from-another-machine).
 - If you use the hosted web app, the browser may ask for permission to access local-network devices; allow it.
-- If you run Utsuwa in the development Docker container, remember that `localhost` inside the container is not the host machine. Use the host IP or run the proxy on a network both can reach.
+- If you run Utsuwa in the development Docker container, remember that `localhost` inside the container is not the host machine. You need the host IP, which means exposing the port as described above.
 
 ## See also
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,7 +9,7 @@ const isTauri = !!process.env.TAURI_ENV_PLATFORM;
 
 const highlighter = await createHighlighter({
 	themes: ['github-light', 'github-dark'],
-	langs: ['js', 'ts', 'bash', 'json', 'svelte', 'html', 'css', 'md']
+	langs: ['js', 'ts', 'bash', 'json', 'svelte', 'html', 'css', 'md', 'yaml']
 });
 
 /** @type {import('@sveltejs/kit').Config} */

--- a/tools/omnivoice/README.md
+++ b/tools/omnivoice/README.md
@@ -7,6 +7,7 @@ For installation instructions, connection details, and troubleshooting, see the 
 ## Files
 
 - `omnivoice-proxy.py` — FastAPI server that exposes `/v1/audio/speech`, `/v1/models`, `/v1/voices`, and `/health`.
-- `Dockerfile` / `docker-compose.yaml` — Container setup for running the proxy with Docker.
+- `Dockerfile` / `docker-compose.yaml` — Container setup for running the proxy with Docker (NVIDIA GPU).
+- `docker-compose.cpu.yaml` — CPU-only variant for machines without a GPU or `nvidia-container-toolkit`.
 - `requirements.txt` — Python dependencies for running the proxy outside of Docker.
 - `test-omnivoice.py` — Integration test that checks the endpoints and synthesises a short clip.

--- a/tools/omnivoice/docker-compose.cpu.yaml
+++ b/tools/omnivoice/docker-compose.cpu.yaml
@@ -1,0 +1,25 @@
+name: omnivoice-proxy
+
+# CPU-only variant. Use this when you have no NVIDIA GPU or no
+# nvidia-container-toolkit:
+#   docker compose -f docker-compose.cpu.yaml up -d
+# Synthesis is noticeably slower, especially on the first load.
+
+services:
+  omnivoice-proxy:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    container_name: omnivoice-proxy
+    command:
+      ["python", "omnivoice-proxy.py", "--host", "0.0.0.0", "--port", "8881", "--device", "cpu"]
+    ports:
+      - "127.0.0.1:8881:8881"
+    ipc: host
+    shm_size: "2g"
+    volumes:
+      - omnivoice-cache:/data/hf_cache
+    restart: unless-stopped
+
+volumes:
+  omnivoice-cache:

--- a/tools/omnivoice/docker-compose.yaml
+++ b/tools/omnivoice/docker-compose.yaml
@@ -6,7 +6,11 @@ services:
       context: .
       dockerfile: ./Dockerfile
     container_name: omnivoice-proxy
-    network_mode: host
+    # Published rather than network_mode: host, which is Linux-only and silently
+    # does nothing on Docker Desktop. Bind to 0.0.0.0 to reach it from another
+    # machine; see the setup guide before you do.
+    ports:
+      - "127.0.0.1:8881:8881"
     ipc: host
     shm_size: "2g"
     deploy:


### PR DESCRIPTION
Follow-up 3 of 3 from #139.

The setup guide offered CPU inference, but the shipped compose file reserved an NVIDIA GPU and the Dockerfile hardcodes `--device cuda`, so the CPU instructions told you to hand-edit the compose file. Separately, `network_mode: host` is Linux-only and silently does nothing on Docker Desktop, so Mac and Windows users could not reach the proxy at all.

## What changed

- **`docker-compose.cpu.yaml`** (new): no GPU reservation, `--device cpu`. One command instead of hand-editing YAML.
- **`docker-compose.yaml`**: `network_mode: host` replaced with an explicit `127.0.0.1:8881:8881` mapping. Works identically on Linux and Docker Desktop.
- **Loopback by default.** The proxy has no authentication and sends `allow_origins=["*"]`, so anything that can reach the port can drive synthesis on your GPU. The guide now has a section on exposing it deliberately, with the tradeoff stated.
- **Docs**: CPU section rewritten, stale "binds to every interface" text corrected, troubleshooting updated to match the new default.
- **`svelte.config.js`**: registers `yaml` with Shiki (see below).

## The yaml thing is worth calling out

My first pass added a ```yaml block to the guide. `pnpm test` and `pnpm check` both passed clean, but the docs page returned **500 Internal Error** in the browser: Shiki only had `js, ts, bash, json, svelte, html, css, md` loaded. That would have shipped a broken docs page to production behind two green gates.

Caught it by actually loading the page. `yaml` is now registered.

## Verification

- `docker compose config` on both files: GPU keeps the nvidia reservation, CPU has zero nvidia references and the correct `--device cpu` command, both bind `127.0.0.1`
- Guide renders at HTTP 200 with the new sections present, yaml block syntax-highlighted, and the section anchor resolving. No stale text remains
- Other docs pages spot-checked at 200 since the Shiki change is global
- `pnpm build` succeeds, 19 pages indexed
- `pnpm test` 409 pass / 0 fail. `pnpm check` 0 errors / 0 warnings

## Behaviour change to be aware of

Anyone who was reaching the proxy from another machine via `network_mode: host` needs the one-line port change now documented in the guide. That only worked on Linux before.