### PR TITLE
Move to JuiceBoxxGames org, rebrand to Juice Boxx Games LLC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!WARNING]
-> Utsuwa and The Lab by Ordinary Company have not minted, launched, endorsed, or authorized any cryptocurrency, token, coin, NFT, or blockchain project. We never will. If you see crypto associated with Utsuwa or The Lab, it is a scam. This repository is the only authentic Utsuwa project repository.
+> Utsuwa and Juice Boxx Games have not minted, launched, endorsed, or authorized any cryptocurrency, token, coin, NFT, or blockchain project. We never will. If you see crypto associated with Utsuwa or The Lab, it is a scam. This repository is the only authentic Utsuwa project repository.
 
 <p align="center">
   <img alt="Utsuwa, an open-source AI companion you can see and talk to" src="static/brand-assets/banner-light.avif" width="100%">

--- a/README.md
+++ b/README.md
@@ -14,24 +14,24 @@
   ·
   <a href="https://utsuwa.ai/blog">Blog</a>
   ·
-  <a href="https://github.com/The-Lab-by-Ordinary-Company/utsuwa/releases">Releases</a>
+  <a href="https://github.com/JuiceBoxxGames/utsuwa/releases">Releases</a>
 </p>
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg" alt="License: AGPL-3.0"></a>
-  <a href="https://github.com/The-Lab-by-Ordinary-Company/utsuwa/releases"><img src="https://img.shields.io/github/v/release/The-Lab-by-Ordinary-Company/utsuwa?label=Release&color=00b2ff" alt="Latest release"></a>
+  <a href="https://github.com/JuiceBoxxGames/utsuwa/releases"><img src="https://img.shields.io/github/v/release/JuiceBoxxGames/utsuwa?label=Release&color=00b2ff" alt="Latest release"></a>
   <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-22+-green.svg" alt="Node.js 22+"></a>
   <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome"></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/The-Lab-by-Ordinary-Company/utsuwa/releases/latest">
+  <a href="https://github.com/JuiceBoxxGames/utsuwa/releases/latest">
     <img alt="Download for macOS" src="static/brand-assets/download-buttons/macos-light.avif" width="31%">
   </a>
-  <a href="https://github.com/The-Lab-by-Ordinary-Company/utsuwa/releases/latest">
+  <a href="https://github.com/JuiceBoxxGames/utsuwa/releases/latest">
     <img alt="Download for Windows" src="static/brand-assets/download-buttons/windows-light.avif" width="31%">
   </a>
-  <a href="https://github.com/The-Lab-by-Ordinary-Company/utsuwa/releases/latest">
+  <a href="https://github.com/JuiceBoxxGames/utsuwa/releases/latest">
     <img alt="Download for Linux" src="static/brand-assets/download-buttons/linux-light.avif" width="31%">
   </a>
 </p>
