### PR TITLE
fix(tts): unlock the shared audio context inside the send gesture for iOS Safari

### DIFF
--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -3,6 +3,7 @@
 	import { sttStore } from '$lib/stores/stt.svelte';
 	import { chatDraftStore } from '$lib/stores/chat-draft.svelte';
 	import { queueFiles, showVisionHint } from './attach-files';
+	import { unlockAudioContext } from '$lib/services/tts';
 	import { type PreparedImage } from '$lib/services/storage/keepsakes';
 	import AudioVisualizer from './AudioVisualizer.svelte';
 	import { pop, fadeFast } from '$lib/utils/motion';
@@ -56,6 +57,8 @@
 	// Single send path: text plus any queued images
 	function doSend() {
 		if (disabled) return;
+		// Inside the gesture, before any await: iOS Safari refuses later
+		unlockAudioContext();
 		const { text, images } = chatDraftStore.takeAll();
 		if (!text && images.length === 0) return;
 		onSend(text, images);
@@ -75,6 +78,7 @@
 	}
 
 	function handleMicClick() {
+		unlockAudioContext();
 		if (!sttStore.isSupported()) {
 			sttStore.showUnsupportedError();
 			return;

--- a/src/lib/services/tts/index.test.ts
+++ b/src/lib/services/tts/index.test.ts
@@ -54,7 +54,7 @@ class MockAudioContext {
 // @ts-expect-error globalThis.AudioContext is not available in Node test environment
 globalThis.AudioContext = MockAudioContext;
 
-import { getTTSProvider } from './index.ts';
+import { getTTSProvider, getSharedAudioContext, unlockAudioContext } from './index.ts';
 import { OpenAITTS } from './openai-tts.ts';
 import { ElevenLabsTTS } from './elevenlabs.ts';
 
@@ -118,4 +118,28 @@ test('factory creates new OmniVoice provider when language changes', () => {
 		speed: 1.0
 	});
 	assert.notEqual(first, second);
+});
+
+test('unlockAudioContext resumes a suspended shared context', () => {
+	const ctx = getSharedAudioContext() as unknown as MockAudioContext;
+	let resumed = 0;
+	ctx.state = 'suspended';
+	ctx.resume = () => {
+		resumed++;
+		ctx.state = 'running';
+		return Promise.resolve();
+	};
+	unlockAudioContext();
+	assert.equal(resumed, 1);
+	// Already running: no second resume
+	unlockAudioContext();
+	assert.equal(resumed, 1);
+});
+
+test('unlockAudioContext is a no-op without AudioContext (SSR)', () => {
+	const saved = globalThis.AudioContext;
+	// @ts-expect-error simulating SSR
+	delete globalThis.AudioContext;
+	assert.doesNotThrow(() => unlockAudioContext());
+	globalThis.AudioContext = saved;
 });

--- a/src/lib/services/tts/index.ts
+++ b/src/lib/services/tts/index.ts
@@ -79,6 +79,15 @@ export function getSharedAudioContext(): AudioContext {
 	return sharedAudioContext;
 }
 
+// iOS Safari keeps an AudioContext suspended unless resume() runs inside a
+// user gesture; the providers' own resume calls happen after the TTS fetch,
+// which no longer counts. Call this synchronously from send and mic handlers.
+export function unlockAudioContext(): void {
+	if (typeof AudioContext === 'undefined') return;
+	const ctx = getSharedAudioContext();
+	if (ctx.state === 'suspended') void ctx.resume();
+}
+
 // Import individual providers
 import { ElevenLabsTTS } from './elevenlabs.ts';
 import { OpenAITTS } from './openai-tts.ts';

--- a/src/lib/services/tts/index.ts
+++ b/src/lib/services/tts/index.ts
@@ -82,10 +82,12 @@ export function getSharedAudioContext(): AudioContext {
 // iOS Safari keeps an AudioContext suspended unless resume() runs inside a
 // user gesture; the providers' own resume calls happen after the TTS fetch,
 // which no longer counts. Call this synchronously from send and mic handlers.
+// Checks !== 'running' rather than === 'suspended' because Safari also reports
+// a nonstandard 'interrupted' state after calls or backgrounding.
 export function unlockAudioContext(): void {
 	if (typeof AudioContext === 'undefined') return;
 	const ctx = getSharedAudioContext();
-	if (ctx.state === 'suspended') void ctx.resume();
+	if (ctx.state !== 'running') ctx.resume().catch(() => {});
 }
 
 // Import individual providers


### PR DESCRIPTION
Fixes #146

## Problem
On iOS Safari, TTS was silent for every provider with no errors. The only `resume()` calls live inside the TTS providers and run after the LLM stream and TTS fetch complete, which iOS no longer treats as part of the user gesture. A context resumed outside a gesture stays suspended silently, which matches the reported symptoms exactly (both providers silent, no errors, valid keys).

## Fix
New `unlockAudioContext()` in `src/lib/services/tts/index.ts`, called synchronously at the top of the single send path (`doSend`) and the mic click handler in `ChatInput.svelte`, before any await. All providers share that context, so one unlock covers ElevenLabs, OpenAI, and the local providers.

## Verified
- TDD: both new tests written first and watched fail (resume called exactly once on a suspended context, no-op without AudioContext for SSR)
- `pnpm test` 429 pass, `pnpm check` clean
- Live on the dev server: the unlock runs inside a real keyboard gesture with no console errors and no behavior change on desktop
- Not verified on a physical iOS device; requesting confirmation from the reporter on app.utsuwa.ai after deploy