### PR TITLE
chore: bump version to 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.2] - 2026-08-25
+
+### Fixed
+- **Your ElevenLabs voice is actually yours now**: the custom Voice ID box was saving to a setting the speech pipeline never read, so everyone heard the default voice no matter what they pasted. The field now drives the voice that plays, offers the built-in voices as suggestions, carries over any ID you had already entered, and a wrong ID tells you so instead of quietly falling back. Reported by @Jessika07.
+- The TTS model dropdown no longer forgets your selection every time you open the tab.
+- **Download Save File works in the desktop app**: it writes the file straight into your Downloads folder and shows you the filename. A brand-new profile also could not export at all, on web or desktop; that is fixed too.
+
 ## [0.13.1] - 2026-08-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.13.1",
+	"version": "0.13.2",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.13.1"
+version = "0.13.2"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "pnpm build",


### PR DESCRIPTION
Version bump and changelog for 0.13.2: ElevenLabs custom voice fix (#156), TTS model dropdown persistence (#156), desktop save export (#157). Closes the loop on #153.