### PR TITLE
fix(tts): make the ElevenLabs voice id field drive the voice that plays

### DIFF
--- a/src/lib/components/onboarding/steps/ServicesStep.svelte
+++ b/src/lib/components/onboarding/steps/ServicesStep.svelte
@@ -292,6 +292,10 @@
 		}
 	}
 
+	function handleTTSVoiceChange(voiceId: string) {
+		modulesStore.setModuleSetting('speech', 'activeVoiceId', voiceId.trim());
+	}
+
 	function handleTTSModelChange(modelId: string) {
 		modulesStore.setModuleSetting('speech', 'activeModel', modelId);
 	}
@@ -503,10 +507,16 @@
 				<input
 					type="text"
 					class="api-key-input"
-					placeholder="Custom Voice ID (optional)"
-					value={settingsStore.elevenLabsVoiceId}
-					oninput={(e) => settingsStore.setElevenLabsVoiceId(e.currentTarget.value)}
+					list="elevenlabs-voices"
+					placeholder="Voice ID"
+					value={ttsSettings.activeVoiceId as string ?? ''}
+					oninput={(e) => handleTTSVoiceChange(e.currentTarget.value)}
 				/>
+				<datalist id="elevenlabs-voices">
+					{#each ttsProvider?.voices ?? [] as voice}
+						<option value={voice.id}>{voice.name}</option>
+					{/each}
+				</datalist>
 			{/if}
 
 			{#if ttsProvider?.isLocal}

--- a/src/lib/components/settings/TtsSettings.svelte
+++ b/src/lib/components/settings/TtsSettings.svelte
@@ -70,10 +70,16 @@ import { checkTTSProviderHealth } from '$lib/services/providers/health-check';
 					<input
 						type="text"
 						class="api-key-input"
-						placeholder="Custom Voice ID (optional)"
-						value={settingsStore.elevenLabsVoiceId}
-						onchange={(e) => settingsStore.setElevenLabsVoiceId(e.currentTarget.value)}
+						list="elevenlabs-voices"
+						placeholder="Voice ID"
+						value={state.speechSettings.activeVoiceId as string ?? ''}
+						onchange={(e) => state.handleTTSVoiceChange(e.currentTarget.value)}
 					/>
+					<datalist id="elevenlabs-voices">
+						{#each provider?.voices ?? [] as voice}
+							<option value={voice.id}>{voice.name}</option>
+						{/each}
+					</datalist>
 				</div>
 			{/if}
 

--- a/src/lib/services/chat/companion-chat.ts
+++ b/src/lib/services/chat/companion-chat.ts
@@ -334,7 +334,7 @@ export async function sendCompanionMessage(
 				ttsStore.speak(turn.dialogue, {
 					provider: ttsProvider,
 					apiKey: ttsConfig.apiKey,
-					voiceId: (speechSettings.activeVoiceId as string) || ttsConfig.voiceId,
+					voiceId: (speechSettings.activeVoiceId as string) || undefined,
 					model: (speechSettings.activeModel as string) || ttsConfig.modelId,
 					baseUrl: ttsConfig.baseUrl || ttsMeta?.defaultBaseUrl,
 					speed: (speechSettings.speed as number) ?? 1,

--- a/src/lib/services/tts/legacy-voice-migration.ts
+++ b/src/lib/services/tts/legacy-voice-migration.ts
@@ -1,0 +1,23 @@
+import { modulesStore } from '$lib/stores/modules.svelte';
+import { settingsStore } from '$lib/stores/settings.svelte';
+import { getTTSProvider } from '$lib/services/providers/registry';
+import { legacyVoiceToAdopt } from './provider-utils';
+
+// One-time move of the old ElevenLabs "custom voice id" into the speech
+// module's activeVoiceId, which is the slot the pipeline actually reads.
+// Runs once per app start after the modules have loaded their state; the
+// legacy slot is cleared either way so this can never re-fire later.
+export function migrateLegacyElevenLabsVoice(): void {
+	const legacy = settingsStore.getProviderConfig('elevenlabs').voiceId;
+	if (legacy === undefined) return;
+
+	const speech = modulesStore.getModuleSettings('speech');
+	const adopt = legacyVoiceToAdopt(
+		speech.activeProvider as string | undefined,
+		speech.activeVoiceId as string | undefined,
+		legacy,
+		getTTSProvider('elevenlabs')
+	);
+	if (adopt) modulesStore.setModuleSetting('speech', 'activeVoiceId', adopt);
+	settingsStore.setProviderConfig('elevenlabs', { voiceId: undefined });
+}

--- a/src/lib/services/tts/provider-utils.test.ts
+++ b/src/lib/services/tts/provider-utils.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { defaultVoiceForProvider, providerErrorMessage } from './provider-utils.ts';
+import { defaultVoiceForProvider, legacyVoiceToAdopt, providerErrorMessage } from './provider-utils.ts';
 
 // --- defaultVoiceForProvider ---
 
@@ -44,4 +44,33 @@ test('falls back to a generic message field, a string body, or status only', () 
 test('long details are truncated so toasts stay readable', () => {
 	const message = providerErrorMessage('TTS', 400, { message: 'x'.repeat(500) });
 	assert.ok(message.length <= 'TTS error 400: '.length + 160);
+});
+
+// --- legacy ElevenLabs custom voice migration ---
+
+const elevenlabs = { voices: [{ id: '21m00Tcm4TlvDq8ikWAM' }, { id: 'EXAVITQu4vr4xnSDxMaL' }] };
+
+test('adopts the legacy custom voice when the active voice is still the provider default', () => {
+	assert.equal(legacyVoiceToAdopt('elevenlabs', '21m00Tcm4TlvDq8ikWAM', 'tnVKC6NjwhdRxoQIfKue', elevenlabs), 'tnVKC6NjwhdRxoQIfKue');
+});
+
+test('adopts the legacy custom voice when no active voice is set', () => {
+	assert.equal(legacyVoiceToAdopt('elevenlabs', '', 'tnVKC6NjwhdRxoQIfKue', elevenlabs), 'tnVKC6NjwhdRxoQIfKue');
+	assert.equal(legacyVoiceToAdopt('elevenlabs', undefined, 'tnVKC6NjwhdRxoQIfKue', elevenlabs), 'tnVKC6NjwhdRxoQIfKue');
+});
+
+test('leaves a voice the user picked on purpose alone', () => {
+	assert.equal(legacyVoiceToAdopt('elevenlabs', 'EXAVITQu4vr4xnSDxMaL', 'tnVKC6NjwhdRxoQIfKue', elevenlabs), null);
+	assert.equal(legacyVoiceToAdopt('elevenlabs', 'someOtherCustomId', 'tnVKC6NjwhdRxoQIfKue', elevenlabs), null);
+});
+
+test('never carries an ElevenLabs voice onto another provider', () => {
+	assert.equal(legacyVoiceToAdopt('openai', '', 'tnVKC6NjwhdRxoQIfKue', elevenlabs), null);
+	assert.equal(legacyVoiceToAdopt(undefined, '', 'tnVKC6NjwhdRxoQIfKue', elevenlabs), null);
+});
+
+test('nothing to adopt when the legacy slot is empty or whitespace', () => {
+	assert.equal(legacyVoiceToAdopt('elevenlabs', '', '', elevenlabs), null);
+	assert.equal(legacyVoiceToAdopt('elevenlabs', '', '   ', elevenlabs), null);
+	assert.equal(legacyVoiceToAdopt('elevenlabs', '', undefined, elevenlabs), null);
 });

--- a/src/lib/services/tts/provider-utils.ts
+++ b/src/lib/services/tts/provider-utils.ts
@@ -9,6 +9,24 @@ export function defaultVoiceForProvider(
 	return provider?.voices?.[0]?.id ?? '';
 }
 
+// Until 0.13.1 the ElevenLabs "custom voice id" box wrote to the provider
+// config while the pipeline read the speech module's activeVoiceId, which the
+// provider switch had already set to the first declared voice. Returns the
+// legacy id to move across when it was never in effect, otherwise null.
+export function legacyVoiceToAdopt(
+	activeProvider: string | undefined,
+	activeVoiceId: string | undefined,
+	legacyVoiceId: string | undefined,
+	provider?: { voices?: Array<{ id: string }> } | null
+): string | null {
+	if (activeProvider !== 'elevenlabs') return null;
+	const legacy = legacyVoiceId?.trim();
+	if (!legacy) return null;
+	const current = activeVoiceId ?? '';
+	if (current !== '' && current !== defaultVoiceForProvider(provider)) return null;
+	return legacy;
+}
+
 const MAX_DETAIL_LENGTH = 160;
 
 // Builds a human-readable error out of a TTS API failure, keeping the API's

--- a/src/lib/stores/ai-services-settings.svelte.ts
+++ b/src/lib/stores/ai-services-settings.svelte.ts
@@ -241,7 +241,11 @@ export function createTtsSettingsState() {
 
 	let ttsIsLoading = $state(false);
 	let ttsFetchError = $state<string | null>(null);
-	let ttsDynamicModels = $state<ModelInfo[] | null>(null);
+	// Start from the cached list so a provider without static models (ElevenLabs)
+	// shows the saved model instead of the placeholder until someone hits refresh.
+	let ttsDynamicModels = $state<ModelInfo[] | null>(
+		getCachedModelsForProvider(modulesStore.getModuleSettings('speech').activeProvider as string)
+	);
 
 	const staticTTSModels = $derived.by(() => {
 		const providerId = speechSettings.activeProvider as string;
@@ -333,7 +337,7 @@ export function createTtsSettingsState() {
 	}
 
 	function handleTTSVoiceChange(voiceId: string) {
-		modulesStore.setModuleSetting('speech', 'activeVoiceId', voiceId);
+		modulesStore.setModuleSetting('speech', 'activeVoiceId', voiceId.trim());
 	}
 
 	function handleTTSLanguageChange(language: string) {

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -177,10 +177,6 @@ function createSettingsStore() {
 		return providerConfigs.elevenlabs?.apiKey ?? '';
 	}
 
-	function getElevenLabsVoiceId(): string {
-		return providerConfigs.elevenlabs?.voiceId ?? '';
-	}
-
 	// Legacy compatibility setters
 	function setAnthropicApiKey(key: string) {
 		setProviderConfig('anthropic', { apiKey: key });
@@ -195,10 +191,6 @@ function createSettingsStore() {
 	function setElevenLabsApiKey(key: string) {
 		setProviderConfig('elevenlabs', { apiKey: key });
 		markProviderAdded('elevenlabs');
-	}
-
-	function setElevenLabsVoiceId(id: string) {
-		setProviderConfig('elevenlabs', { voiceId: id });
 	}
 
 	// Cached models management
@@ -252,9 +244,6 @@ function createSettingsStore() {
 		get elevenLabsApiKey() {
 			return getElevenLabsApiKey();
 		},
-		get elevenLabsVoiceId() {
-			return getElevenLabsVoiceId();
-		},
 
 		// Provider management
 		setProviderConfig,
@@ -270,7 +259,6 @@ function createSettingsStore() {
 		setAnthropicApiKey,
 		setOpenaiApiKey,
 		setElevenLabsApiKey,
-		setElevenLabsVoiceId,
 
 		// Cached models
 		setCachedModels,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 	import { goto } from '$app/navigation';
 	import { modulesStore } from '$lib/stores/modules.svelte';
 	import { moduleRegistry } from '$lib/services/modules';
+	import { migrateLegacyElevenLabsVoice } from '$lib/services/tts/legacy-voice-migration';
 	import { isDesktopBuild } from '$lib/services/platform/platform';
 	import { SITE_URL } from '$lib/config/site';
 
@@ -27,6 +28,7 @@
 		for (const mod of moduleRegistry) {
 			modulesStore.registerModule(mod);
 		}
+		migrateLegacyElevenLabsVoice();
 
 		// React to system theme changes in real-time when using "system" mode
 		const themeQuery = window.matchMedia('(prefers-color-scheme: dark)');


### PR DESCRIPTION
Fixes #153.

## Root cause

Selecting ElevenLabs (settings dropdown or onboarding) sets `speech.activeVoiceId` to the first declared voice, Rachel `21m00Tcm4TlvDq8ikWAM`. The "Custom Voice ID" box wrote to a different slot, `providerConfigs.elevenlabs.voiceId`, and the pipeline resolved `activeVoiceId || ttsConfig.voiceId`. Rachel is never empty, so every pasted id was shadowed. Reproduced against a mock ElevenLabs with the reporter's exact stored state: three requests to `text-to-speech/21m00Tcm4TlvDq8ikWAM/stream` while the custom id sat unused. That matches "ElevenLabs receives the requests, the voice does not change".

## Change

- The ElevenLabs voice field edits `activeVoiceId` through `handleTTSVoiceChange`, the same path every other provider uses, with the declared voices as a native datalist. Onboarding twin gets the same treatment.
- One-time migration at startup (`legacy-voice-migration.ts`, decision in `legacyVoiceToAdopt`): if a legacy custom id exists and the active voice is empty or still the provider default, it moves across. The legacy slot is cleared either way so the migration can never fire twice or apply an ElevenLabs voice to another provider. Users who had a legacy id but are on a different TTS provider lose an id that was never in effect and will see the real slot when they switch back.
- Pipeline reads one slot again; the dead getter and setter are gone from the settings store.
- Second symptom from the screenshots: the TTS settings state now seeds its model list from the cache on init, so ElevenLabs shows the saved model instead of "Select model..." until someone hits refresh.

## Verification

- `pnpm test` 440 pass (5 new for `legacyVoiceToAdopt`), `pnpm check` 0 errors 0 warnings.
- Live against the real ElevenLabs API on a Creator account:
  - Migration: seeded `activeVoiceId` Rachel plus a legacy custom id, reloaded, `activeVoiceId` became the custom id and the legacy slot was removed, API key kept.
  - Playback: chat turn produced three `text-to-speech/JBFqnCBsd6RMkjVDRZzb/stream` calls (George, not in our declared list), all 200 `audio/mpeg`.
  - Fresh user: picked ElevenLabs from the dropdown (voice resets to Rachel, field shows it), pasted the custom id, `activeVoiceId` updated, model dropdown showed "Eleven Turbo v2.5" after refresh and again after a full reload without refresh.
  - Invalid id: request goes out with the typed id, ElevenLabs returns 400, the chat bar shows "ElevenLabs error 400: An invalid ID has been received for voice". Before this fix a bad id never left the machine.
  - Onboarding: Services step field shows the current voice, typing writes it trimmed, datalist present.

## Notes

- Touches the same `voiceId:` line in `companion-chat.ts` as #154; whichever merges second gets a one-line conflict.
- Not in scope, worth their own issues: the desktop "Download Save File" button in the reporter's fourth screenshot does nothing under WebView2 (`db/export.ts` uses an anchor download), and `ElevenLabsTTS` defaults to Bella when the voice is empty while the registry's first voice is Rachel.
