### PR TITLE
fix(data): write the save file to Downloads on desktop and surface export errors

### DIFF
--- a/src/lib/components/photomode/PhotoModeDock.svelte
+++ b/src/lib/components/photomode/PhotoModeDock.svelte
@@ -11,7 +11,7 @@
 	import { vrmStore } from '$lib/stores/vrm.svelte';
 	import { loadPoseManifest, type PoseEntry } from '$lib/services/poses';
 	import { keepImage } from '$lib/services/storage/keepsakes';
-	import { isTauri } from '$lib/services/platform';
+	import { saveToDownloads } from '$lib/utils/save-to-downloads';
 	import { BACKGROUND_PRESETS, presetSwatch } from '$lib/services/scene-backgrounds';
 
 	type Tab = 'pose' | 'face' | 'scene' | 'camera' | 'sticker';
@@ -120,21 +120,10 @@
 			// the browser via a download, the desktop app by writing directly to
 			// the Downloads folder. The keepsake-store copy is kept either way.
 			const filename = `utsuwa-photo-${Date.now()}.png`;
-			if (isTauri()) {
-				try {
-					const { writeFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
-					const bytes = new Uint8Array(await blob.arrayBuffer());
-					await writeFile(filename, bytes, { baseDir: BaseDirectory.Download });
-				} catch (e) {
-					console.error('[PhotoMode] Could not write to Downloads:', e);
-				}
-			} else {
-				const url = URL.createObjectURL(blob);
-				const link = document.createElement('a');
-				link.download = filename;
-				link.href = url;
-				link.click();
-				URL.revokeObjectURL(url);
+			try {
+				await saveToDownloads(filename, blob);
+			} catch (e) {
+				console.error('[PhotoMode] Could not write to Downloads:', e);
 			}
 
 			savedTick = true;

--- a/src/lib/components/settings/DataManagement.svelte
+++ b/src/lib/components/settings/DataManagement.svelte
@@ -24,16 +24,24 @@
 	let importMode = $state<'merge' | 'replace'>('replace');
 	let importError = $state<string | null>(null);
 	let importSuccess = $state<{ imported: number; skipped: number } | null>(null);
+	let exportMessage = $state<{ kind: 'success' | 'error'; text: string } | null>(null);
 
 	let fileInput: HTMLInputElement;
 
 	async function handleExport() {
 		isExporting = true;
+		exportMessage = null;
 		try {
 			const saveFile = await exportSave();
-			downloadSaveFile(saveFile);
+			const { filename, savedToDownloads } = await downloadSaveFile(saveFile);
+			// The browser shows its own download UI; the desktop app writes silently,
+			// so tell the user where the file went.
+			if (savedToDownloads) {
+				exportMessage = { kind: 'success', text: `Saved to your Downloads folder as ${filename}` };
+			}
 		} catch (e) {
 			console.error('Export failed:', e);
+			exportMessage = { kind: 'error', text: `Export failed: ${e instanceof Error ? e.message : String(e)}` };
 		} finally {
 			isExporting = false;
 		}
@@ -178,6 +186,15 @@
 					{/if}
 				{/snippet}
 			</Button>
+			{#if exportMessage}
+				<div
+					class={exportMessage.kind === 'error' ? 'error-message' : 'success-message'}
+					transition:pop={{ duration: 200, y: 6 }}
+				>
+					<Icon name={exportMessage.kind === 'error' ? 'alert' : 'check-circle'} size={16} />
+					<span>{exportMessage.text}</span>
+				</div>
+			{/if}
 		</div>
 
 		<!-- Import -->

--- a/src/lib/db/export.ts
+++ b/src/lib/db/export.ts
@@ -1,4 +1,5 @@
 import { db } from '$lib/db';
+import { saveToDownloads } from '$lib/utils/save-to-downloads';
 import { characterStore } from '$lib/stores/character.svelte';
 import { partitionNewRecords, factKey, sessionKey, turnKey, eventKey } from './import-dedup';
 import type {
@@ -66,8 +67,10 @@ export async function exportSave(): Promise<SaveFile> {
 		]
 	);
 
-	// Get the single character state (or use current store state)
-	const characterState = characterStates[0] || $state.snapshot(characterStore.state);
+	// Get the single character state (or use current store state). Runes are
+	// not available in a plain .ts module, so unwrap the store proxy the same
+	// way the file itself is serialised.
+	const characterState = characterStates[0] || JSON.parse(JSON.stringify(characterStore.state));
 
 	// Remove IndexedDB auto-increment ids and derived data (embeddings) from export
 	const { id: _charId, ...cleanCharacter } = characterState as CharacterState & { id?: number };
@@ -307,20 +310,18 @@ export function getSaveFilePreview(saveFile: SaveFile | LegacySaveFile): SaveFil
 	};
 }
 
-export function downloadSaveFile(saveFile: SaveFile): void {
+export async function downloadSaveFile(
+	saveFile: SaveFile
+): Promise<{ filename: string; savedToDownloads: boolean }> {
 	const json = JSON.stringify(saveFile, null, 2);
 	const blob = new Blob([json], { type: 'application/json' });
-	const url = URL.createObjectURL(blob);
 
-	const date = new Date().toISOString().split('T')[0];
-	const filename = `utsuwa-save-${date}.json`;
-
-	const a = document.createElement('a');
-	a.href = url;
-	a.download = filename;
-	a.click();
-
-	URL.revokeObjectURL(url);
+	// Date plus time so two exports on the same day never overwrite each other
+	// on desktop, where the file is written directly instead of auto-renamed.
+	const stamp = new Date().toISOString().slice(0, 16).replace('T', '-').replace(':', '');
+	const filename = `utsuwa-save-${stamp}.json`;
+	const savedToDownloads = await saveToDownloads(filename, blob);
+	return { filename, savedToDownloads };
 }
 
 export async function clearAllData(): Promise<void> {

--- a/src/lib/utils/save-to-downloads.ts
+++ b/src/lib/utils/save-to-downloads.ts
@@ -1,0 +1,23 @@
+import { isTauri } from '$lib/services/platform/platform';
+
+// Puts a file where users expect downloads to land. Browsers get a normal
+// download. The desktop webview drops blob: downloads on the floor, so the app
+// writes straight into the Downloads folder instead (the only folder the fs
+// capability allows writing to). Resolves true when it wrote the file itself,
+// false when the browser took over.
+export async function saveToDownloads(filename: string, blob: Blob): Promise<boolean> {
+	if (isTauri()) {
+		const { writeFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+		await writeFile(filename, new Uint8Array(await blob.arrayBuffer()), {
+			baseDir: BaseDirectory.Download
+		});
+		return true;
+	}
+	const url = URL.createObjectURL(blob);
+	const a = document.createElement('a');
+	a.href = url;
+	a.download = filename;
+	a.click();
+	URL.revokeObjectURL(url);
+	return false;
+}


### PR DESCRIPTION
Second half of #153 (the fourth screenshot): "Download Save File" did nothing in the desktop app.

## Root cause

`downloadSaveFile` created a `blob:` URL and clicked an anchor. Browsers handle that as a download; the desktop webview drops it, so the click produced nothing. The reporter's "brief flash, request cancelled" matches. Photo mode already solved this for images by writing straight into the Downloads folder through `plugin-fs`, and the fs capability is already scoped to `$DOWNLOAD/**`, so the fix is to share that path.

A second, pre-existing failure sat on the same button: `exportSave` called `$state.snapshot` from a plain `.ts` module, which throws `rune_outside_svelte` whenever IndexedDB has no character row yet. Any fresh profile could never export at all, on web or desktop.

## Change

- `src/lib/utils/save-to-downloads.ts`: one helper. Web gets the anchor download as before; desktop writes the bytes with `writeFile` into `BaseDirectory.Download` (`writeFile`, not `writeTextFile`, because only `fs:allow-write-file` is granted). Resolves whether it wrote the file itself.
- Save export and photo mode both call it. Photo mode loses its own copy of the same logic.
- The Data page now tells desktop users where the file went and shows export failures instead of only logging them.
- Filenames carry date and time (`utsuwa-save-2026-08-25-1432.json`) so two desktop exports on one day cannot overwrite each other; browsers auto-rename, the direct write does not.
- The store proxy is unwrapped with a JSON round-trip in `exportSave`, which is how the file is serialised anyway.

## Verification

- `pnpm test` 440 pass, `pnpm check` 0 errors 0 warnings.
- Web: on two dev servers (one long-running, one fresh module graph) the button produces an `application/json` blob and an anchor download named `utsuwa-save-<stamp>.json`, no message shown. Before the rune fix the long-running profile (no character row) showed "Export failed: rune_outside_svelte".
- Desktop: see the comment below for the macOS dev-build result.

## Notes

- Desktop users only get this in the next release; 0.13.1 is what the reporter is running.
- Windows was not tested here; the desktop branch is the same `writeFile` call photo mode has shipped with.