@@ -175,7 +175,7 @@ Use Utsuwa directly at **[app.utsuwa.ai](https://app.utsuwa.ai)**. No installati
 
 ### Download the Desktop App
 
-Native desktop builds (with transparent overlay mode) are available for all three platforms on the [GitHub Releases](https://github.com/The-Lab-by-Ordinary-Company/utsuwa/releases) page:
+Native desktop builds (with transparent overlay mode) are available for all three platforms on the [GitHub Releases](https://github.com/JuiceBoxxGames/utsuwa/releases) page:
 
 | Platform | Download |
 |----------|----------|
@@ -202,7 +202,7 @@ If you prefer to run Utsuwa locally or host your own instance:
 
 ```bash
 # Clone the repository
-git clone https://github.com/The-Lab-by-Ordinary-Company/utsuwa.git
+git clone https://github.com/JuiceBoxxGames/utsuwa.git
 cd utsuwa
 
 # Install dependencies
@@ -392,10 +392,10 @@ Releases up to and including 0.12.0 were published under the MIT License and rem
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=The-Lab-by-Ordinary-Company%2Futsuwa&type=date&legend=top-left">
+<a href="https://www.star-history.com/?repos=JuiceBoxxGames%2Futsuwa&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=The-Lab-by-Ordinary-Company/utsuwa&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=The-Lab-by-Ordinary-Company/utsuwa&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=The-Lab-by-Ordinary-Company/utsuwa&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=JuiceBoxxGames/utsuwa&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=JuiceBoxxGames/utsuwa&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=JuiceBoxxGames/utsuwa&type=date&legend=top-left" />
  </picture>
 </a>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.13.3",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
-	"author": "Ordinary Company Group LLC",
+	"author": "Juice Boxx Games LLC",
 	"license": "AGPL-3.0-or-later",
 	"engines": {
 		"node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.13.2",
+	"version": "0.13.3",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",
@@ -10,12 +10,12 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/The-Lab-by-Ordinary-Company/utsuwa.git"
+		"url": "git+https://github.com/JuiceBoxxGames/utsuwa.git"
 	},
 	"bugs": {
-		"url": "https://github.com/The-Lab-by-Ordinary-Company/utsuwa/issues"
+		"url": "https://github.com/JuiceBoxxGames/utsuwa/issues"
 	},
-	"homepage": "https://github.com/The-Lab-by-Ordinary-Company/utsuwa#readme",
+	"homepage": "https://github.com/JuiceBoxxGames/utsuwa#readme",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.13.2"
+version = "0.13.3"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "utsuwa"
 version = "0.13.3"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
-authors = ["Ordinary Company Group LLC"]
+authors = ["Juice Boxx Games LLC"]
 edition = "2021"
 rust-version = "1.70"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "pnpm build",
@@ -45,7 +45,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/The-Lab-by-Ordinary-Company/utsuwa/releases/latest/download/latest.json"
+        "https://github.com/JuiceBoxxGames/utsuwa/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDVFOUNENjZFQTkyOTUxM0UKUldRK1VTbXBidGFjWHVHckhFSitveFRHNHlkTmpWeXhTa3IzZWdpeVNlSDVRMVppeFVhQml2TjgK"
     }

--- a/src/content/docs/guides/desktop-guide.md
+++ b/src/content/docs/guides/desktop-guide.md
@@ -13,7 +13,7 @@ Available for **macOS**, **Windows**, and **Linux**.
 
 ### Download
 
-Head to the [GitHub Releases](https://github.com/The-Lab-by-Ordinary-Company/utsuwa/releases) page and grab the build for your platform:
+Head to the [GitHub Releases](https://github.com/JuiceBoxxGames/utsuwa/releases) page and grab the build for your platform:
 
 | Platform | File | Install |
 |----------|------|---------|
@@ -42,7 +42,7 @@ If you prefer to build it yourself:
 
 ```bash
 # Clone the repo
-git clone https://github.com/The-Lab-by-Ordinary-Company/utsuwa.git
+git clone https://github.com/JuiceBoxxGames/utsuwa.git
 cd utsuwa
 
 # Install dependencies
@@ -143,14 +143,14 @@ If not installed, run:
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-If you downloaded a release binary and it won't launch, try downloading it again or check the [GitHub Issues](https://github.com/The-Lab-by-Ordinary-Company/utsuwa/issues) page.
+If you downloaded a release binary and it won't launch, try downloading it again or check the [GitHub Issues](https://github.com/JuiceBoxxGames/utsuwa/issues) page.
 
 ### Overlay background not transparent
 
 This can happen if the renderer isn't properly configured. Try:
 
 1. Exit and relaunch the app
-2. Make sure you're on the latest version from [Releases](https://github.com/The-Lab-by-Ordinary-Company/utsuwa/releases)
+2. Make sure you're on the latest version from [Releases](https://github.com/JuiceBoxxGames/utsuwa/releases)
 
 ### Character facing wrong direction
 

--- a/src/content/docs/guides/troubleshooting.md
+++ b/src/content/docs/guides/troubleshooting.md
@@ -270,7 +270,7 @@ This often means something loaded out of order:
 
 If your issue isn't covered here:
 
-1. Check the [GitHub Issues](https://github.com/The-Lab-by-Ordinary-Company/utsuwa/issues) for similar problems
+1. Check the [GitHub Issues](https://github.com/JuiceBoxxGames/utsuwa/issues) for similar problems
 2. Open a new issue with:
    - App version (web or desktop) and browser if web
    - Steps to reproduce

--- a/src/content/docs/guides/web-guide.md
+++ b/src/content/docs/guides/web-guide.md
@@ -18,7 +18,7 @@ This guide walks you through using Utsuwa, whether on the hosted version at [uts
 ### Installation
 
 ```bash
-git clone https://github.com/The-Lab-by-Ordinary-Company/utsuwa.git
+git clone https://github.com/JuiceBoxxGames/utsuwa.git
 cd utsuwa
 pnpm install
 pnpm dev

--- a/src/lib/components/marketing/SiteFooter.svelte
+++ b/src/lib/components/marketing/SiteFooter.svelte
@@ -51,7 +51,7 @@
 		</div>
 
 		<div class="site-footer-bottom">
-			<span>&copy; 2026 Ordinary Company Group LLC. Open source under AGPL-3.0.</span>
+			<span>&copy; 2026 Juice Boxx Games LLC. Open source under AGPL-3.0.</span>
 			<div class="site-footer-actions">
 				<button
 					type="button"

--- a/src/lib/components/ui/InfoModal.svelte
+++ b/src/lib/components/ui/InfoModal.svelte
@@ -109,7 +109,7 @@
 		<!-- Links -->
 		<nav class="link-list">
 			<a
-				href="https://github.com/The-Lab-by-Ordinary-Company/utsuwa"
+				href="https://github.com/JuiceBoxxGames/utsuwa"
 				target="_blank"
 				rel="noopener"
 				class="link-row"

--- a/src/lib/config/site.ts
+++ b/src/lib/config/site.ts
@@ -1,5 +1,5 @@
 export const SITE_URL = 'https://utsuwa.ai';
 export const DOCS_URL = 'https://docs.utsuwa.ai';
 export const APP_URL = 'https://app.utsuwa.ai';
-export const GITHUB_REPO = 'https://github.com/The-Lab-by-Ordinary-Company/utsuwa';
+export const GITHUB_REPO = 'https://github.com/JuiceBoxxGames/utsuwa';
 export const GITHUB_RELEASES = `${GITHUB_REPO}/releases`;

--- a/src/routes/(legal)/privacy/+page.svelte
+++ b/src/routes/(legal)/privacy/+page.svelte
@@ -38,7 +38,7 @@
 	<p>
 		Utsuwa is an open-source AI companion built to be local-first. This policy explains what
 		happens to your data when you use the Utsuwa website and hosted web app (utsuwa.ai and its
-		subdomains) and the Utsuwa desktop app, operated by Ordinary Company Group LLC. The short
+		subdomains) and the Utsuwa desktop app, operated by Juice Boxx Games LLC. The short
 		version: your companion lives on your device, and we like it that way.
 	</p>
 
@@ -146,7 +146,7 @@
 	<p>
 		The fastest way to reach us is on
 		<a href={`${GITHUB_REPO}/issues`} target="_blank" rel="noopener noreferrer">GitHub</a>. Utsuwa
-		is maintained by Ordinary Company Group LLC, a limited liability company formed in Ohio, USA.
+		is maintained by Juice Boxx Games LLC, a limited liability company formed in Ohio, USA.
 	</p>
 </article>
 

--- a/src/routes/(legal)/terms/+page.svelte
+++ b/src/routes/(legal)/terms/+page.svelte
@@ -28,7 +28,7 @@
 	<p>
 		Thanks for using Utsuwa. These terms cover the Utsuwa website and hosted services at
 		utsuwa.ai (including app.utsuwa.ai and docs.utsuwa.ai) and the Utsuwa desktop app, operated by
-		Ordinary Company Group LLC ("we", "us"), a limited liability company formed in Ohio, USA.
+		Juice Boxx Games LLC ("we", "us"), a limited liability company formed in Ohio, USA.
 		Utsuwa's source code is open source and separately licensed under the
 		<a href={`${GITHUB_REPO}/blob/main/LICENSE`} target="_blank" rel="noopener noreferrer">GNU AGPL-3.0-or-later</a>; nothing in these terms limits the rights that license gives you. By using Utsuwa,
 		you agree to these terms.
@@ -68,7 +68,7 @@
 	<p>
 		Use Utsuwa lawfully. Don't interfere with, disrupt, or overload our hosted services or attempt
 		to circumvent their protections; don't use our relay to violate your AI provider's policies;
-		and don't misrepresent yourself as affiliated with Utsuwa or Ordinary Company Group LLC.
+		and don't misrepresent yourself as affiliated with Utsuwa or Juice Boxx Games LLC.
 	</p>
 
 	<h2 id="no-crypto">No crypto, ever</h2>
@@ -83,7 +83,7 @@
 		Utsuwa's code is licensed under the
 		<a href={`${GITHUB_REPO}/blob/main/LICENSE`} target="_blank" rel="noopener noreferrer">GNU AGPL-3.0-or-later</a>, and these terms don't restrict what that license permits you to do with the code.
 		These terms govern your use of our website and hosted services. The Utsuwa name, logo, and
-		branding belong to Ordinary Company Group LLC; please don't use them in ways that imply
+		branding belong to Juice Boxx Games LLC; please don't use them in ways that imply
 		endorsement or affiliation. Avatar models, animations, and other assets you import remain
 		yours, subject to whatever licenses they came with.
 	</p>
@@ -104,7 +104,7 @@
 
 	<h2 id="liability">Limitation of liability</h2>
 	<p>
-		To the maximum extent permitted by law, Ordinary Company Group LLC and its members and
+		To the maximum extent permitted by law, Juice Boxx Games LLC and its members and
 		contributors will not be liable for any indirect, incidental, special, consequential, or
 		exemplary damages, or for lost profits, data, or goodwill, arising from your use of Utsuwa.
 		Our total liability for any claim relating to Utsuwa will not exceed fifty US dollars (US $50)

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -142,7 +142,7 @@
 		license: 'https://www.gnu.org/licenses/agpl-3.0.html',
 		author: {
 			'@type': 'Organization',
-			name: 'Ordinary Company Group LLC',
+			name: 'Juice Boxx Games LLC',
 			url: SITE_URL
 		}
 	})}</script>`}

--- a/src/routes/download/+page.ts
+++ b/src/routes/download/+page.ts
@@ -2,7 +2,7 @@ import type { PageLoad } from './$types';
 
 export const prerender = true;
 
-const REPO = 'The-Lab-by-Ordinary-Company/utsuwa';
+const REPO = 'JuiceBoxxGames/utsuwa';
 
 // Resolve the latest release's real asset URLs at build time so the download
 // buttons point straight at the files instead of fetching from the browser.


### PR DESCRIPTION
Org rename follow-through: updater endpoint, repo URLs, docs, and download page now point at JuiceBoxxGames; legal entity updated to Juice Boxx Games LLC across footer, JSON-LD, privacy, and terms; version bumped to 0.13.3.