### PR TITLE
chore: bump version to 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2026-08-03
+
+### Added
+- **Design your OmniVoice voice**: OmniVoice grew a proper settings panel. Pick a language and a preset voice side by side, or describe the voice you want by gender, age, pitch, and accent and let it build one. Sliders for speed and synthesis quality, a Test button that speaks a phrase in the active language, and a Regenerate button when a voice drifts and you want a fresh one. Voices now keep a persistent profile, so the speaker sounds like the same person from sentence to sentence instead of shifting between takes. You can also clone a voice from a few seconds of reference audio, manage your clones, and switch between synthetic and cloned modes. Contributed by @dezihh.
+
+### Fixed
+- **She speaks on iPhones again**: iOS Safari requires audio to start inside your tap, and her voice arrived just late enough to be refused, silently. The audio pipeline now unlocks the moment you hit send, so TTS works on iOS for every provider. One thing the fix cannot do: if the ring/silent switch is on, iOS mutes her anyway. Check the switch before assuming she has nothing to say.
+- Animation files are fetched once and reused instead of being downloaded again on every idle cycle. Less network chatter, quicker transitions.
+
 ## [0.13.0] - 2026-07-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.13.0",
+	"version": "0.13.1",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.13.0"
+version = "0.13.1"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "pnpm build",


### PR DESCRIPTION
Version bump and changelog for 0.13.1.

Ships since 0.13.0:
- OmniVoice settings UI with persistent voice profiles and cloning (#147)
- iOS Safari TTS gesture unlock (#151, fixes #146)
- VRM animation caching (#148)

pnpm test 435 pass, svelte-check clean.