### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-07-28
+
+### Added
+- **OmniVoice, a local voice that speaks a lot of languages**: a new keyless TTS provider that runs entirely on your own machine, no cloud account and no API key. Pick it under Settings > Speech (TTS), choose one of thirteen preset voices, set a language and a speed, and she talks. It needs a small proxy you run yourself, which ships in `tools/omnivoice` with a Docker setup for both NVIDIA and CPU machines. The [setup guide](/docs/guides/omnivoice) walks through it. An NVIDIA GPU makes it quick; CPU works but takes its time. Contributed by @dezihh.
+- **You can see whether your local voice server is awake**: local TTS providers now show a small green or red dot in the provider dropdown, so you know at a glance whether the thing on the other end is actually running before you send a message and wait for silence. Contributed by @dezihh.
+
+### Changed
+- The OmniVoice proxy listens on port 8881 rather than 8880, so it can sit alongside a Kokoro or openedai-speech server without the two fighting over the same address.
+- The OmniVoice proxy is published on localhost only. It has no password and accepts requests from anywhere, so it stays on your machine unless you deliberately open it up. The setup guide shows the one-line change if you want to reach it from another device, and what you are agreeing to when you do.
+
+### Fixed
+- Docker Desktop users on Mac and Windows can reach the OmniVoice proxy now. The old container setup used a networking mode that only ever worked on Linux and quietly did nothing everywhere else.
+
 ## [0.12.1] - 2026-07-19
 
 ### License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.12.1",
+	"version": "0.13.0",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.12.1"
+version = "0.13.0"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "pnpm build",


### PR DESCRIPTION
Release prep for 0.13.0.

Version bumped in all four places: `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and the `utsuwa` block in `src-tauri/Cargo.lock`.

## What is in this release

- OmniVoice local TTS provider, contributed by @dezihh (#139)
- Health dots for local TTS providers in the dropdown, also #139
- Distinct default port so OmniVoice does not collide with Kokoro (#139)
- CPU compose path, Docker Desktop fix, loopback-only default (#143)
- Session language no longer pinned to English (#142)
- OmniVoice folded into the shared OpenAI TTS client (#141, #144)

The last three are invisible to users, so they are not in the changelog.

Minor rather than patch because this adds a new provider.

Note the AGPL relicense already shipped in 0.12.1. Only the blog post about it was unreleased, and that is marketing site content rather than app behaviour, so it is not in the notes either.

Gates: `pnpm test` 415 pass / 0 fail, `pnpm check` clean, `pnpm build` clean.