### PR TITLE
chore: release Utsuwa 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-09-09
+
+### Added
+- OmniVoice can switch languages and voices within a reply. Configure an alternative language with its own preset or cloned voice, speed, and synthesis settings under Settings > Speech (TTS). A test button previews the alternative voice, and its profile warms up in the background. Contributed by @dezihh in [#154](https://github.com/JuiceBoxxGames/utsuwa/pull/154).
+- Optional native speech tool calls require a language for each segment. Local language detection helps validate language tags and route speech to the configured voice. Inline speech markup remains available for models without tool support, including Anthropic.
+
+### Changed
+- The landing, download, blog, and docs pages have updated layouts and navigation, with responsive images and smaller image downloads.
+- OmniVoice prepares short foreign-language segments to reduce silent or swallowed words and supports expressive speech markers without displaying them in chat.
+
+### Fixed
+- Streaming chat and speech now handle fragmented markup, reasoning blocks, internal state, and reminder tags without leaking control text into dialogue. Ordinary dialogue, apostrophes, and decimal numbers survive speech cleanup.
+- Queued speech playback keeps avatar lip-sync working.
+- The avatar view shows a fallback when WebGL is unavailable instead of crashing during renderer creation.
+
+### Upgrade notes
+- Update and restart your local OmniVoice proxy to use the new synthesis parameters. Docker users should rebuild the image after pulling the updated source. See the [OmniVoice guide](https://docs.utsuwa.ai/docs/guides/omnivoice#updating-the-proxy-after-code-changes).
+- Multilingual speech is in beta, with the most testing in German, Spanish, and English. Other languages are less mature, and very short foreign words can still produce weak or missing audio.
+- If your model rejects speech tools or speaks mixed text/tool replies out of order, disable **Force language per segment** in OmniVoice settings.
+
 ## [0.13.2] - 2026-08-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.13.3",
+	"version": "0.14.0",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Juice Boxx Games LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4483,7 +4483,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.13.3"
+version = "0.14.0"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Juice Boxx Games LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "pnpm build",


### PR DESCRIPTION
Release Utsuwa 0.14.0 after merging multilingual OmniVoice support in #154.

Updates the version in package.json, Cargo.toml, Cargo.lock, and tauri.conf.json. Adds a changelog covering the new speech feature, chat and avatar fixes, website changes since v0.13.3, and OmniVoice proxy upgrade instructions.

Validation: 736 tests pass; svelte-check reports zero errors and zero warnings. CI verifies the production build and Rust check before the release tag is pushed.
